### PR TITLE
fix(uat): exclude all generated-sources from PMD checks

### DIFF
--- a/uat/custom-components/client-ipc/pom.xml
+++ b/uat/custom-components/client-ipc/pom.xml
@@ -125,7 +125,7 @@
                         <exclude>**/generated/*.java</exclude>
                     </excludes>
                     <excludeRoots>
-                        <excludeRoot>target/generated-sources/protobuf</excludeRoot>
+                        <excludeRoot>target/generated-sources</excludeRoot>
                     </excludeRoots>
                 </configuration>
                 <executions>

--- a/uat/custom-components/client-java-sdk/pom.xml
+++ b/uat/custom-components/client-java-sdk/pom.xml
@@ -267,7 +267,7 @@
                         <exclude>**/generated/*.java</exclude>
                     </excludes>
                     <excludeRoots>
-                        <excludeRoot>target/generated-sources/protobuf</excludeRoot>
+                        <excludeRoot>target/generated-sources</excludeRoot>
                     </excludeRoots>
                 </configuration>
                 <executions>

--- a/uat/mqtt-client-control/pom.xml
+++ b/uat/mqtt-client-control/pom.xml
@@ -256,7 +256,7 @@
                         <exclude>**/generated/*.java</exclude>
                     </excludes>
                     <excludeRoots>
-                        <excludeRoot>target/generated-sources/protobuf</excludeRoot>
+                        <excludeRoot>target/generated-sources</excludeRoot>
                     </excludeRoots>
                 </configuration>
                 <executions>


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-226
Building project on Windows failed with PMD failures

**Description of changes:**
- Exclude whole generated-sources from PMD checks for 3 subprojects

**Why is this change necessary:**
Build on Windows 11 failed

**How was this change tested:**
Manually and build on CI.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
