### PR TITLE
feat(uat): implement passing received MQTT message to gRPC server

### DIFF
--- a/uat/README.md
+++ b/uat/README.md
@@ -1,17 +1,22 @@
 # Test MQTT5 client bases on AWS IoT Device SDK for Java v2
 
-The test controlled MQTT v5.0 client based on AWS IoT Device SDK for Java v2 is used to test Greengrass v2 MQTT v5.0 compatibility.
+The controlled test MQTT v5.0 client based on AWS IoT Device SDK for Java v2 is used to test Greengrass v2 MQTT v5.0 compatibility.
 
 ## How to compile
-
-To complie this client, use the following command:
+To compile this client, use the following command:
 
 ```sh
 mvn clean license:check checkstyle:check pmd:check package
 ```
 
+# How to test
+To run integrated with sources tests, use the following command:
+```sh
+mvn -ntp -U clean verify
+```
+
 # How to run
-To Run this client use the following command:
+To run this client use the following command:
 ```sh
 mvn exec:java
 ```

--- a/uat/README.md
+++ b/uat/README.md
@@ -1,6 +1,6 @@
 # Test MQTT5 client bases on AWS IoT Device SDK for Java v2
 
-The controlled test MQTT v5.0 client based on AWS IoT Device SDK for Java v2 is used to test Greengrass v2 MQTT v5.0 compatibility.
+The controlled `test MQTT v5.0 client` is based on AWS IoT Device SDK for Java v2 is used to test Greengrass v2 MQTT v5.0 compatibility.
 
 ## How to compile
 To compile this client, use the following command:

--- a/uat/pom.xml
+++ b/uat/pom.xml
@@ -41,7 +41,6 @@
             <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-1.2-api</artifactId>
@@ -167,6 +166,9 @@
                 <configuration>
                     <source>8</source>
                     <target>8</target>
