### PR TITLE
feat(uat): added base of connect/disconnect

### DIFF
--- a/uat/README.md
+++ b/uat/README.md
@@ -2,3 +2,16 @@
 
 The test controlled MQTT v5.0 client based on AWS IoT Device SDK for Java v2 is used to test Greengrass v2 MQTT v5.0 compatibility.
 
+## How to compile
+
+To complie this client, use the following command:
+
+```sh
+mvn clean license:check checkstyle:check pmd:check package
+```
+
+# How to run
+To Run this client use the following command:
+```sh
+mvn exec:java
+```

--- a/uat/pom.xml
+++ b/uat/pom.xml
@@ -45,7 +45,6 @@
             <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
             <artifactId>aws-iot-device-sdk</artifactId>
             <version>${iot.device.sdk.version}</version>
-            <type>pom</type>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/uat/pom.xml
+++ b/uat/pom.xml
@@ -41,6 +41,17 @@
             <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
         <dependency>
             <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
             <artifactId>aws-iot-device-sdk</artifactId>
@@ -279,6 +290,7 @@
         <jar.name>test-iot-device-sdk-mqtt5-client</jar.name>
         <main.class>com.aws.greengrass.testing.mqtt5.client.Main</main.class>
         <!-- Dependencies versions -->
+        <log4j.version>2.20.0</log4j.version>
         <iot.device.sdk.version>1.11.2</iot.device.sdk.version>
         <protobuf.version>3.21.7</protobuf.version>
         <protoc.version>3.21.7</protoc.version>

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/Main.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/Main.java
@@ -44,10 +44,9 @@ public class Main {
      * The main method of application.
      *
      * @param args program's arguments
-     * @throws Exception on errors
      */
-    @SuppressWarnings("PMD.DoNotCallSystemExit")
-    public static void main(String[] args) throws Exception {
+    @SuppressWarnings({"PMD.DoNotCallSystemExit", "PMD.AvoidCatchingGenericException"})
+    public static void main(String[] args) {
         int rc;
         try {
             doAll(args);
@@ -60,6 +59,9 @@ public class Main {
         } catch (ClientException ex) {
             logger.log(Level.WARNING, "ClientException", ex);
             rc = 2;
+        } catch (Exception ex) {
+            logger.log(Level.WARNING, "Exception", ex);
+            rc = 3;
         }
         System.exit(rc);
     }

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/Main.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/Main.java
@@ -44,10 +44,10 @@ public class Main {
      * The main method of application.
      *
      * @param args program's arguments
-     * @throws InterruptedException when main thread was interrupted
+     * @throws Exception on errors
      */
     @SuppressWarnings("PMD.DoNotCallSystemExit")
-    public static void main(String[] args) throws InterruptedException {
+    public static void main(String[] args) throws Exception {
         int rc;
         try {
             doAll(args);
@@ -76,7 +76,7 @@ public class Main {
                 // agent_id ip port
                 port = Integer.parseInt(args[2]);
                 if (port < PORT_MIN || port > PORT_MAX) {
-                    throw new IllegalArgumentException("Invalid port value %s, expected [1..65535]");
+                    throw new IllegalArgumentException("Invalid port value " + port + " , expected [1..65535]");
                 }
                 // fallthrough
             case 2:
@@ -94,15 +94,16 @@ public class Main {
         return new Arguments(agentId, address, port);
     }
 
-    private static void doAll(String... args) throws InterruptedException, ClientException {
+    private static void doAll(String... args) throws Exception {
         Arguments arguments = parseArgs(args);
 
         GRPCLib gprcLib = new GRPCLibImpl();
         GRPCLink link = gprcLib.makeLink(arguments.getAgentId(), arguments.getHost(), arguments.getPort());
 
-        MqttLib mqttLib = new MqttLibImpl();
-        String reason = link.handleRequests(mqttLib);
-        link.shutdown(reason);
+        try (MqttLib mqttLib = new MqttLibImpl()) {
+            String reason = link.handleRequests(mqttLib);
+            link.shutdown(reason);
+        }
     }
 
     private static void printUsage() {

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/Main.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/Main.java
@@ -93,6 +93,7 @@ public class Main {
         return new Arguments(agentId, address, port);
     }
 
+    @SuppressWarnings("PMD.SignatureDeclareThrowsException")
     private static void doAll(String... args) throws Exception {
         Arguments arguments = parseArgs(args);
 

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/Main.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/Main.java
@@ -11,15 +11,15 @@ import com.aws.greengrass.testing.mqtt5.client.sdkmqtt.MqttLibImpl;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.experimental.UtilityClass;
-
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Main class of application.
  */
 @UtilityClass
 public class Main {
+    private static final Logger logger = LogManager.getLogger(Main.class);
 
     @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
     private static final String DEFAULT_GRPC_SERVER_IP = "127.0.0.1";
@@ -27,9 +27,6 @@ public class Main {
 
     private static final int PORT_MIN = 1;
     private static final int PORT_MAX = 65_535;
-
-    private static final Logger logger = Logger.getLogger(Main.class.getName());
-
 
     @Data
     @AllArgsConstructor
@@ -50,17 +47,17 @@ public class Main {
         int rc;
         try {
             doAll(args);
-            logger.log(Level.INFO, "Execution done");
+            logger.atInfo().log("Execution done successfully");
             rc = 0;
         } catch (IllegalArgumentException ex) {
-            logger.log(Level.WARNING, "Invalid arguments", ex);
+            logger.atError().withThrowable(ex).log("Invalid arguments");
             printUsage();
             rc = 1;
         } catch (ClientException ex) {
-            logger.log(Level.WARNING, "ClientException", ex);
+            logger.atError().withThrowable(ex).log("ClientException");
             rc = 2;
         } catch (Exception ex) {
-            logger.log(Level.WARNING, "Exception", ex);
+            logger.atError().withThrowable(ex).log("Exception");
             rc = 3;
         }
         System.exit(rc);
@@ -109,6 +106,6 @@ public class Main {
     }
 
     private static void printUsage() {
-        logger.log(Level.INFO, "Usage: agent_id [host [port]]");
+        logger.atWarn().log("Usage: agent_id [host [port]]");
     }
 }

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
@@ -11,6 +11,8 @@ import com.aws.greengrass.testing.mqtt5.client.exceptions.MqttException;
  * Interface of MQTT5 connection.
  */
 public interface MqttConnection {
+    int DEFAULT_DISCONNECT_REASON = 4;
+
     /**
      * Close MQTT connection.
      *

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
@@ -12,11 +12,11 @@ import lombok.Data;
 /**
  * Interface of MQTT5 library.
  */
-public interface MqttLib {
+public interface MqttLib extends AutoCloseable {
 
     @Data
     @Builder
-    class ConnectRequest {
+    class ConnectionParams {
         private String clientId;
         private String host;
         private int port;
@@ -25,14 +25,39 @@ public interface MqttLib {
         private String ca;
         private String cert;
         private String key;
+        private int connectTimeout;
     }
 
     /**
-     * Creates a MQTT5 connection.
+     * Creates a MQTT connection.
      *
-     * @param connectionRequest connect arguments
+     * @param connectionParams connection parameters
      * @return MqttConnection on success
      * @throws MqttException on errors
      */
-    MqttConnection createConnection(ConnectRequest connectionRequest) throws MqttException;
+    MqttConnection createConnection(ConnectionParams connectionParams) throws MqttException;
+
+    /**
+     * Register the MQTT connection.
+     *
+     * @param mqttConnection connection to register
+     * @return id of connection
+     */
+    int registerConnection(MqttConnection mqttConnection);
+
+    /**
+     * Get a MQTT connection.
+     *
+     * @param connectionId id of connection
+     * @return MqttConnection on success and null when connection does not found
+     */
+    MqttConnection getConnection(int connectionId);
+
+    /**
+     * Get MQTT connection and remove from list.
+     *
+     * @param connectionId id of connection
+     * @return MqttConnection on success and null when connection does not found
+     */
+    MqttConnection unregisterConnection(int connectionId);
 }

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
@@ -22,10 +22,10 @@ public interface MqttLib extends AutoCloseable {
         private int port;
         private int keepalive;
         private boolean cleanSession;
-        private String ca;
-        private String cert;
-        private String key;
         private int connectTimeout;
+        private String ca;                      // optional
+        private String cert;                    // optional
+        private String key;                     // optional
     }
 
     /**

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
@@ -5,11 +5,22 @@
 
 package com.aws.greengrass.testing.mqtt5.client.grpc;
 
-import com.aws.greengrass.testing.mqtt.client.MqttAgentDiscoveryGrpc;
+import com.aws.greengrass.testing.mqtt.client.MqttClientControlGrpc;
+import com.aws.greengrass.testing.mqtt.client.MqttCloseRequest;
+import com.aws.greengrass.testing.mqtt.client.MqttConnectRequest;
+import com.aws.greengrass.testing.mqtt.client.MqttConnectionId;
+import com.aws.greengrass.testing.mqtt.client.MqttProtoVersion;
+import com.aws.greengrass.testing.mqtt.client.ShutdownRequest;
+import com.aws.greengrass.testing.mqtt.client.TLSSettings;
+import com.aws.greengrass.testing.mqtt5.client.MqttConnection;
 import com.aws.greengrass.testing.mqtt5.client.MqttLib;
+import com.aws.greengrass.testing.mqtt5.client.exceptions.MqttException;
+import com.google.protobuf.Empty;
 import io.grpc.Grpc;
 import io.grpc.InsecureServerCredentials;
 import io.grpc.Server;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
 
 import java.io.IOException;
 import java.util.logging.Level;
@@ -18,26 +29,216 @@ import java.util.logging.Logger;
 /**
  * Implementation of gRPC server handles requests of OTF.
  */
-class GRPCControlServer extends MqttAgentDiscoveryGrpc.MqttAgentDiscoveryImplBase {
+class GRPCControlServer {
+    private static final int PORT_MIN = 1;
+    private static final int PORT_MAX = 65535;
+
+    private static final int KEEPALIVE_OFF = 0;
+    private static final int KEEPALIVE_MIN = 5;
+    private static final int KEEPALIVE_MAX = 65535;
+
+    private static final int REASON_MIN = 0;
+    private static final int REASON_MAX = 255;
+
+    private static final int CONNECT_TIMEOUT_MIN = 1;
+
+
     private static final Logger logger = Logger.getLogger(GRPCControlServer.class.getName());
 
     @SuppressWarnings("PMD.UnusedPrivateField") // TODO: remove
     private final GRPCDiscoveryClient client;
     private final Server server;
     private final int boundPort;
-    @SuppressWarnings("PMD.UnusedPrivateField") // TODO: remove
     private MqttLib mqttLib;
+    private String shutdownReason;
 
 
     /**
-     * Build gRPC address string from host and port.
-     *
-     * @param host host part of gRPC address
-     * @param port port part of gRPC address
-     * @return address of gRPC service
+     * MQTT client control service implementation.
      */
-    public static String buildAddress(String host, int port) {
-        return host + ":" + port;
+    class MqttClientControlImpl extends MqttClientControlGrpc.MqttClientControlImplBase {
+
+        @Override
+        public void shutdownAgent(ShutdownRequest request, StreamObserver<Empty> responseObserver) {
+            // save reason
+            shutdownReason = request.getReason();
+
+            // log an event
+            logger.log(Level.INFO, "shutdownAgent: {0}", new Object[]{shutdownReason});
+
+            Empty reply = Empty.newBuilder().build();
+            responseObserver.onNext(reply);
+            responseObserver.onCompleted();
+
+            // request server to shutdown
+            server.shutdown();
+        }
+
+        @Override
+        public void createMqttConnection(MqttConnectRequest request,
+                                            StreamObserver<MqttConnectionId> responseObserver) {
+
+            String clientId = request.getClientId();
+            String host = request.getHost();
+            int port = request.getPort();
+
+            logger.log(Level.INFO, "createMqttConnection: clientId {0} broker {1}:{2}",
+                            new Object[]{clientId, host, String.valueOf(port)});
+
+            if (clientId == null || clientId.isEmpty()) {
+                logger.log(Level.WARNING, "createMqttConnection: clientId can't be empty");
+                responseObserver.onError(Status.INVALID_ARGUMENT
+                                            .withDescription("clientId can't be empty")
+                                            .asRuntimeException());
+                return;
+            }
+
+            if (host == null || host.isEmpty()) {
+                logger.log(Level.WARNING, "createMqttConnection: host can't be empty");
+                responseObserver.onError(Status.INVALID_ARGUMENT
+                                            .withDescription("host can't be empty")
+                                            .asRuntimeException());
+                return;
+            }
+
+            if (port < PORT_MIN || port > PORT_MAX) {
+                logger.log(Level.WARNING, "createMqttConnection: invalid port, must be in range [{0}, {1}]",
+                                new Object[]{PORT_MIN,  String.valueOf(PORT_MAX)});
+                responseObserver.onError(Status.INVALID_ARGUMENT
+                                            .withDescription("invalid port, must be in range [1, 65535]")
+                                            .asRuntimeException());
+                return;
+            }
+
+            MqttProtoVersion version = request.getProtocolVersion();
+            if (version != MqttProtoVersion.MQTT_PROTOCOL_V50) {
+                logger.log(Level.WARNING, "createMqttConnection: MQTT_PROTOCOL_V50 is only supported but {0} requested",
+                                new Object[]{version});
+                responseObserver.onError(Status.INVALID_ARGUMENT
+                                .withDescription("invalid protocolVersion, only MQTT_PROTOCOL_V50 is supported")
+                                .asRuntimeException());
+                return;
+            }
+
+            int keepalive = request.getKeepalive();
+            if (keepalive != KEEPALIVE_OFF && (keepalive < KEEPALIVE_MIN || keepalive > KEEPALIVE_MAX)) {
+                logger.log(Level.WARNING, "createMqttConnection: invalid keepalive, must be in range [{0}, {1}]",
+                                new Object[]{KEEPALIVE_MIN,  String.valueOf(KEEPALIVE_MAX)});
+
+                responseObserver.onError(Status.INVALID_ARGUMENT
+                                            .withDescription("invalid keepalive, must be in range [1, 65535]")
+                                            .asRuntimeException());
+                return;
+            }
+
+
+            int connectTimeout = request.getConnectTimeout();
+            if (connectTimeout < CONNECT_TIMEOUT_MIN) {
+                logger.log(Level.WARNING, "createMqttConnection: invalid connectTimeout, must be >= {0}",
+                                new Object[]{String.valueOf(CONNECT_TIMEOUT_MIN)});
+
+                responseObserver.onError(Status.INVALID_ARGUMENT
+                                            .withDescription("invalid connectTimeout, must be >= 1")
+                                            .asRuntimeException());
+                return;
+            }
+            MqttLib.ConnectionParams.ConnectionParamsBuilder builder = MqttLib.ConnectionParams.builder();
+
+            // check TLS optional settings
+            if (request.hasTls()) {
+                TLSSettings tls = request.getTls();
+                String ca = tls.getCa();
+
+                if (ca == null || ca.isEmpty()) {
+                    logger.log(Level.WARNING,  "createMqttConnection: ca is empty");
+                    responseObserver.onError(Status.INVALID_ARGUMENT
+                                                .withDescription("CA is empty")
+                                                .asRuntimeException());
+                    return;
+                }
+
+                String cert = tls.getCert();
+                if (cert == null || cert.isEmpty()) {
+                    logger.log(Level.WARNING,  "createMqttConnection: cert is empty");
+                    responseObserver.onError(Status.INVALID_ARGUMENT
+                                                .withDescription("cert is empty")
+                                                .asRuntimeException());
+                    return;
+                }
+
+                String key = tls.getKey();
+                if (key == null || key.isEmpty()) {
+                    logger.log(Level.WARNING, "createMqttConnection: key is empty");
+                    responseObserver.onError(Status.INVALID_ARGUMENT
+                                                .withDescription("key is empty")
+                                                .asRuntimeException());
+                    return;
+                }
+
+                builder.ca(ca).cert(cert).key(key);
+            }
+
+            MqttConnection connection;
+            try {
+                connection = mqttLib.createConnection(builder.clientId(clientId)
+                            .host(host)
+                            .port(port)
+                            .keepalive(keepalive)
+                            .cleanSession(request.getCleanSession())
+                            .connectTimeout(connectTimeout)
+                            .build());
+            } catch (MqttException ex) {
+                logger.log(Level.WARNING, "createMqttConnection: exception during connect", ex);
+                responseObserver.onError(ex);
+                return;
+            }
+            int connectionId = mqttLib.registerConnection(connection);
+
+            MqttConnectionId reply = MqttConnectionId.newBuilder().setConnectionId(connectionId).build();
+            responseObserver.onNext(reply);
+            responseObserver.onCompleted();
+        }
+
+        @Override
+        public void closeMqttConnection(MqttCloseRequest request, StreamObserver<Empty> responseObserver) {
+
+            int connectionId = request.getConnectionId().getConnectionId();
+            int reason = request.getReason();
+            logger.log(Level.INFO, "closeMqttConnection: connectionId {0} reason {1}",
+                        new Object[]{connectionId, reason});
+
+            if (reason < REASON_MIN || reason > REASON_MAX) {
+                logger.log(Level.WARNING, "closeMqttConnection: invalid reason, must be in range [{0}, {1}]",
+                                new Object[]{REASON_MIN, REASON_MAX});
+                responseObserver.onError(Status.INVALID_ARGUMENT
+                                            .withDescription("invalid reason, must be in range [0, 255]")
+                                            .asRuntimeException());
+                return;
+            }
+
+            MqttConnection connection = mqttLib.unregisterConnection(connectionId);
+            if (connection == null) {
+                logger.log(Level.WARNING, "closeMqttConnection: connection with id {0} doesn't found",
+                                new Object[]{connectionId});
+                responseObserver.onError(Status.NOT_FOUND
+                                            .withDescription("connection doesn't found")
+                                            .asRuntimeException());
+                return;
+            }
+
+            try {
+                // TODO: pass also DISCONNECT properties
+                connection.disconnect(reason);
+            } catch (MqttException ex) {
+                logger.log(Level.WARNING, "closeMqttConnection: exception during disconnect", ex);
+                responseObserver.onError(ex);
+                return;
+            }
+
+            Empty reply = Empty.newBuilder().build();
+            responseObserver.onNext(reply);
+            responseObserver.onCompleted();
+        }
     }
 
     /**
@@ -52,14 +253,14 @@ class GRPCControlServer extends MqttAgentDiscoveryGrpc.MqttAgentDiscoveryImplBas
         super();
         this.client = client;
 
-        // String address = buildAddress(host, port);
+        // TODO: Java implementation of gRPC server has no usage of host
         server = Grpc.newServerBuilderForPort(port, InsecureServerCredentials.create())
-                    .addService(this)
+                    .addService(new MqttClientControlImpl())
                     .build()
                     .start();
 
         this.boundPort = server.getPort();
-        logger.log(Level.INFO, "GRPCControlServer created and listed on %s:%hu",
+        logger.log(Level.INFO, "GRPCControlServer created and listed on {0}:{1}",
                     new Object[]{host, String.valueOf(boundPort)});
     }
 
@@ -68,17 +269,18 @@ class GRPCControlServer extends MqttAgentDiscoveryGrpc.MqttAgentDiscoveryImplBas
     }
 
     public String getShutdownReason() {
-        return null;
+        return shutdownReason;
     }
 
 
     public void waiting(MqttLib mqttLib) throws InterruptedException {
         this.mqttLib = mqttLib;
+        logger.log(Level.INFO, "Server awaitTermination");
         server.awaitTermination();
+        logger.log(Level.INFO, "Server awaitTermination done");
     }
 
     public void close() {
         server.shutdown(); // or       shutdownNow()
     }
-
 }

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
@@ -21,15 +21,17 @@ import io.grpc.InsecureServerCredentials;
 import io.grpc.Server;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Implementation of gRPC server handles requests of OTF.
  */
 class GRPCControlServer {
+    private static final Logger logger = LogManager.getLogger(GRPCControlServer.class);
+
     private static final int PORT_MIN = 1;
     private static final int PORT_MAX = 65_535;
 
@@ -43,7 +45,6 @@ class GRPCControlServer {
     private static final int CONNECT_TIMEOUT_MIN = 1;
 
 
-    private static final Logger logger = Logger.getLogger(GRPCControlServer.class.getName());
 
     @SuppressWarnings("PMD.UnusedPrivateField") // TODO: remove
     private final GRPCDiscoveryClient client;
@@ -64,7 +65,7 @@ class GRPCControlServer {
             shutdownReason = request.getReason();
 
             // log an event
-            logger.log(Level.INFO, "shutdownAgent: {0}", new Object[]{shutdownReason});
+            logger.atInfo().log("shutdownAgent: {}", shutdownReason);
 
             Empty reply = Empty.newBuilder().build();
             responseObserver.onNext(reply);
@@ -82,11 +83,10 @@ class GRPCControlServer {
             String host = request.getHost();
             int port = request.getPort();
 
-            logger.log(Level.INFO, "createMqttConnection: clientId {0} broker {1}:{2}",
-                            new Object[]{clientId, host, String.valueOf(port)});
+            logger.atInfo().log("createMqttConnection: clientId {} broker {}:{}", clientId, host, port);
 
             if (clientId == null || clientId.isEmpty()) {
-                logger.log(Level.WARNING, "createMqttConnection: clientId can't be empty");
+                logger.atWarn().log("clientId can't be empty");
                 responseObserver.onError(Status.INVALID_ARGUMENT
                                             .withDescription("clientId can't be empty")
                                             .asRuntimeException());
@@ -94,7 +94,7 @@ class GRPCControlServer {
             }
 
             if (host == null || host.isEmpty()) {
-                logger.log(Level.WARNING, "createMqttConnection: host can't be empty");
+                logger.atWarn().log("host can't be empty");
                 responseObserver.onError(Status.INVALID_ARGUMENT
                                             .withDescription("host can't be empty")
                                             .asRuntimeException());
@@ -102,8 +102,7 @@ class GRPCControlServer {
             }
 
             if (port < PORT_MIN || port > PORT_MAX) {
-                logger.log(Level.WARNING, "createMqttConnection: invalid port, must be in range [{0}, {1}]",
-                                new Object[]{PORT_MIN,  String.valueOf(PORT_MAX)});
+                logger.atWarn().log("invalid port, must be in range [{}, {}]", PORT_MIN, PORT_MAX);
                 responseObserver.onError(Status.INVALID_ARGUMENT
                                             .withDescription("invalid port, must be in range [1, 65535]")
                                             .asRuntimeException());
@@ -112,8 +111,7 @@ class GRPCControlServer {
 
             MqttProtoVersion version = request.getProtocolVersion();
             if (version != MqttProtoVersion.MQTT_PROTOCOL_V50) {
-                logger.log(Level.WARNING, "createMqttConnection: MQTT_PROTOCOL_V50 is only supported but {0} requested",
-                                new Object[]{version});
+                logger.atWarn().log("MQTT_PROTOCOL_V50 is only supported but {} requested", version);
                 responseObserver.onError(Status.INVALID_ARGUMENT
                                 .withDescription("invalid protocolVersion, only MQTT_PROTOCOL_V50 is supported")
                                 .asRuntimeException());
@@ -122,9 +120,7 @@ class GRPCControlServer {
 
             int keepalive = request.getKeepalive();
             if (keepalive != KEEPALIVE_OFF && (keepalive < KEEPALIVE_MIN || keepalive > KEEPALIVE_MAX)) {
-                logger.log(Level.WARNING, "createMqttConnection: invalid keepalive, must be in range [{0}, {1}]",
-                                new Object[]{KEEPALIVE_MIN,  String.valueOf(KEEPALIVE_MAX)});
-
+                logger.atWarn().log("invalid keepalive, must be in range [{}, {}]", KEEPALIVE_MIN, KEEPALIVE_MAX);
                 responseObserver.onError(Status.INVALID_ARGUMENT
                                             .withDescription("invalid keepalive, must be in range [1, 65535]")
                                             .asRuntimeException());
@@ -134,15 +130,20 @@ class GRPCControlServer {
 
             int connectTimeout = request.getConnectTimeout();
             if (connectTimeout < CONNECT_TIMEOUT_MIN) {
-                logger.log(Level.WARNING, "createMqttConnection: invalid connectTimeout, must be >= {0}",
-                                new Object[]{String.valueOf(CONNECT_TIMEOUT_MIN)});
-
+                logger.atWarn().log("invalid connectTimeout, must be >= {}", CONNECT_TIMEOUT_MIN);
                 responseObserver.onError(Status.INVALID_ARGUMENT
                                             .withDescription("invalid connectTimeout, must be >= 1")
                                             .asRuntimeException());
                 return;
             }
-            MqttLib.ConnectionParams.ConnectionParamsBuilder builder = MqttLib.ConnectionParams.builder();
+
+            MqttLib.ConnectionParams.ConnectionParamsBuilder builder = MqttLib.ConnectionParams.builder()
+                            .clientId(clientId)
+                            .host(host)
+                            .port(port)
+                            .keepalive(keepalive)
+                            .cleanSession(request.getCleanSession())
+                            .connectTimeout(connectTimeout);
 
             // check TLS optional settings
             if (request.hasTls()) {
@@ -150,7 +151,7 @@ class GRPCControlServer {
                 String ca = tls.getCa();
 
                 if (ca == null || ca.isEmpty()) {
-                    logger.log(Level.WARNING,  "createMqttConnection: ca is empty");
+                    logger.atWarn().log("ca is empty");
                     responseObserver.onError(Status.INVALID_ARGUMENT
                                                 .withDescription("CA is empty")
                                                 .asRuntimeException());
@@ -159,7 +160,7 @@ class GRPCControlServer {
 
                 String cert = tls.getCert();
                 if (cert == null || cert.isEmpty()) {
-                    logger.log(Level.WARNING,  "createMqttConnection: cert is empty");
+                    logger.atWarn().log("cert is empty");
                     responseObserver.onError(Status.INVALID_ARGUMENT
                                                 .withDescription("cert is empty")
                                                 .asRuntimeException());
@@ -168,7 +169,7 @@ class GRPCControlServer {
 
                 String key = tls.getKey();
                 if (key == null || key.isEmpty()) {
-                    logger.log(Level.WARNING, "createMqttConnection: key is empty");
+                    logger.atWarn().log("key is empty");
                     responseObserver.onError(Status.INVALID_ARGUMENT
                                                 .withDescription("key is empty")
                                                 .asRuntimeException());
@@ -178,21 +179,16 @@ class GRPCControlServer {
                 builder.ca(ca).cert(cert).key(key);
             }
 
-            MqttConnection connection;
+
+            int connectionId;
             try {
-                connection = mqttLib.createConnection(builder.clientId(clientId)
-                            .host(host)
-                            .port(port)
-                            .keepalive(keepalive)
-                            .cleanSession(request.getCleanSession())
-                            .connectTimeout(connectTimeout)
-                            .build());
+                MqttConnection connection = mqttLib.createConnection(builder.build());
+                connectionId = mqttLib.registerConnection(connection);
             } catch (MqttException ex) {
-                logger.log(Level.WARNING, "createMqttConnection: exception during connect", ex);
+                logger.atWarn().withThrowable(ex).log("Exception during connect");
                 responseObserver.onError(ex);
                 return;
             }
-            int connectionId = mqttLib.registerConnection(connection);
 
             MqttConnectionId reply = MqttConnectionId.newBuilder().setConnectionId(connectionId).build();
             responseObserver.onNext(reply);
@@ -204,12 +200,10 @@ class GRPCControlServer {
 
             int connectionId = request.getConnectionId().getConnectionId();
             int reason = request.getReason();
-            logger.log(Level.INFO, "closeMqttConnection: connectionId {0} reason {1}",
-                        new Object[]{connectionId, reason});
+            logger.atInfo().log("closeMqttConnection: connectionId {} reason {}", connectionId, reason);
 
             if (reason < REASON_MIN || reason > REASON_MAX) {
-                logger.log(Level.WARNING, "closeMqttConnection: invalid reason, must be in range [{0}, {1}]",
-                                new Object[]{REASON_MIN, REASON_MAX});
+                logger.atWarn().log("invalid reason, must be in range [{}, {0}]", REASON_MIN, REASON_MAX);
                 responseObserver.onError(Status.INVALID_ARGUMENT
                                             .withDescription("invalid reason, must be in range [0, 255]")
                                             .asRuntimeException());
@@ -218,8 +212,7 @@ class GRPCControlServer {
 
             MqttConnection connection = mqttLib.unregisterConnection(connectionId);
             if (connection == null) {
-                logger.log(Level.WARNING, "closeMqttConnection: connection with id {0} doesn't found",
-                                new Object[]{connectionId});
+                logger.atWarn().log("connection with id {0} doesn't found");
                 responseObserver.onError(Status.NOT_FOUND
                                             .withDescription("connection doesn't found")
                                             .asRuntimeException());
@@ -230,7 +223,7 @@ class GRPCControlServer {
                 // TODO: pass also DISCONNECT properties
                 connection.disconnect(reason);
             } catch (MqttException ex) {
-                logger.log(Level.WARNING, "closeMqttConnection: exception during disconnect", ex);
+                logger.atError().withThrowable(ex).log("exception during disconnect");
                 responseObserver.onError(ex);
                 return;
             }
@@ -260,8 +253,7 @@ class GRPCControlServer {
                     .start();
 
         this.boundPort = server.getPort();
-        logger.log(Level.INFO, "GRPCControlServer created and listed on {0}:{1}",
-                    new Object[]{host, String.valueOf(boundPort)});
+        logger.atInfo().log("GRPCControlServer created and listed on {}:{}", host, boundPort);
     }
 
     public int getPort() {
@@ -275,9 +267,9 @@ class GRPCControlServer {
 
     public void waiting(MqttLib mqttLib) throws InterruptedException {
         this.mqttLib = mqttLib;
-        logger.log(Level.INFO, "Server awaitTermination");
+        logger.atInfo().log("Server awaitTermination");
         server.awaitTermination();
-        logger.log(Level.INFO, "Server awaitTermination done");
+        logger.atInfo().log("Server awaitTermination done");
     }
 
     public void close() {

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
@@ -31,11 +31,11 @@ import java.util.logging.Logger;
  */
 class GRPCControlServer {
     private static final int PORT_MIN = 1;
-    private static final int PORT_MAX = 65535;
+    private static final int PORT_MAX = 65_535;
 
     private static final int KEEPALIVE_OFF = 0;
     private static final int KEEPALIVE_MIN = 5;
-    private static final int KEEPALIVE_MAX = 65535;
+    private static final int KEEPALIVE_MAX = 65_535;
 
     private static final int REASON_MIN = 0;
     private static final int REASON_MAX = 255;

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCDiscoveryClient.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCDiscoveryClient.java
@@ -15,15 +15,14 @@ import io.grpc.Grpc;
 import io.grpc.InsecureChannelCredentials;
 import io.grpc.ManagedChannel;
 import io.grpc.StatusRuntimeException;
-
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Implementation of gRPC client used to discover agent.
  */
 class GRPCDiscoveryClient {
-    private static final Logger logger = Logger.getLogger(GRPCDiscoveryClient.class.getName());
+    private static final Logger logger = LogManager.getLogger(GRPCDiscoveryClient.class);
 
 
     private final String agentId;
@@ -37,6 +36,7 @@ class GRPCDiscoveryClient {
      * @throws GRPCException on errors
      */
     GRPCDiscoveryClient(String agentId, String address) throws GRPCException {
+        super();
         this.agentId = agentId;
         ManagedChannel channel = Grpc.newChannelBuilder(address, InsecureChannelCredentials.create()).build();
         this.blockingStub = MqttAgentDiscoveryGrpc.newBlockingStub(channel);
@@ -57,7 +57,7 @@ class GRPCDiscoveryClient {
         try {
             reply = blockingStub.registerAgent(request);
         } catch (StatusRuntimeException ex) {
-            logger.log(Level.WARNING, "gRPC request failed", ex);
+            logger.atError().withThrowable(ex).log("gRPC request failed");
             throw new GRPCException(ex);
         }
         return reply.getAddress();
@@ -78,7 +78,7 @@ class GRPCDiscoveryClient {
         try {
             blockingStub.discoveryAgent(request);
         } catch (StatusRuntimeException ex) {
-            logger.log(Level.WARNING, "gRPC request failed", ex);
+            logger.atError().withThrowable(ex).log("gRPC request failed");
             throw new GRPCException(ex);
         }
     }
@@ -97,11 +97,12 @@ class GRPCDiscoveryClient {
         try {
             blockingStub.unregisterAgent(request);
         } catch (StatusRuntimeException ex) {
-            logger.log(Level.WARNING, "gRPC request failed", ex);
+            logger.atError().withThrowable(ex).log("gRPC request failed");
             throw new GRPCException(ex);
         }
     }
 
-    public void close() {
+    void close() {
+        // TODO: implement
     }
 }

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCLinkImpl.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCLinkImpl.java
@@ -8,18 +8,19 @@ package com.aws.greengrass.testing.mqtt5.client.grpc;
 import com.aws.greengrass.testing.mqtt5.client.GRPCLink;
 import com.aws.greengrass.testing.mqtt5.client.MqttLib;
 import com.aws.greengrass.testing.mqtt5.client.exceptions.GRPCException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Implementation of gRPC bidirectional link.
  */
-public class GRPCLinkImpl implements GRPCLink  {
+public class GRPCLinkImpl implements GRPCLink {
+    private static final Logger logger = LogManager.getLogger(GRPCLinkImpl.class);
+
     private static final int AUTOSELECT_PORT = 0;
 
-    private static final Logger logger = Logger.getLogger(GRPCLinkImpl.class.getName());
     private final GRPCDiscoveryClient client;
     private final GRPCControlServer server;
 
@@ -34,13 +35,12 @@ public class GRPCLinkImpl implements GRPCLink  {
      */
     public GRPCLinkImpl(String agentId, String host, int port) throws GRPCException {
         super();
-        logger.log(Level.INFO, "Making gPRC link with {0}:{1} as {2}",
-                    new Object[]{host, String.valueOf(port), agentId});
+        logger.atInfo().log("Making gPRC link with {}:{} as {}", host, port, agentId);
 
         String otfAddress = buildAddress(host, port);
         GRPCDiscoveryClient client = new GRPCDiscoveryClient(agentId, otfAddress);
         String localIP = client.registerAgent();
-        logger.log(Level.INFO, "Local address is {0}", localIP);
+        logger.atInfo().log("Local address is {0}", localIP);
 
         try {
             GRPCControlServer server = new GRPCControlServer(client, localIP, AUTOSELECT_PORT);
@@ -63,7 +63,7 @@ public class GRPCLinkImpl implements GRPCLink  {
      */
     @Override
     public String handleRequests(MqttLib mqttLib) throws GRPCException, InterruptedException {
-        logger.log(Level.INFO, "Handle gRPC requests");
+        logger.atInfo().log("Handle gRPC requests");
         server.waiting(mqttLib);
         return  "Agent shutdown by OTF request '" + server.getShutdownReason() + "'";
     }
@@ -76,7 +76,7 @@ public class GRPCLinkImpl implements GRPCLink  {
      */
     @Override
     public void shutdown(String reason) throws GRPCException {
-        logger.log(Level.INFO, "Shutdown gPRC link");
+        logger.atInfo().log("Shutdown gPRC link");
         client.unregisterAgent(reason);
         server.close();
         client.close();

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCLinkImpl.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCLinkImpl.java
@@ -37,7 +37,7 @@ public class GRPCLinkImpl implements GRPCLink  {
         logger.log(Level.INFO, "Making gPRC link with {0}:{1} as {2}",
                     new Object[]{host, String.valueOf(port), agentId});
 
-        String otfAddress = GRPCControlServer.buildAddress(host, port);
+        String otfAddress = buildAddress(host, port);
         GRPCDiscoveryClient client = new GRPCDiscoveryClient(agentId, otfAddress);
         String localIP = client.registerAgent();
         logger.log(Level.INFO, "Local address is {0}", localIP);
@@ -81,4 +81,17 @@ public class GRPCLinkImpl implements GRPCLink  {
         server.close();
         client.close();
     }
+
+    /**
+     * Build gRPC address string from host and port.
+     *
+     * @param host host part of gRPC address
+     * @param port port part of gRPC address
+     * @return address of gRPC service
+     */
+    private static String buildAddress(String host, int port) {
+        return host + ":" + port;
+    }
+
+
 }

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttLibImpl.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttLibImpl.java
@@ -9,20 +9,91 @@ import com.aws.greengrass.testing.mqtt5.client.MqttConnection;
 import com.aws.greengrass.testing.mqtt5.client.MqttLib;
 import com.aws.greengrass.testing.mqtt5.client.exceptions.MqttException;
 
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 /**
  * Interface of MQTT5 library.
  */
 public class MqttLibImpl implements MqttLib {
+    private static final Logger logger = Logger.getLogger(MqttLibImpl.class.getName());
+
+    private final ConcurrentHashMap<Integer, MqttConnection> connections = new ConcurrentHashMap<>();
+    private final AtomicInteger nextConnectionId = new AtomicInteger();
 
     /**
      * Creates a MQTT5 connection.
      *
-     * @param connectionRequest connect arguments
+     * @param connectionParams connection parameters
      * @return MqttConnection on success
      * @throws MqttException on errors
      */
     @Override
-    public MqttConnection createConnection(ConnectRequest connectionRequest) throws MqttException {
-        return new MqttConnectionImpl(connectionRequest);
+    public MqttConnection createConnection(ConnectionParams connectionParams) throws MqttException {
+        return new MqttConnectionImpl(connectionParams);
+    }
+
+    /**
+     * Register the MQTT connection.
+     *
+     * @param mqttConnection connection to register
+     * @return id of connection
+     */
+    @Override
+    public int registerConnection(MqttConnection mqttConnection) {
+        int connectionId = 0;
+        final boolean[] wasSet = new boolean[1];
+        while (! wasSet[0]) {
+            connectionId = nextConnectionId.incrementAndGet();
+            connections.computeIfAbsent(connectionId, key -> {
+                wasSet[0] = true;
+                return mqttConnection;
+                });
+        }
+        return connectionId;
+    }
+
+    /**
+     * Get MQTT connection and remove from list.
+     *
+     * @param connectionId id of connection
+     * @return MqttConnection on success and null when connection does not found
+     */
+    @Override
+    public MqttConnection unregisterConnection(int connectionId) {
+        return connections.remove(connectionId);
+    }
+
+    /**
+     * Get a MQTT connection.
+     *
+     * @param connectionId id of connection
+     * @return MqttConnection on success and null when connection does not found
+     */
+    @Override
+    public MqttConnection getConnection(int connectionId) {
+        return connections.get(connectionId);
+    }
+
+
+    @Override
+    public void close() {
+        cleaupConnections();
+    }
+
+
+    private void cleaupConnections() {
+        connections.forEach((key, connection) -> {
+            try {
+                // delete if value is up to date, otherwise leave for next round
+                if (connections.remove(key, connection)) {
+                    connection.disconnect(MqttConnection.DEFAULT_DISCONNECT_REASON);
+                }
+            } catch (MqttException ex) {
+                logger.log(Level.WARNING, "failed during disconnect", ex);
+            }
+        });
     }
 }

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttLibImpl.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttLibImpl.java
@@ -8,17 +8,17 @@ package com.aws.greengrass.testing.mqtt5.client.sdkmqtt;
 import com.aws.greengrass.testing.mqtt5.client.MqttConnection;
 import com.aws.greengrass.testing.mqtt5.client.MqttLib;
 import com.aws.greengrass.testing.mqtt5.client.exceptions.MqttException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Interface of MQTT5 library.
  */
 public class MqttLibImpl implements MqttLib {
-    private static final Logger logger = Logger.getLogger(MqttLibImpl.class.getName());
+    private static final Logger logger = LogManager.getLogger(MqttLibImpl.class);
 
     private final ConcurrentHashMap<Integer, MqttConnection> connections = new ConcurrentHashMap<>();
     private final AtomicInteger nextConnectionId = new AtomicInteger();
@@ -92,7 +92,7 @@ public class MqttLibImpl implements MqttLib {
                     connection.disconnect(MqttConnection.DEFAULT_DISCONNECT_REASON);
                 }
             } catch (MqttException ex) {
-                logger.log(Level.WARNING, "failed during disconnect", ex);
+                logger.atError().withThrowable(ex).log("failed during disconnect");
             }
         });
     }

--- a/uat/src/main/proto/mqtt_client_control.proto
+++ b/uat/src/main/proto/mqtt_client_control.proto
@@ -132,7 +132,7 @@ message MqttConnectRequest {
     string host = 2;                                    // host of MQTT broker
     int32 port = 3;                                     // port of MQTT broker
     int32 keepalive = 4;                                // MQTT keep alive interval in seconds
-    bool cleanSession = 5;                              // clean sesions flag
+    bool cleanSession = 5;                              // clean sesions (clean start) flag
     MqttProtoVersion protocolVersion = 6;               // version of MQTT protocol to use, currently only 5 is supported
     int32 connectTimeout = 7;                           // connect timeout in seconds
     optional Mqtt5Properties properties = 8;            // CONNECT packet MQTT 5 properties

--- a/uat/src/main/proto/mqtt_client_control.proto
+++ b/uat/src/main/proto/mqtt_client_control.proto
@@ -68,15 +68,19 @@ service MqttClientControl {
     // request to terminate agent
     rpc ShutdownAgent(ShutdownRequest) returns (google.protobuf.Empty) {}
 
-    // connection
+    // create MQTT connection
     rpc CreateMqttConnection(MqttConnectRequest) returns (MqttConnectionId) {}
+
+    // close MQTT connection
     rpc CloseMqttConnection(MqttCloseRequest) returns (google.protobuf.Empty) {}
 
-    // subscription(s)
+    // MQTT subscribe
     rpc SubscribeMqtt(MqttSubscribeRequest) returns (google.protobuf.Empty) {}
+
+    // MQTT unsubscribe
     rpc UnsubscribeMqtt(MqttUnsubscribeRequest) returns (google.protobuf.Empty) {}
 
-    // publishing
+    // publish MQTT message
     rpc PublishMqtt(MqttPublishRequest) returns (google.protobuf.Empty) {}
 }
 
@@ -130,9 +134,10 @@ message MqttConnectRequest {
     int32 keepalive = 4;                                // MQTT keep alive interval in seconds
     bool cleanSession = 5;                              // clean sesions flag
     MqttProtoVersion protocolVersion = 6;               // version of MQTT protocol to use, currently only 5 is supported
-    optional Mqtt5Properties properties = 7;            // CONNECT packet MQTT 5 properties
-    optional TLSSettings tls = 8;                       // TLS settings for secured connection
-    optional Mqtt5Message willMessage = 9;              // will message to set
+    int32 connectTimeout = 7;                           // connect timeout in seconds
+    optional Mqtt5Properties properties = 8;            // CONNECT packet MQTT 5 properties
+    optional TLSSettings tls = 9;                       // TLS settings for secured connection
+    optional Mqtt5Message willMessage = 10;              // will message to set
 }
 
 

--- a/uat/src/main/resources/log4j2.properties
+++ b/uat/src/main/resources/log4j2.properties
@@ -1,0 +1,12 @@
+name=PropertiesConfig
+property.filename = logs
+appenders = console
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n
+
+rootLogger.level = info
+rootLogger.appenderRefs = stdout
+rootLogger.appenderRef.stdout.ref = STDOUT


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-11

**Description of changes:**

- Update protocol to pass connection timeout
- Extend gRPC part to handle shutdownAgent/createMqttConnection/closeMqttConnection requests
- Added MqttLibImpl and MqttConnectionImpl and implement methods required for connect and disconnect
- Update README
- Tune pom.xml

**Why is this change necessary:**
MQTT client should be able to connect MQTT broker and disconnect from it

**How was this change tested:**
At the moment manually, later will covered by unit tests

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
