### PR TITLE
feat(uat): implement ggad t14

### DIFF
--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -618,7 +618,7 @@ public class MqttControlSteps {
                     ci.getHostAddress(),
                     ci.getPortNumber(),
                     group.getCAs()))
-                 .collect(Collectors.toCollection(()-> bc));
+                 .collect(Collectors.toCollection(() -> bc));
         });
 
         brokers.put(brokerId, bc);

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -327,7 +327,7 @@ public class MqttControlSteps {
      * @throws IllegalArgumentException on invalid QoS argument
      */
     @When("I subscribe {string} to {string} with qos {int}")
-    public void subscribe(String clientDeviceId, String topicFilterString, int qos) {
+    public void subscribe(@NonNull String clientDeviceId, @NonNull String topicFilterString, int qos) {
         // getting connectionControl by clientDeviceId
         final String clientDeviceThingName = getClientDeviceThingName(clientDeviceId);
         ConnectionControl connectionControl = getConnectionControl(clientDeviceThingName);

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -547,7 +547,7 @@ public class MqttControlSteps {
 
         final int boundPort = engineControl.getBoundPort();
         String[] addresses = engineControl.getIPs();
-        log.info("MQTT clients control started gRPC service on port {} adrresses {}", boundPort, addresses);
+        log.info("MQTT clients control started gRPC service on port {} addresses {}", boundPort, addresses);
 
         if (addresses == null || addresses.length == 0) {
             addresses = new String[] { DEFAULT_CONTROL_GRPC_IP };

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -61,3 +61,101 @@ Feature: GGMQ-1
     When I subscribe "clientDeviceTest" to "iot_data_0" with qos 0
     When I publish from "clientDeviceTest" to "iot_data_0" with qos 0 and message "Test message"
     And message "Test message" received on "clientDeviceTest" from "iot_data_0" topic within 5 seconds
+
+  Scenario: GGMQ-1-T14: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic
+    When I create a Greengrass deployment with components
+      | aws.greengrass.clientdevices.Auth        | LATEST                                                        |
+      | aws.greengrass.clientdevices.mqtt.EMQX   | LATEST                                                        |
+      | aws.greengrass.clientdevices.IPDetector  | LATEST                                                        |
+      | aws.greengrass.clientdevices.mqtt.Bridge | LATEST                                                        |
+      | aws.greengrass.client.Mqtt5JavaSdkClient | classpath:/greengrass/components/recipes/client_java_sdk.yaml |
+    And I create client device "localMqttSubscriber"
+    And I create client device "iotCorePublisher"
+    When I associate "localMqttSubscriber" with ggc
+    And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:
+    """
+{
+   "MERGE":{
+      "deviceGroups":{
+         "formatVersion":"2021-03-05",
+         "definitions":{
+            "MyPermissiveDeviceGroup":{
+               "selectionRule": "thingName: ${localMqttSubscriber}",
+               "policyName":"MyPermissivePolicy"
+            }
+         },
+         "policies":{
+            "MyPermissivePolicy":{
+               "AllowAll":{
+                  "statementDescription":"Allow client devices to perform all actions.",
+                  "operations":[
+                     "*"
+                  ],
+                  "resources":[
+                     "*"
+                  ]
+               }
+            }
+         }
+      }
+   }
+}
+    """
+    And I update my Greengrass deployment configuration, setting the component aws.greengrass.client.Mqtt5JavaSdkClient configuration to:
+    """
+{
+   "MERGE":{
+      "agentId":"aws.greengrass.client.Mqtt5JavaSdkClient",
+      "controlAddresses":"${mqttControlAddresses}",
+      "controlPort":"${mqttControlPort}"
+   }
+}
+    """
+    And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.mqtt.Bridge configuration to:
+    """
+{
+  "MERGE": {
+      "mqttTopicMapping": {
+          "mapping1:": {
+              "topic": "${localMqttSubscriber}topic/to/localmqtt",
+              "source": "IotCore",
+              "target": "LocalMqtt"
+          },
+          "mapping2:": {
+              "topic": "${localMqttSubscriber}topic/+/humidity",
+              "source": "IotCore",
+              "target": "LocalMqtt"
+          },
+          "mapping3:": {
+              "topic": "${localMqttSubscriber}topic/device2/#",
+              "source": "IotCore",
+              "target": "LocalMqtt"
+          },
+          "mapping4:": {
+              "topic": "${localMqttSubscriber}topic/with/prefix",
+              "source": "IotCore",
+              "target": "LocalMqtt",
+              "targetTopicPrefix": "prefix/"
+          }
+      }
+  }
+}
+    """
+    And I deploy the Greengrass deployment configuration
+    Then the Greengrass deployment is COMPLETED on the device after 300 seconds
+    When I discover core device broker as "localBroker" from "localMqttSubscriber"
+    And I label IoT core broker as "iotCoreBroker"
+    And I connect device "localMqttSubscriber" on aws.greengrass.client.Mqtt5JavaSdkClient to "localBroker"
+    And I connect device "iotCorePublisher" on aws.greengrass.client.Mqtt5JavaSdkClient to "iotCoreBroker"
+    And I subscribe "localMqttSubscriber" to "${localMqttSubscriber}topic/to/localmqtt" with qos 1
+    And I subscribe "localMqttSubscriber" to "${localMqttSubscriber}topic/device2/#" with qos 1
+    And I subscribe "localMqttSubscriber" to "${localMqttSubscriber}topic/+/humidity" with qos 1
+    And I subscribe "localMqttSubscriber" to "prefix/${localMqttSubscriber}topic/with/prefix" with qos 1
+    When I publish from "iotCorePublisher" to "${localMqttSubscriber}topic/to/localmqtt" with qos 1 and message "Hello world"
+    Then message "Hello world" received on "localMqttSubscriber" from "${localMqttSubscriber}topic/to/localmqtt" topic within 10 seconds
+    When I publish from "iotCorePublisher" to "${localMqttSubscriber}topic/device1/humidity" with qos 1 and message "H=10%"
+    Then message "H=10%" received on "localMqttSubscriber" from "${localMqttSubscriber}topic/device1/humidity" topic within 10 seconds
+    When I publish from "iotCorePublisher" to "${localMqttSubscriber}topic/device2/temperature" with qos 1 and message "T=100C"
+    Then message "T=100C" received on "localMqttSubscriber" from "${localMqttSubscriber}topic/device2/temperature" topic within 10 seconds
+    When I publish from "iotCorePublisher" to "${localMqttSubscriber}topic/with/prefix" with qos 1 and message "Hello world"
+    Then message "Hello world" received on "localMqttSubscriber" from "prefix/${localMqttSubscriber}topic/with/prefix" topic within 10 seconds


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-97

**Description of changes:**
- added GGAD-1-T14 scenario using OTF and new building blocks

**Why is this change necessary:**
- to test bridge functionality

**Test results:**

```
Given my device is registered as a Thing....................................passed
And my device is running Greengrass.........................................passed
When I create a Greengrass deployment with components.......................passed
And I create client device "localMqttSubscriber"............................passed
And I create client device "iotCorePublisher"...............................passed
When I associate "localMqttSubscriber" with ggc.............................passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:.passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.client.Mqtt5JavaSdkClient configuration to:.passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.mqtt.Bridge configuration to:.passed
And I deploy the Greengrass deployment configuration........................passed
Then the Greengrass deployment is COMPLETED on the device after 300 seconds.passed
When I discover core device broker as "localBroker" from "localMqttSubscriber".passed
And I label IoT core broker as "iotCoreBroker"..............................passed
And I connect device "localMqttSubscriber" on aws.greengrass.client.Mqtt5JavaSdkClient to "localBroker".passed
And I connect device "iotCorePublisher" on aws.greengrass.client.Mqtt5JavaSdkClient to "iotCoreBroker".passed
And I subscribe "localMqttSubscriber" to "${localMqttSubscriber}topic/to/localmqtt" with qos 1.passed
And I subscribe "localMqttSubscriber" to "${localMqttSubscriber}topic/device2/#" with qos 1.passed
And I subscribe "localMqttSubscriber" to "${localMqttSubscriber}topic/+/humidity" with qos 1.passed
And I subscribe "localMqttSubscriber" to "prefix/${localMqttSubscriber}topic/with/prefix" with qos 1.passed
When I publish from "iotCorePublisher" to "${localMqttSubscriber}topic/to/localmqtt" with qos 1 and message "Hello world".passed
Then message "Hello world" received on "localMqttSubscriber" from "${localMqttSubscriber}topic/to/localmqtt" topic within 10 seconds.passed
When I publish from "iotCorePublisher" to "${localMqttSubscriber}topic/device1/humidity" with qos 1 and message "H=10%".passed
Then message "H=10%" received on "localMqttSubscriber" from "${localMqttSubscriber}topic/device1/humidity" topic within 10 seconds.passed
When I publish from "iotCorePublisher" to "${localMqttSubscriber}topic/device2/temperature" with qos 1 and message "T=100C".passed
Then message "T=100C" received on "localMqttSubscriber" from "${localMqttSubscriber}topic/device2/temperature" topic within 10 seconds.passed
When I publish from "iotCorePublisher" to "${localMqttSubscriber}topic/with/prefix" with qos 1 and message "Hello world".passed
Then message "Hello world" received on "localMqttSubscriber" from "prefix/${localMqttSubscriber}topic/with/prefix" topic within 10 seconds.passed
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
