### PR TITLE
feat(uat): add subscribe/unsubscribe/publish to MQTT v3.1.1 client

### DIFF
--- a/uat/custom-components/client-java-sdk/README.md
+++ b/uat/custom-components/client-java-sdk/README.md
@@ -55,6 +55,6 @@ SDK-based client does not provide OS specific error code or string, correspondin
 
 SDK-based client provides only session present flag of CONNACK packet. The Connect Return code of CONNACK is missing.
 
-Raal SUBACK information is not available from that client. Instead hard-coded Result Code 0 is used to create a response on gRPC request.
+Real SUBACK information is not available from that client. Instead hard-coded Result Code 0 is used to create a response on gRPC request.
 
 Real PUBACK information is not available from that client. Instead hard-coded Result Code 0 is used to create a response on gRPC request.

--- a/uat/custom-components/client-java-sdk/README.md
+++ b/uat/custom-components/client-java-sdk/README.md
@@ -49,6 +49,12 @@ Will message not yet supported.
 Currenly information from packets related to QoS2 like PUBREC PUBREL PUBCOMP is missing.
 
 ## MQTT v3.1.1 client
-SDK-based client provides only session present flag of CONNACK packet.
-Connect Return code is missing.
+String result code is not available in MQTT 3.1.1, corresponding fields of gRPC messages will not be set.
 
+SDK-based client does not provide OS specific error code or string, corresponding fields of gRPC messages will be not set.
+
+SDK-based client provides only session present flag of CONNACK packet. The Connect Return code of CONNACK is missing.
+
+Raal SUBACK information is not available from that client. Instead hard-coded Result Code 0 is used to create a response on gRPC request.
+
+Real PUBACK information is not available from that client. Instead hard-coded Result Code 0 is used to create a response on gRPC request.

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt311/client/sdkmqtt/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt311/client/sdkmqtt/Mqtt311ConnectionImpl.java
@@ -210,13 +210,12 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
         }
 
         final String filter = filters.get(0);
