### PR TITLE
feat(uat): add support of multi-homed broker

### DIFF
--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
@@ -184,12 +184,12 @@ class GRPCControlServer {
             // check TLS optional settings
             if (request.hasTls()) {
                 TLSSettings tls = request.getTls();
-                String ca = tls.getCa();
+                List<String> caList = tls.getCaListList();
 
-                if (ca == null || ca.isEmpty()) {
-                    logger.atWarn().log("empty CA");
+                if (caList == null || caList.isEmpty()) {
+                    logger.atWarn().log("empty CA list");
                     responseObserver.onError(Status.INVALID_ARGUMENT
-                                                .withDescription("empty CA")
+                                                .withDescription("empty CA list")
                                                 .asRuntimeException());
                     return;
                 }
@@ -212,9 +212,9 @@ class GRPCControlServer {
                     return;
                 }
 
+                final String ca = String.join("\n", caList);
                 connectionParamsBuilder.ca(ca).cert(cert).key(key);
             }
-
 
             logger.atInfo().log("createMqttConnection: clientId {} broker {}:{}", clientId, host, port);
             MqttConnectReply.Builder builder = MqttConnectReply.newBuilder();

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
@@ -179,7 +179,7 @@ class AgentTestScenario implements Runnable {
                     .setProtocolVersion(MqttProtoVersion.MQTT_PROTOCOL_V50);
 
         if (useTLS) {
-            TLSSettings tlsSettings = TLSSettings.newBuilder().setCa(ca).setCert(cert).setKey(key).build();
+            TLSSettings tlsSettings = TLSSettings.newBuilder().addCaList(ca).setCert(cert).setKey(key).build();
             builder.setTls(tlsSettings);
         }
 

--- a/uat/proto/mqtt_client_control.proto
+++ b/uat/proto/mqtt_client_control.proto
@@ -192,7 +192,7 @@ message Mqtt5Subscription {
 
 // Optional TLS settings for MQTT connection
 message TLSSettings {
-    string ca = 1;                                      // list of PEM formatted CA, separated by "\n\n\n"
+    repeated string caList = 1;                         // list of PEM formatted CA
     string cert = 2;                                    // MQTT client's certificate, PEM formatted
     string key = 3;                                     // MQTT client's private key
 };

--- a/uat/proto/mqtt_client_control.proto
+++ b/uat/proto/mqtt_client_control.proto
@@ -192,9 +192,9 @@ message Mqtt5Subscription {
 
 // Optional TLS settings for MQTT connection
 message TLSSettings {
-    string ca = 1;
-    string cert = 2;
-    string key = 3;
+    string ca = 1;                                      // list of PEM formatted CA, separated by "\n\n\n"
+    string cert = 2;                                    // MQTT client's certificate, PEM formatted
+    string key = 3;                                     // MQTT client's private key
 };
 
 // Request to shutdown client has a reason field


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-85
Multi-homed broker is not supported

**Description of changes:**
- Add support of multi-homed broker but implement iteration over addresses in building block of connect
- Add comments in gRPC protocol about semantic and format of TLS message

**Why is this change necessary:**
Currently implementation is use just first address of broker which available locally. 
It will not works for remote clients.
That cons should be fixed.

**How was this change tested:**
No specific tests for that code due to it is building blocks


**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
