### PR TITLE
feat(uat): added configure iot core broker step

### DIFF
--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -618,7 +618,7 @@ public class MqttControlSteps {
                     ci.getHostAddress(),
                     ci.getPortNumber(),
                     group.getCAs()))
-                 .collect(Collectors.toCollection(()-> bc));
+                 .collect(Collectors.toCollection(() -> bc));
         });
 
         brokers.put(brokerId, bc);


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-94

**Description of changes:**
- refactor broker connectivity info storage
- added create IoT core step

**Why is this change necessary:**
- required step for several test features

**Log results:**
```
[INFO ] 2023-04-26 17:33:21.570 [main] MqttControlSteps - Connection with broker iot_core_broker established to address a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:443 as Thing gg-3f0b962c546b494c371c-clientDeviceTest on aws.greengrass.client.Mqtt5JavaSdkClient
[INFO ] 2023-04-26 17:33:21.570 [main] feature - Finished step: 'I connect device "clientDeviceTest" on aws.greengrass.client.Mqtt5JavaSdkClient to "iot_core_broker"' with status PASSED

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