-
         CompletableFuture<Integer> unsubscribeFuture = connection.unsubscribe(filter);
         try {
             Integer packetId = unsubscribeFuture.get(timeout, TimeUnit.SECONDS);
             logger.atInfo().log("Unsubscribed on connection {} from topics filter {} packet Id {}", connectionId,
                                     filter, packetId);
-            return new UnsubAckInfo(Collections.singletonList(0), null);
+            return new UnsubAckInfo(Collections.singletonList(REASON_CODE_SUCCESS), null);
         } catch (InterruptedException ex) {
             Thread.currentThread().interrupt();
             logger.atError().withThrowable(ex).log(EXCEPTION_WHEN_UNSUBSCRIBING);

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt311/client/sdkmqtt/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt311/client/sdkmqtt/Mqtt311ConnectionImpl.java
@@ -14,9 +14,12 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.crt.mqtt.MqttClientConnection;
 import software.amazon.awssdk.crt.mqtt.MqttClientConnectionEvents;
+import software.amazon.awssdk.crt.mqtt.MqttMessage;
+import software.amazon.awssdk.crt.mqtt.QualityOfService;
 import software.amazon.awssdk.iot.AwsIotMqttConnectionBuilder;
 
 import java.io.UnsupportedEncodingException;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -31,6 +34,11 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
     private static final Logger logger = LogManager.getLogger(Mqtt311ConnectionImpl.class);
     private static final String EXCEPTION_WHEN_CONNECTING = "Exception occurred during connect";
     private static final String EXCEPTION_WHEN_DISCONNECTING = "Exception occurred during disconnect";
+    private static final String EXCEPTION_WHEN_PUBLISHING = "Exception occurred during publish";
+    private static final String EXCEPTION_WHEN_SUBSCRIBING = "Exception occurred during subscribe";
+    private static final String EXCEPTION_WHEN_UNSUBSCRIBING = "Exception occurred during unsubscribe";
+
+    private static final int REASON_CODE_SUCCESS = 0;
 
     private final AtomicBoolean isClosing = new AtomicBoolean();
     private final AtomicBoolean isConnected = new AtomicBoolean();
@@ -112,10 +120,10 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
     public void disconnect(long timeout, int reasonCode) throws MqttException {
 
         if (!isClosing.getAndSet(true)) {
-            CompletableFuture<Void> disconnected = connection.disconnect();
+            CompletableFuture<Void> disconnnectFuture = connection.disconnect();
             try {
-                disconnected.get(timeout, TimeUnit.SECONDS);
-            logger.atInfo().log("MQTT 3.1.1 connection {} has been closed", connectionId);
+                disconnnectFuture.get(timeout, TimeUnit.SECONDS);
+                logger.atInfo().log("MQTT 3.1.1 connection {} has been disconnected", connectionId);
             } catch (InterruptedException ex) {
                 Thread.currentThread().interrupt();
                 logger.atError().withThrowable(ex).log(EXCEPTION_WHEN_DISCONNECTING);
@@ -135,7 +143,24 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
 
         stateCheck();
 
-        return null;
+        final QualityOfService qos = QualityOfService.getEnumValueFromInteger(message.getQos());
+        final String topic = message.getTopic();
+        final MqttMessage msg = new MqttMessage(topic, message.getPayload(), qos, message.isRetain(), false);
+
+        CompletableFuture<Integer> pubishFuture = connection.publish(msg);
+        try {
+            Integer packetId = pubishFuture.get(timeout, TimeUnit.SECONDS);
+            logger.atInfo().log("Publish on connection {} to topic {} QoS {} packet Id {}",
+                                    connectionId, topic, qos, packetId);
+            return new PubAckInfo(REASON_CODE_SUCCESS, null);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            logger.atError().withThrowable(ex).log(EXCEPTION_WHEN_PUBLISHING);
+            throw new MqttException(EXCEPTION_WHEN_PUBLISHING, ex);
+        } catch (TimeoutException | ExecutionException ex) {
+            logger.atError().withThrowable(ex).log(EXCEPTION_WHEN_PUBLISHING);
+            throw new MqttException(EXCEPTION_WHEN_PUBLISHING, ex);
+        }
     }
 
     @Override
@@ -144,7 +169,33 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
 
         stateCheck();
 
-        return null;
+        if (subscriptionId != null) {
+            throw new IllegalArgumentException("MQTT v3.1.1 doesn't support subscription id");
+        }
+
+        if (subscriptions.size() != 1) {
+            throw new IllegalArgumentException("Iot device SDK MQTT v3.1.1 client does not support to subscribe on "
+                                            + "multiple filters at once");
+        }
+
+        Subscription subscription = subscriptions.get(0);
+        final String filter = subscription.getFilter();
+        final QualityOfService qos = QualityOfService.getEnumValueFromInteger(subscription.getQos());
+
+        CompletableFuture<Integer> subscribeFuture = connection.subscribe(filter, qos);
+        try {
+            Integer packetId = subscribeFuture.get(timeout, TimeUnit.SECONDS);
+            logger.atInfo().log("Subscribed on connection {} for topics filter {} QoS {} packet Id {}",
+                                    connectionId, filter, qos, packetId);
+            return new SubAckInfo(Collections.singletonList(REASON_CODE_SUCCESS), null);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            logger.atError().withThrowable(ex).log(EXCEPTION_WHEN_SUBSCRIBING);
+            throw new MqttException(EXCEPTION_WHEN_SUBSCRIBING, ex);
+        } catch (TimeoutException | ExecutionException ex) {
+            logger.atError().withThrowable(ex).log(EXCEPTION_WHEN_SUBSCRIBING);
+            throw new MqttException(EXCEPTION_WHEN_SUBSCRIBING, ex);
+        }
     }
 
     @Override
@@ -153,7 +204,28 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
 
         stateCheck();
 
-        return null;
+        if (filters.size() != 1) {
+            throw new IllegalArgumentException("Iot device SDK MQTT v3.1.1 client does not support to unsubscribe from "
+                                            + "multiple filters at once");
+        }
+
+        final String filter = filters.get(0);
+
+        CompletableFuture<Integer> unsubscribeFuture = connection.unsubscribe(filter);
+        try {
+            Integer packetId = unsubscribeFuture.get(timeout, TimeUnit.SECONDS);
+            logger.atInfo().log("Unsubscribed on connection {} from topics filter {} packet Id {}", connectionId,
+                                    filter, packetId);
+            return new UnsubAckInfo(Collections.singletonList(0), null);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            logger.atError().withThrowable(ex).log(EXCEPTION_WHEN_UNSUBSCRIBING);
+            throw new MqttException(EXCEPTION_WHEN_UNSUBSCRIBING, ex);
+        } catch (TimeoutException | ExecutionException ex) {
+            logger.atError().withThrowable(ex).log(EXCEPTION_WHEN_UNSUBSCRIBING);
+            throw new MqttException(EXCEPTION_WHEN_UNSUBSCRIBING, ex);
+        }
+
     }
 
     /**


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-100
Implement MQTT 3.1.1 subscribe

https://klika-tech.atlassian.net/browse/GGMQ-101
Implement MQTT 3.1.1 unsubscribe

https://klika-tech.atlassian.net/browse/GGMQ-102
Implement MQTT 3.1.1 publish


**Description of changes:**
- Added implementation of subscribe
- Added implementation of unsubscribe
- Added implementation of publish
- Updated README of client to describe limitations

**Why is this change necessary:**
To run scenarios also on MQTT v3.1.1 protocol.

**How was this change tested:**
At the moment manually, using control as a standalone program.

**Test logs:**

Control:
```
[INFO ] 2023-04-24 22:03:21.788 [main] EngineControlImpl - MQTT client control gRPC server started, listening on 47619
[INFO ] 2023-04-24 22:03:30.588 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId agent1
[INFO ] 2023-04-24 22:03:30.639 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId agent1 address 127.0.0.1 port 44345
[INFO ] 2023-04-24 22:03:30.642 [grpc-default-executor-0] EngineControlImpl - Created new agent control for agent1 on 127.0.0.1:44345
[INFO ] 2023-04-24 22:03:30.681 [grpc-default-executor-0] ExampleControl - Agent agent1 is connected
[INFO ] 2023-04-24 22:03:30.683 [pool-2-thread-1] AgentTestScenario - Playing test scenario for agent id agent1
[INFO ] 2023-04-24 22:03:34.598 [pool-2-thread-1] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
'
[INFO ] 2023-04-24 22:03:34.598 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-04-24 22:03:34.598 [pool-2-thread-1] AgentTestScenario - MQTT connection with id 1 is established
[INFO ] 2023-04-24 22:03:39.605 [pool-2-thread-1] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-04-24 22:03:39.680 [pool-2-thread-1] AgentTestScenario - Subscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-04-24 22:03:44.690 [pool-2-thread-1] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic test/topic
[INFO ] 2023-04-24 22:03:44.774 [pool-2-thread-1] AgentTestScenario - Published connectionId 1 reasonCode 0 reasonString 0
[INFO ] 2023-04-24 22:03:49.780 [pool-2-thread-1] AgentControlImpl - UnsubscribeMqtt: unsubscribe on connectionId 1
[INFO ] 2023-04-24 22:03:49.842 [pool-2-thread-1] AgentTestScenario - Unsubscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-04-24 22:04:04.857 [pool-2-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 1 closed
[INFO ] 2023-04-24 22:04:04.867 [pool-2-thread-1] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-04-24 22:04:04.879 [grpc-default-executor-0] GRPCDiscoveryServer - UnregisterAgent: agentId agent1 reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-04-24 22:04:04.882 [grpc-default-executor-0] ExampleControl - Agent agent1 is disconnected
```

Client:
```
[INFO ] 2023-04-24 22:03:30.606 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Client connection with Control is established, local address is 127.0.0.1
[INFO ] 2023-04-24 22:03:30.635 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - GRPCControlServer created and listed on 127.0.0.1:44345
[INFO ] 2023-04-24 22:03:30.686 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Handle gRPC requests
[INFO ] 2023-04-24 22:03:30.686 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - Server awaitTermination
[INFO ] 2023-04-24 22:03:33.766 [grpc-default-executor-0] GRPCControlServer - createMqttConnection: clientId GGMQ-test-device2 broker a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[INFO ] 2023-04-24 22:03:33.769 [grpc-default-executor-0] Mqtt311ConnectionImpl - Creating AwsIotMqttConnectionBuilder with TLS
[INFO ] 2023-04-24 22:03:34.510 [grpc-default-executor-0] Mqtt311ConnectionImpl - MQTT 3.1.1 connection 1 is establisted
[INFO ] 2023-04-24 22:03:39.614 [grpc-default-executor-0] GRPCControlServer - Subscription: filter test/topic QoS 0 noLocal false retainAsLocal false retainHandling 2
[INFO ] 2023-04-24 22:03:39.614 [grpc-default-executor-0] GRPCControlServer - Subscribe: connectionId 1 subscriptionId null for 1 filters
[INFO ] 2023-04-24 22:03:39.674 [grpc-default-executor-0] Mqtt311ConnectionImpl - Subscribed on connection 1 for topics filter test/topic QoS AT_MOST_ONCE packet Id 1
[INFO ] 2023-04-24 22:03:39.674 [grpc-default-executor-0] GRPCControlServer - Subscribe response: connectionId 1 reason codes [0] reason string null
[INFO ] 2023-04-24 22:03:44.712 [grpc-default-executor-0] GRPCControlServer - Publish: connectionId 1 topic test/topic QoS 1 retain false
[INFO ] 2023-04-24 22:03:44.765 [grpc-default-executor-0] Mqtt311ConnectionImpl - Publish on connection 1 to topic test/topic QoS AT_LEAST_ONCE packet Id 2
[INFO ] 2023-04-24 22:03:44.766 [grpc-default-executor-0] GRPCControlServer - Publish response: connectionId 1 reason code 0 reason string null
[INFO ] 2023-04-24 22:03:49.784 [grpc-default-executor-0] GRPCControlServer - Unsubscribe: connectionId 1 for [test/topic] filters
[INFO ] 2023-04-24 22:03:49.835 [grpc-default-executor-0] Mqtt311ConnectionImpl - Unsubscribed on connection 1 from topics filter test/topic packet Id 3
[INFO ] 2023-04-24 22:03:49.836 [grpc-default-executor-0] GRPCControlServer - Unsubscribe response: connectionId 1 reason codes [0] reason string null
[INFO ] 2023-04-24 22:04:04.853 [grpc-default-executor-0] GRPCControlServer - closeMqttConnection: connectionId 1 reason 4
[INFO ] 2023-04-24 22:04:04.853 [grpc-default-executor-0] Mqtt311ConnectionImpl - MQTT 3.1.1 connection 1 has been disconnected
[INFO ] 2023-04-24 22:04:04.853 [Thread-2] Mqtt311ConnectionImpl - MQTT connection 1 interrupted, error code 0
[INFO ] 2023-04-24 22:04:04.863 [grpc-default-executor-0] GRPCControlServer - shutdownAgent: reason That's it.
[INFO ] 2023-04-24 22:04:04.874 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - Server awaitTermination done
[INFO ] 2023-04-24 22:04:04.874 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Shutdown gPRC link
[INFO ] 2023-04-24 22:04:04.885 [com.aws.greengrass.testing.mqtt5.client.Main.main()] Main - Execution done successfully
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
