### PR TITLE
feat(uat): added EngineControl.getConnectionControl() and connection name

### DIFF
--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
@@ -18,6 +18,7 @@ import com.aws.greengrass.testing.mqtt.client.TLSSettings;
 import com.aws.greengrass.testing.mqtt.client.control.api.AgentControl;
 import com.aws.greengrass.testing.mqtt.client.control.api.AgentControl.ConnectionEvents;
 import com.aws.greengrass.testing.mqtt.client.control.api.ConnectionControl;
+import com.aws.greengrass.testing.mqtt.client.control.api.EngineControl;
 import com.google.protobuf.ByteString;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
@@ -29,6 +30,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.UUID;
 
 /**
  * Class with hardcoded scenario to do manual tests of client and control.
@@ -83,6 +85,7 @@ class AgentTestScenario implements Runnable {
 
     private boolean useTLS;
     private final AgentControl agent;
+    private final EngineControl engine;
 
     private String ca = null;
     private String cert = null;
@@ -110,10 +113,13 @@ class AgentTestScenario implements Runnable {
         }
     };
 
-    public AgentTestScenario(boolean useTLS, AgentControl agent) {
+    public AgentTestScenario(boolean useTLS, EngineControl engine, AgentControl agent) {
         super();
+
         this.useTLS = useTLS;
         this.agent = agent;
+        this.engine = engine;
+
         if (useTLS) {
             this.ca = readFile(getCaFile());
             this.cert = readFile(getCertFile());
@@ -133,6 +139,8 @@ class AgentTestScenario implements Runnable {
             MqttConnectRequest connectRequest = getMqttConnectRequest();
             connectionControl = agent.createMqttConnection(connectRequest, connectionEvents);
             logger.atInfo().log("MQTT connection with id {} is established", connectionControl.getConnectionId());
+
+            checkGetConnectionControl(connectionControl);
 
             Thread.sleep(PAUSE_BEFORE_SUBSCRIBE);
             testSubscribe(connectionControl);
@@ -274,6 +282,31 @@ class AgentTestScenario implements Runnable {
             useTLS = false;
         }
         return null;
+    }
+
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    private void checkGetConnectionControl(ConnectionControl connectionControl) {
+        final String connectionName = UUID.randomUUID().toString();
+        connectionControl.setConnectionName(connectionName);
+        logger.atInfo().log("Connection name set to {}", connectionName);
+
+        logger.atInfo().log("Looking for connection with name {} in engine", connectionName);
+        ConnectionControl foundConnectionContol = engine.getConnectionControl(connectionName);
+        if (foundConnectionContol == connectionControl) {
+            logger.atInfo().log("Correct connection is found");
+        } else {
+            logger.atError().log("Invalid connection returned by EngineControl.getConnectionControl()");
+        }
+
+        final String connectionNameNotExists = UUID.randomUUID().toString();
+        logger.atInfo().log("Looking for connection with name {} in engine", connectionNameNotExists);
+        ConnectionControl mustBeNull = engine.getConnectionControl(connectionNameNotExists);
+        if (mustBeNull == null) {
+            logger.atInfo().log("Not existing connection does not found");
+        } else {
+            logger.atError().log("Connection with such name does not found but method return value");
+        }
+
     }
 }
 

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/ExampleControl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/ExampleControl.java
@@ -30,12 +30,13 @@ public class ExampleControl {
 
     private final boolean useTLS;
     private final int port;
+    private final EngineControl engine;
 
     private final EngineEvents engineEvents = new EngineEvents() {
         @Override
         public void onAgentAttached(AgentControl agent) {
             logger.atInfo().log("Agent {} is connected", agent.getAgentId());
-            AgentTestScenario scenario = new AgentTestScenario(useTLS, agent);
+            AgentTestScenario scenario = new AgentTestScenario(useTLS, engine, agent);
             executorService.submit(scenario);
         }
 
@@ -56,10 +57,10 @@ public class ExampleControl {
         super();
         this.useTLS = useTLS;
         this.port = port;
+        this.engine = new EngineControlImpl();
     }
 
     private void testRun() throws IOException, InterruptedException {
-        final EngineControl engine = new EngineControlImpl();
         engine.startEngine(port, engineEvents);
         Runtime.getRuntime().addShutdownHook(new Thread() {
             @Override

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/ConnectionControl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/ConnectionControl.java
@@ -18,9 +18,25 @@ import lombok.NonNull;
 public interface ConnectionControl {
     /**
      * Gets id of the connection.
-     * @return agent id
+     *
+     * @return connection id
      */
     int getConnectionId();
