### PR TITLE
fix(uat): rename MQTT versions enum in protocol due to conflict with mosquitto

### DIFF
--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
@@ -17,7 +17,7 @@ import java.util.List;
  * Interface of MQTT5 connection.
  */
 public interface MqttConnection {
-    int DEFAULT_DISCONNECT_REASON = 4;
+    int DEFAULT_DISCONNECT_REASON = 0;       // MQTT_RC_NORMAL_DISCONNECTION
     long DEFAULT_DISCONNECT_TIMEOUT = 10;
     long MIN_SHUTDOWN_NS = 200_000_000;      // 200ms
 

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
@@ -145,14 +145,14 @@ class GRPCControlServer {
             }
 
             MqttProtoVersion version = request.getProtocolVersion();
-            if (version != MqttProtoVersion.MQTT_PROTOCOL_V311 && version != MqttProtoVersion.MQTT_PROTOCOL_V50) {
+            if (version != MqttProtoVersion.MQTT_PROTOCOL_V_311 && version != MqttProtoVersion.MQTT_PROTOCOL_V_50) {
                 logger.atWarn().log("invalid protocolVersion {}, {} and {} are only supported",
                                         version,
-                                        MqttProtoVersion.MQTT_PROTOCOL_V311,
-                                        MqttProtoVersion.MQTT_PROTOCOL_V50);
+                                        MqttProtoVersion.MQTT_PROTOCOL_V_311,
+                                        MqttProtoVersion.MQTT_PROTOCOL_V_50);
                 responseObserver.onError(Status.INVALID_ARGUMENT
                                 .withDescription("invalid protocolVersion, only "
-                                                    + "MQTT_PROTOCOL_V311 and MQTT_PROTOCOL_V50 are supported")
+                                                    + "MQTT_PROTOCOL_V_311 and MQTT_PROTOCOL_V_50 are supported")
                                 .asRuntimeException());
                 return;
             }
@@ -183,7 +183,7 @@ class GRPCControlServer {
                             .port(port)
                             .keepalive(keepalive)
                             .cleanSession(request.getCleanSession())
-                            .mqtt50(version == MqttProtoVersion.MQTT_PROTOCOL_V50);
+                            .mqtt50(version == MqttProtoVersion.MQTT_PROTOCOL_V_50);
 
             // check TLS optional settings
             if (request.hasTls()) {
@@ -451,11 +451,11 @@ class GRPCControlServer {
                 }
 
                 boolean noLocal = subscription.getNoLocal();
-                boolean retainAsLocal = subscription.getRetainAsPublished();
-                MqttConnection.Subscription tmp = new MqttConnection.Subscription(filter, qos, noLocal, retainAsLocal,
-                                                                                    retainHandling);
-                logger.atInfo().log("Subscription: filter {} QoS {} noLocal {} retainAsLocal {} retainHandling {}",
-                                        filter, qos, noLocal, retainAsLocal, retainHandling);
+                boolean retainAsPublished = subscription.getRetainAsPublished();
+                MqttConnection.Subscription tmp = new MqttConnection.Subscription(filter, qos, noLocal,
+                                                                                    retainAsPublished, retainHandling);
+                logger.atInfo().log("Subscription: filter {} QoS {} noLocal {} retainAsPublished {} retainHandling {}",
+                                        filter, qos, noLocal, retainAsPublished, retainHandling);
                 outSubscriptions.add(tmp);
                 index++;
             }

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
@@ -178,8 +178,8 @@ class AgentTestScenario implements Runnable {
                     .setKeepalive(KEEP_ALIVE)
                     .setCleanSession(CLEAN_SESSION)
                     .setTimeout(CONNECT_TIMEOUT)
-                    .setProtocolVersion(mqtt50  ? MqttProtoVersion.MQTT_PROTOCOL_V50
-                                                : MqttProtoVersion.MQTT_PROTOCOL_V311);
+                    .setProtocolVersion(mqtt50  ? MqttProtoVersion.MQTT_PROTOCOL_V_50
+                                                : MqttProtoVersion.MQTT_PROTOCOL_V_311);
 
         if (useTLS) {
             TLSSettings tlsSettings = TLSSettings.newBuilder().addCaList(ca).setCert(cert).setKey(key).build();

--- a/uat/proto/mqtt_client_control.proto
+++ b/uat/proto/mqtt_client_control.proto
@@ -135,10 +135,10 @@ service MqttClientControl {
 
 // Versions of MQTT protocol, used for compatibility, only MQTT_PROTOCOL_V50 actually supported
 enum MqttProtoVersion {
-    MQTT_PROTOCOL_V0    = 0;
-    MQTT_PROTOCOL_V31   = 3;            // unsupported
-    MQTT_PROTOCOL_V311  = 4;            // supported
-    MQTT_PROTOCOL_V50   = 5;            // supported
+    MQTT_PROTOCOL_V_0    = 0;
+    MQTT_PROTOCOL_V_31   = 3;           // unsupported
+    MQTT_PROTOCOL_V_311  = 4;           // supported
+    MQTT_PROTOCOL_V_50   = 5;           // supported
 };
 
 // MQTT QoS values
@@ -245,9 +245,9 @@ message MqttSubscribeRequest {
 
 // Response to subscribe request
 message MqttSubscribeReply {
-    repeated int32 reasonCodes = 1;                     // MQTT v5.0 SUBBACK reason codes
+    repeated int32 reasonCodes = 1;                     // MQTT v5.0 SUBACK reason codes
     optional string reasonString = 2;                   // MQTT v5.0 SUBACK  reason string
-    optional Mqtt5Properties properties = 3;            // MQTT v5.0 SUBBACK user's properties
+    optional Mqtt5Properties properties = 3;            // MQTT v5.0 SUBACK user's properties
 }
 
 // Request to unsubscribe from MQTT topic(s)

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -302,7 +302,7 @@ public class MqttControlSteps {
         final String clientDeviceThingName = getClientDeviceThingName(clientDeviceId);
         ConnectionControl connectionControl = getConnectionControl(clientDeviceThingName);
 
-        //do disconnect
+        // do disconnect
         connectionControl.closeMqttConnection(reasonCode);
         log.info("Thing {} was disconnected with reason code {}", clientDeviceId, reasonCode);
     }
@@ -719,8 +719,8 @@ public class MqttControlSteps {
     }
 
     private void initMqttVersions() {
-        mqttVersions.put(MQTT_VERSION_311, MqttProtoVersion.MQTT_PROTOCOL_V311);
-        mqttVersions.put(MQTT_VERSION_50, MqttProtoVersion.MQTT_PROTOCOL_V50);
+        mqttVersions.put(MQTT_VERSION_311, MqttProtoVersion.MQTT_PROTOCOL_V_311);
+        mqttVersions.put(MQTT_VERSION_50, MqttProtoVersion.MQTT_PROTOCOL_V_50);
     }
 
     private MqttProtoVersion convertMqttVersion(String mqttVersion) {


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-111
Provide CONNACK info Mosquitto client

**Description of changes:**
- Rename MQTT version enum members in protocol
- Change default disconnect reason to 0 (normal disconnect) from 4 (will should be sent).
- Fix typos

**Why is this change necessary:**
When C++ code of protocol is generated we got an conflict of MQTT version names with defines in mosquitto.h
In results in mosquitto.h and protocol headers can't be included in the same source file.

**How was this change tested:**
CI

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