+                    <compilerArgs>
+                        <arg>-Xlint:deprecation</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/GRPCClient.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/GRPCClient.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.testing.mqtt5.client;
+
+import com.aws.greengrass.testing.mqtt5.client.exceptions.GRPCException;
+
+/**
+ * Interface to gRPC client.
+ */
+public interface GRPCClient {
+    /**
+     * Called when MQTT message is receive my MQTT client and deliver information from it to gRPC server.
+     *
+     * @param connectionId connection id which receives the message
+     * @param message information from the received MQTT message
+     * @throws GRPCException on errors
+     */
+    void onReceiveMqttMessage(int connectionId, MqttReceivedMessage message) throws GRPCException;
+}

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/GRPCLib.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/GRPCLib.java
@@ -12,10 +12,10 @@ import com.aws.greengrass.testing.mqtt5.client.exceptions.GRPCException;
  */
 public interface GRPCLib {
     /**
-     * Establish bidirectional link with the testing framework.
+     * Creates and establishes bidirectional link with the client control.
      *
-     * @param agentId id of agent to identify control channel by gRPC server
-     * @param host host name of gRPC server to connect to testing framework
+     * @param agentId id of agent to identify control channel by control
+     * @param host host name of gRPC server to connect to
      * @param port TCP port to connect to
      * @return connection handler
      * @throws GRPCException on errors

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/GRPCLink.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/GRPCLink.java
@@ -12,17 +12,17 @@ import com.aws.greengrass.testing.mqtt5.client.exceptions.GRPCException;
  */
 public interface GRPCLink {
     /**
-     * Handle gRPC requests.
+     * Handle all gRPC requests received from control.
      *
-     * @param mqttLib MQTT library handler
-     * @return shutdown reason as received from gRPC server
+     * @param mqttLib MQTT library
+     * @return shutdown reason as received from control or null
      * @throws GRPCException on errors
      * @throws InterruptedException when thread has been interrupted
      */
     String handleRequests(MqttLib mqttLib) throws GRPCException, InterruptedException;
 
     /**
-     * Unregister MQTT client control in testing framework.
+     * Unregister agent from control.
      *
      * @param reason reason of shutdown
      * @throws GRPCException on errors

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
@@ -20,7 +20,7 @@ public interface MqttConnection {
     long DEFAULT_DISCONNECT_TIMEOUT = 10;
 
     /**
-     * Contains information about MQTT v5.0 message.
+     * Contains information about publishing MQTT v5.0 message.
      */
     @Data
     @Builder
@@ -79,24 +79,12 @@ public interface MqttConnection {
     }
 
     /**
-     * Closes MQTT connection.
+     * Starts MQTT connection.
      *
-     * @param timeout disconnect operation timeout in seconds
-     * @param reasonCode reason why connection is closed
+     * @param connectionId connection id
      * @throws MqttException on errors
      */
-    void disconnect(long timeout, int reasonCode) throws MqttException;
-
-
-    /**
-     * Publishes MQTT message.
-     *
-     * @param timeout publish operation timeout in seconds
-     * @param message message to publish
-     * @return useful information from PUBACK packet or null of no PUBACK has been received (as for QoS 0)
-     * @throws MqttException on errors
-     */
-    PubAckInfo publish(long timeout, final Message message) throws MqttException;
+    void start(int connectionId) throws MqttException;
 
     /**
      * Subscribes to topics.
@@ -110,6 +98,17 @@ public interface MqttConnection {
     SubAckInfo subscribe(long timeout, final Integer subscriptionId, final List<Subscription> subscriptions)
             throws MqttException;
 
+
+    /**
+     * Publishes MQTT message.
+     *
+     * @param timeout publish operation timeout in seconds
+     * @param message message to publish
+     * @return useful information from PUBACK packet or null of no PUBACK has been received (as for QoS 0)
+     * @throws MqttException on errors
+     */
+    PubAckInfo publish(long timeout, final Message message) throws MqttException;
+
     /**
      * Unsubscribes from topics.
      *
@@ -119,4 +118,13 @@ public interface MqttConnection {
      * @throws MqttException on errors
      */
     SubAckInfo unsubscribe(long timeout, final List<String> filters) throws MqttException;
+
+    /**
+     * Closes MQTT connection.
+     *
+     * @param timeout disconnect operation timeout in seconds
+     * @param reasonCode reason why connection is closed
+     * @throws MqttException on errors
+     */
+    void disconnect(long timeout, int reasonCode) throws MqttException;
 }

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
@@ -25,10 +25,19 @@ public interface MqttConnection {
     @Data
     @Builder
     class Message {
+        /** QoS value. */
         int qos;
+
+        /** Retain flag. */
         boolean retain;
+
+        /** Topic of message. */
         String topic;
+
+        /** Payload of message. */
         byte[] payload;
+
+        // TODO: add user's properties and so one
     }
 
     /**
@@ -66,7 +75,7 @@ public interface MqttConnection {
     }
 
     /**
-     * Useful information from SUBACK and UNSUBACK packets.
+     * Useful information from SUBACK packet.
      */
     @Data
     @AllArgsConstructor
@@ -78,13 +87,25 @@ public interface MqttConnection {
         // TODO: add user's properties
     }
 
+
+    /**
+     * Useful information from UNSUBACK packet.
+     * Actually is the same as SubAckInfo.
+     */
+    class UnsubAckInfo extends SubAckInfo {
+        public UnsubAckInfo(List<Integer> reasonCodes, String reasonString) {
+            super(reasonCodes, reasonString);
+        }
+    }
+
     /**
      * Starts MQTT connection.
      *
-     * @param connectionId connection id
+     * @param timeout connect operation timeout in seconds
+     * @param connectionId connection id as assigned by MQTT library
      * @throws MqttException on errors
      */
-    void start(int connectionId) throws MqttException;
+    void start(long timeout, int connectionId) throws MqttException;
 
     /**
      * Subscribes to topics.
@@ -117,7 +138,7 @@ public interface MqttConnection {
      * @return useful information from UNSUBACK packet
      * @throws MqttException on errors
      */
-    SubAckInfo unsubscribe(long timeout, final List<String> filters) throws MqttException;
+    UnsubAckInfo unsubscribe(long timeout, final List<String> filters) throws MqttException;
 
     /**
      * Closes MQTT connection.

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.testing.mqtt5.client;
 
 import com.aws.greengrass.testing.mqtt5.client.exceptions.MqttException;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 
 import java.util.List;
@@ -17,6 +18,18 @@ import java.util.List;
 public interface MqttConnection {
     int DEFAULT_DISCONNECT_REASON = 4;
     long DEFAULT_DISCONNECT_TIMEOUT = 10;
+
+    /**
+     * Contains information about MQTT v5.0 message.
+     */
+    @Data
+    @Builder
+    class Message {
+        int qos;
+        boolean retain;
+        String topic;
+        byte[] payload;
+    }
 
     /**
      * Useful information from PUBACK packet.
@@ -68,25 +81,22 @@ public interface MqttConnection {
     /**
      * Closes MQTT connection.
      *
-     * @param reasonCode reason why connection is closed
      * @param timeout disconnect operation timeout in seconds
+     * @param reasonCode reason why connection is closed
      * @throws MqttException on errors
      */
-    void disconnect(int reasonCode, long timeout) throws MqttException;
+    void disconnect(long timeout, int reasonCode) throws MqttException;
 
 
     /**
      * Publishes MQTT message.
      *
-     * @param retain if set message will retained
-     * @param qos QoS value to publish message
      * @param timeout publish operation timeout in seconds
-     * @param topic topic to publish message
-     * @param content message content
+     * @param message message to publish
      * @return useful information from PUBACK packet or null of no PUBACK has been received (as for QoS 0)
      * @throws MqttException on errors
      */
-    PubAckInfo publish(boolean retain, int qos, long timeout, String topic, byte[] content) throws MqttException;
+    PubAckInfo publish(long timeout, final Message message) throws MqttException;
 
     /**
      * Subscribes to topics.
@@ -97,7 +107,8 @@ public interface MqttConnection {
      * @return useful information from SUBACK packet
      * @throws MqttException on errors
      */
-    SubAckInfo subscribe(long timeout, Integer subscriptionId, List<Subscription> subscriptions) throws MqttException;
+    SubAckInfo subscribe(long timeout, final Integer subscriptionId, final List<Subscription> subscriptions)
+            throws MqttException;
 
     /**
      * Unsubscribes from topics.
@@ -107,5 +118,5 @@ public interface MqttConnection {
      * @return useful information from UNSUBACK packet
      * @throws MqttException on errors
      */
-    SubAckInfo unsubscribe(long timeout, List<String> filters) throws MqttException;
+    SubAckInfo unsubscribe(long timeout, final List<String> filters) throws MqttException;
 }

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
@@ -9,6 +9,8 @@ import com.aws.greengrass.testing.mqtt5.client.exceptions.MqttException;
 import lombok.Builder;
 import lombok.Data;
 
+import java.util.function.BiConsumer;
+
 /**
  * Interface of MQTT5 library.
  */
@@ -52,10 +54,13 @@ public interface MqttLib extends AutoCloseable {
      * Creates a MQTT connection.
      *
      * @param connectionParams connection parameters
+     * @param messageConsumer consumer of received messages
      * @return MqttConnection on success
      * @throws MqttException on errors
      */
-    MqttConnection createConnection(ConnectionParams connectionParams) throws MqttException;
+    MqttConnection createConnection(ConnectionParams connectionParams,
+                                        BiConsumer<Integer, MqttReceivedMessage> messageConsumer)
+                throws MqttException;
 
     /**
      * Register the MQTT connection.

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
@@ -37,9 +37,6 @@ public interface MqttLib extends AutoCloseable {
         /** Clean session (clean start) flag of CONNECT packet. */
         private boolean cleanSession;
 
-        /** Connection timeout in seconds. */
-        private int timeout;
-
         /** Content of CA, optional. */
         private String ca;
 

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttReceivedMessage.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttReceivedMessage.java
@@ -14,8 +14,17 @@ import lombok.Data;
 @Data
 @Builder
 public class MqttReceivedMessage {
+    /** QoS value. */
     int qos;
+
+    /** Retain flag. */
     boolean retain;
+
+    /** Topic of message. */
     String topic;
+
+    /** Payload of message. */
     byte[] payload;
+
+    // TODO: add user's properties and so one
 }

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttReceivedMessage.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttReceivedMessage.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.testing.mqtt5.client;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Contains information about received MQTT v5.0 message.
+ */
+@Data
+@Builder
+public class MqttReceivedMessage {
+    int qos;
+    boolean retain;
+    String topic;
+    byte[] payload;
+}

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
@@ -297,7 +297,7 @@ class GRPCControlServer {
             if (qos < QOS_MIN || qos > QOS_MAX) {
                 logger.atWarn().log("invalid QoS {}, must be in range [{},{}]", qos, QOS_MIN, QOS_MAX);
                 responseObserver.onError(Status.INVALID_ARGUMENT
-                                            .withDescription("invalie QoS, must be in range [0,3]")
+                                            .withDescription("invalid QoS, must be in range [0,3]")
                                             .asRuntimeException());
                 return;
             }

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCDiscoveryClient.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCDiscoveryClient.java
@@ -34,6 +34,7 @@ class GRPCDiscoveryClient implements GRPCClient {
     private static final String GRPC_REQUEST_FAILED = "gRPC request failed";
 
     private final String agentId;
+    private final ManagedChannel channel;
     private final MqttAgentDiscoveryGrpc.MqttAgentDiscoveryBlockingStub blockingStub;
 
     /**
@@ -46,7 +47,7 @@ class GRPCDiscoveryClient implements GRPCClient {
     GRPCDiscoveryClient(String agentId, String address) throws GRPCException {
         super();
         this.agentId = agentId;
-        ManagedChannel channel = Grpc.newChannelBuilder(address, InsecureChannelCredentials.create()).build();
+        this.channel = Grpc.newChannelBuilder(address, InsecureChannelCredentials.create()).build();
         this.blockingStub = MqttAgentDiscoveryGrpc.newBlockingStub(channel);
     }
 
@@ -116,7 +117,7 @@ class GRPCDiscoveryClient implements GRPCClient {
         Mqtt5Message msg = Mqtt5Message.newBuilder()
                                         .setTopic(message.getTopic())
                                         .setPayload(ByteString.copyFrom(message.getPayload()))
-                                        .setQos(MqttQoS.valueOf(message.getQos()))
+                                        .setQos(MqttQoS.forNumber(message.getQos()))
                                         .setRetain(message.isRetain())
                                         .build();
 
@@ -133,7 +134,10 @@ class GRPCDiscoveryClient implements GRPCClient {
         }
     }
 
+    /**
+     * Closes the gRPC client.
+     */
     void close() {
-        // TODO: implement
+        channel.shutdown();
     }
 }

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCLibImpl.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCLibImpl.java
@@ -13,15 +13,6 @@ import com.aws.greengrass.testing.mqtt5.client.exceptions.GRPCException;
  * Implementation of gRPC library.
  */
 public class GRPCLibImpl implements GRPCLib {
-    /**
-     * Establish bidirectional link with the testing framework.
-     *
-     * @param agentId id of agent to identify control channel by gRPC server
-     * @param host host name of gRPC server to connect to testing framework
-     * @param port TCP port to connect to
-     * @return connection handler
-     * @throws GRPCException on errors
-     */
     @Override
     public GRPCLink makeLink(String agentId, String host, int port) throws GRPCException {
         return new GRPCLinkImpl(agentId, host, port);

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCLinkImpl.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCLinkImpl.java
@@ -26,10 +26,10 @@ public class GRPCLinkImpl implements GRPCLink {
 
 
     /**
-     * Establish bidirectional link with the testing framework.
+     * Creates and establishes bidirectional link with the control.
      *
      * @param agentId id of agent to identify control channel by gRPC server
-     * @param host host name of gRPC server to connect to testing framework
+     * @param host host name of gRPC server to connect to
      * @param port TCP port to connect to
      * @throws GRPCException on errors
      */
@@ -40,7 +40,7 @@ public class GRPCLinkImpl implements GRPCLink {
         String otfAddress = buildAddress(host, port);
         GRPCDiscoveryClient client = new GRPCDiscoveryClient(agentId, otfAddress);
         String localIP = client.registerAgent();
-        logger.atInfo().log("Local address is {0}", localIP);
+        logger.atInfo().log("Local address is {}", localIP);
 
         try {
             GRPCControlServer server = new GRPCControlServer(client, localIP, AUTOSELECT_PORT);
@@ -53,14 +53,6 @@ public class GRPCLinkImpl implements GRPCLink {
         }
     }
 
-    /**
-     * Handle gRPC requests.
-     *
-     * @param mqttLib MQTT library handler
-     * @return shutdown reason
-     * @throws GRPCException on errors
-     * @throws InterruptedException when thread has been interrupted
-     */
     @Override
     public String handleRequests(MqttLib mqttLib) throws GRPCException, InterruptedException {
         logger.atInfo().log("Handle gRPC requests");
@@ -68,12 +60,6 @@ public class GRPCLinkImpl implements GRPCLink {
         return  "Agent shutdown by OTF request '" + server.getShutdownReason() + "'";
     }
 
-    /**
-     * Unregister MQTT client control in testing framework.
-     *
-     * @param reason reason of shutdown
-     * @throws GRPCException on errors
-     */
     @Override
     public void shutdown(String reason) throws GRPCException {
         logger.atInfo().log("Shutdown gPRC link");

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCLinkImpl.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCLinkImpl.java
@@ -92,6 +92,4 @@ public class GRPCLinkImpl implements GRPCLink {
     private static String buildAddress(String host, int port) {
         return host + ":" + port;
     }
-
-
 }

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttLibImpl.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttLibImpl.java
@@ -17,22 +17,17 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 
 /**
- * Interface of MQTT5 library.
+ * Implementation of MQTT5 library.
  */
 public class MqttLibImpl implements MqttLib {
     private static final Logger logger = LogManager.getLogger(MqttLibImpl.class);
 
+    /** Map of connections by id. */
     private final ConcurrentHashMap<Integer, MqttConnection> connections = new ConcurrentHashMap<>();
+
+    /** Next connection id to use. */
     private final AtomicInteger nextConnectionId = new AtomicInteger();
 
-    /**
-     * Creates a MQTT5 connection.
-     *
-     * @param connectionParams connection parameters
-     * @param messageConsumer consumer of received messages
-     * @return MqttConnection on success
-     * @throws MqttException on errors
-     */
     @Override
     public MqttConnection createConnection(ConnectionParams connectionParams,
                                             BiConsumer<Integer, MqttReceivedMessage> messageConsumer)
@@ -40,12 +35,6 @@ public class MqttLibImpl implements MqttLib {
         return new MqttConnectionImpl(connectionParams, messageConsumer);
     }
 
-    /**
-     * Register the MQTT connection.
-     *
-     * @param mqttConnection connection to register
-     * @return id of connection
-     */
     @Override
     public int registerConnection(MqttConnection mqttConnection) {
         int connectionId = 0;
@@ -60,23 +49,11 @@ public class MqttLibImpl implements MqttLib {
         return connectionId;
     }
 
-    /**
-     * Get MQTT connection and remove from list.
-     *
-     * @param connectionId id of connection
-     * @return MqttConnection on success and null when connection does not found
-     */
     @Override
     public MqttConnection unregisterConnection(int connectionId) {
         return connections.remove(connectionId);
     }
 
-    /**
-     * Get a MQTT connection.
-     *
-     * @param connectionId id of connection
-     * @return MqttConnection on success and null when connection does not found
-     */
     @Override
     public MqttConnection getConnection(int connectionId) {
         return connections.get(connectionId);
@@ -89,6 +66,9 @@ public class MqttLibImpl implements MqttLib {
     }
 
 
+    /**
+     * Dry connections.
+     */
     private void cleaupConnections() {
         connections.forEach((key, connection) -> {
             try {
@@ -98,7 +78,7 @@ public class MqttLibImpl implements MqttLib {
                                             MqttConnection.DEFAULT_DISCONNECT_REASON);
                 }
             } catch (MqttException ex) {
-                logger.atError().withThrowable(ex).log("failed during disconnect");
+                logger.atError().withThrowable(ex).log("Failed during disconnect");
             }
         });
     }

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttLibImpl.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttLibImpl.java
@@ -89,8 +89,8 @@ public class MqttLibImpl implements MqttLib {
             try {
                 // delete if value is up to date, otherwise leave for next round
                 if (connections.remove(key, connection)) {
-                    connection.disconnect(MqttConnection.DEFAULT_DISCONNECT_REASON,
-                                            MqttConnection.DEFAULT_DISCONNECT_TIMEOUT);
+                    connection.disconnect(MqttConnection.DEFAULT_DISCONNECT_TIMEOUT,
+                                            MqttConnection.DEFAULT_DISCONNECT_REASON);
                 }
             } catch (MqttException ex) {
                 logger.atError().withThrowable(ex).log("failed during disconnect");

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttLibImpl.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttLibImpl.java
@@ -7,12 +7,14 @@ package com.aws.greengrass.testing.mqtt5.client.sdkmqtt;
 
 import com.aws.greengrass.testing.mqtt5.client.MqttConnection;
 import com.aws.greengrass.testing.mqtt5.client.MqttLib;
+import com.aws.greengrass.testing.mqtt5.client.MqttReceivedMessage;
 import com.aws.greengrass.testing.mqtt5.client.exceptions.MqttException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
 
 /**
  * Interface of MQTT5 library.
@@ -27,12 +29,15 @@ public class MqttLibImpl implements MqttLib {
      * Creates a MQTT5 connection.
      *
      * @param connectionParams connection parameters
+     * @param messageConsumer consumer of received messages
      * @return MqttConnection on success
      * @throws MqttException on errors
      */
     @Override
-    public MqttConnection createConnection(ConnectionParams connectionParams) throws MqttException {
-        return new MqttConnectionImpl(connectionParams);
+    public MqttConnection createConnection(ConnectionParams connectionParams,
+                                            BiConsumer<Integer, MqttReceivedMessage> messageConsumer)
+                throws MqttException {
+        return new MqttConnectionImpl(connectionParams, messageConsumer);
     }
 
     /**

--- a/uat/src/main/proto/mqtt_client_control.proto
+++ b/uat/src/main/proto/mqtt_client_control.proto
@@ -30,12 +30,17 @@ service MqttAgentDiscovery {
     rpc UnregisterAgent(UnregisterRequest) returns (google.protobuf.Empty) {}
 
     // called when client receives MQTT message on subscription
-    rpc OnReceiveMqttMessage(ReceivedMqttMessage) returns (google.protobuf.Empty) {}
+    rpc OnReceiveMessage(OnReceiveMessageRequest) returns (google.protobuf.Empty) {}
 }
 
 // Request to register new agent, contains the agent id.
 message RegisterRequest {
     string agentId = 1;
+}
+
+// Response to Register request contains address of agent's client as visible from OTF side
+message RegisterReply {
+    string address = 1;
 }
 
 // Request to register service address of agent, contains the agent's service address and port.
@@ -51,12 +56,12 @@ message UnregisterRequest {
     string reason = 2;
 }
 
-// Response to Register request contains address of agent's client as visible from OFT side
-message RegisterReply {
-    string address = 1;
+// MQTT message received by agent
+message OnReceiveMessageRequest {
+    string agentId = 1;                                 // really required ?
+    MqttConnectionId connectionId = 2;                  // id of connection which received the message
+    Mqtt5Message msg = 3;                               // received MQTT message
 }
-
-// see also ReceivedMqttMessage
 
 // End of discovery part
 
@@ -174,12 +179,6 @@ message MqttCloseRequest {
     optional Mqtt5Properties properties = 4;            // DISCONNECT packet MQTT v5.0 properties
 }
 
-// MQTT message received by agent
-message ReceivedMqttMessage {
-    string agentId = 1;                                 // really required ?
-    MqttConnectionId connectionId = 2;                  // id of connection which received the message
-    // TODO: received MQTT message fields and metadata
-}
 
 // Request to subscribe to MQTT topic(s)
 message MqttSubscribeRequest {


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-15

**Description of changes:**

- gRPC protocol has been updated to receive message by control side
- Implement passing received message from MQTT connection layer to gRPC client via BiConsumer
- Updated README
- Added GRPCClient and MqttReceivedMessage interfaces to decouple classes.
- Arguments of publish now collected in Message object
- Tune error messages in GRPCControlServer

**Why is this change necessary:**
Controlled MQTT client should be able to deliver information from receive MQTT message to contol side.

**How was this change tested:**
At the moment manually, later will cover code by unit tests.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