+
+    /**
+     * Sets connection name.
+     * Can be used instead of agentId:connectionId pair to identify connection
+     *
+     * @param connectionName logical connection name
+     */
+    void setConnectionName(@NonNull String connectionName);
+
+    /**
+     * Gets connection name.
+     *
+     * @return logical connection name
+     */
+    String getConnectionName();
 
     /**
      * Gets information from CONNACK packet.

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/EngineControl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/EngineControl.java
@@ -34,11 +34,17 @@ public interface EngineControl {
     /**
      * Starts engine instance.
      *
-     * @param port port number to listen for gRPC service
+     * @param port port number to listen for gRPC service, can be 0 to autoselect port
      * @param engineEvents received of engine level events
      * @throws IOException on IO errors
      */
     void startEngine(int port, @NonNull EngineEvents engineEvents) throws IOException;
+
+    /**
+     * Gets port where gRPC service actually bound to.
+     * @return actual port where gRPC server is listeding
+     */
+    int getBoundPort();
 
     /**
      * Checks is engine runing.

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/EngineControl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/EngineControl.java
@@ -62,6 +62,15 @@ public interface EngineControl {
     void awaitTermination() throws InterruptedException;
 
     /**
+     * Gets connection control by connection name.
+     * Searching over all agents and find first occurrence of control with such name
+     *
+     * @param connectionName the logical name of a connection control
+     * @return connection control with that name or null if control does not found
+     */
+    ConnectionControl getConnectionControl(@NonNull String connectionName);
+
+    /**
      * Stops engine instance.
      *
      */

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/AgentControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/AgentControlImpl.java
@@ -179,7 +179,7 @@ public class AgentControlImpl implements AgentControl {
      * @param closeRequest parameters of MQTT disconnect
      * @throws StatusRuntimeException on errors
      */
-    public void closeMqttConnection(MqttCloseRequest closeRequest) {
+    void closeMqttConnection(MqttCloseRequest closeRequest) {
         blockingStub.closeMqttConnection(closeRequest);
         int connectionId = closeRequest.getConnectionId().getConnectionId();
         connections.remove(connectionId);
@@ -193,7 +193,7 @@ public class AgentControlImpl implements AgentControl {
      * @return reply to subscribe
      * @throws StatusRuntimeException on errors
      */
-    public MqttSubscribeReply subscribeMqtt(MqttSubscribeRequest subscribeRequest) {
+    MqttSubscribeReply subscribeMqtt(MqttSubscribeRequest subscribeRequest) {
         int connectionId = subscribeRequest.getConnectionId().getConnectionId();
         logger.atInfo().log("SubscribeMqtt: subscribe on connection {}", connectionId);
         return blockingStub.subscribeMqtt(subscribeRequest);
@@ -206,7 +206,7 @@ public class AgentControlImpl implements AgentControl {
      * @return reply to unsubscribe
      * @throws StatusRuntimeException on errors
      */
-    public MqttSubscribeReply unsubscribeMqtt(MqttUnsubscribeRequest unsubscribeRequest) {
+    MqttSubscribeReply unsubscribeMqtt(MqttUnsubscribeRequest unsubscribeRequest) {
         int connectionId = unsubscribeRequest.getConnectionId().getConnectionId();
         logger.atInfo().log("UnsubscribeMqtt: unsubscribe on connectionId {}", connectionId);
         return blockingStub.unsubscribeMqtt(unsubscribeRequest);
@@ -219,11 +219,28 @@ public class AgentControlImpl implements AgentControl {
      * @return reply to publish
      * @throws StatusRuntimeException on errors
      */
-    public MqttPublishReply publishMqtt(MqttPublishRequest publishRequest) {
+    MqttPublishReply publishMqtt(MqttPublishRequest publishRequest) {
         int connectionId = publishRequest.getConnectionId().getConnectionId();
         String topic = publishRequest.getMsg().getTopic();
         logger.atInfo().log("PublishMqtt: publishing on connectionId {} topic {}", connectionId, topic);
         return blockingStub.publishMqtt(publishRequest);
+    }
+
+    /**
+     * Gets connection control by connection name.
+     * Searching over all controls and find first occurrence of control with such name
+     *
+     * @param connectionName the logical name of a connection
+     * @return connection control or null when does not found
+     */
+    ConnectionControlImpl getConnectionControl(@NonNull String connectionName) {
+        for (ConcurrentHashMap.Entry<Integer, ConnectionControlImpl> entry : connections.entrySet()) {
+            ConnectionControlImpl connectionControl = entry.getValue();
+            if (connectionName.equals(connectionControl.getConnectionName())) {
+                return connectionControl;
+            }
+        }
+        return null;
     }
 
     private void closeAllMqttConnections() {

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
@@ -9,6 +9,7 @@ package com.aws.greengrass.testing.mqtt.client.control.implementation;
 import com.aws.greengrass.testing.mqtt.client.Mqtt5Disconnect;
 import com.aws.greengrass.testing.mqtt.client.Mqtt5Message;
 import com.aws.greengrass.testing.mqtt.client.control.api.AgentControl;
+import com.aws.greengrass.testing.mqtt.client.control.api.ConnectionControl;
 import com.aws.greengrass.testing.mqtt.client.control.api.EngineControl;
 import com.aws.greengrass.testing.mqtt.client.control.implementation.grpc.GRPCDiscoveryServer;
 import com.aws.greengrass.testing.mqtt.client.control.implementation.grpc.GRPCDiscoveryServerInterceptor;
@@ -69,6 +70,18 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
         if (srv != null) {
             srv.awaitTermination();
         }
+    }
+
+    @Override
+    public ConnectionControl getConnectionControl(@NonNull String connectionName) {
+        ConnectionControl connectionControl = null;
+        for (ConcurrentHashMap.Entry<String, AgentControlImpl> entry : agents.entrySet()) {
+            connectionControl = entry.getValue().getConnectionControl(connectionName);
+            if (connectionControl != null) {
+                break;
+            }
+        }
+        return connectionControl;
     }
 
     @Override

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
@@ -33,8 +33,8 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
     private final ConcurrentHashMap<String, AgentControlImpl> agents = new ConcurrentHashMap<>();
     private final AtomicReference<Server> server = new AtomicReference<>();
 
-
     private EngineEvents engineEvents;
+    private int boundPort;
 
     @Override
     public void startEngine(int port, @NonNull EngineEvents engineEvents) throws IOException {
@@ -46,12 +46,18 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
                 .addService(ServerInterceptors.intercept(new GRPCDiscoveryServer(this), interceptors))
                 .build()
                 .start();
+        boundPort = srv.getPort();
 
         Server oldSrv = server.getAndSet(srv);
         if (oldSrv != null) {
             oldSrv.shutdown();
         }
-        logger.atInfo().log("gRPC MQTT client control server started, listening on {}", port);
+        logger.atInfo().log("gRPC MQTT client control server started, listening on {}", boundPort);
+    }
+
+    @Override
+    public int getBoundPort() {
+        return boundPort;
     }
 
     @Override


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-48

Implement mapping from string logicalConnectionId to agent/connection

**Description of changes:**
- Added EngineControl.getConnectionControl()
- Added ConnectionControl.setConnectionName()
- Added ConnectionControl.getConnectionName()
- Added AgentControlImpl.getConnectionControl()
- Added build of default connection name value in constructor of ConnectionControlImpl()
- Added EngineControl.getBoundPort()


**Why is this change necessary:**
It require to simplify access to connection control from scenario by only logical name instead of pair agent id and connection id

**How was this change tested:**
At the moment manually, in phase 2 we going to cover code by unit tests

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
