### PR TITLE
feat(uat): add mosquitto client to T101 scenarios

### DIFF
--- a/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
@@ -370,6 +370,7 @@ Status GRPCControlServer::SubscribeMqtt(ServerContext *, const MqttSubscribeRequ
     try {
         std::vector<int> reason_codes = connection->subscribe(timeout, subscription_id_ptr, filters, common_qos, common_retain_handling, common_no_local, common_retain_as_published);
         for (int reason_code : reason_codes) {
+            logd("subscribe reason code %d\n", reason_code);
             reply->add_reasoncodes(reason_code);
         }
 

--- a/uat/custom-components/client-mosquitto-c/src/MqttConnection.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/MqttConnection.cpp
@@ -52,6 +52,7 @@ public:
         : rc(MOSQ_ERR_SUCCESS), flags(0), props(0), mid(mid_), granted_qos(granted_qos_, granted_qos_ + qos_count_) {
         mosquitto_property_copy_all(&props, props_);
     }
+
     AsyncResult(const AsyncResult &) = delete;
     AsyncResult & operator=(const AsyncResult &) = delete;
 

--- a/uat/custom-components/client-mosquitto-c/src/MqttConnection.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/MqttConnection.cpp
@@ -347,7 +347,7 @@ std::vector<int> MqttConnection::subscribe(unsigned timeout, const int * subscri
     {
         std::ostringstream imploded;
         std::copy(filters.begin(), filters.end(), std::ostream_iterator<std::string>(imploded, " "));
-        logd("Subscribed on '%s' filters QoS %d message id %d\n", imploded.str().c_str(), qos, message_id);
+        logd("Subscribed on filters '%s' QoS %d no local %d retain as published %d retain handing %d with message id %d\n", imploded.str().c_str(), qos, no_local, retain_as_published, retain_handling, message_id);
     }
 
     mosquitto_property_free_all(&properties);
@@ -409,7 +409,7 @@ std::vector<int> MqttConnection::unsubscribe(unsigned timeout, const std::vector
     {
         std::ostringstream imploded;
         std::copy(filters.begin(), filters.end(), std::ostream_iterator<std::string>(imploded, " "));
-        logd("Unsubscribed from '%s' filters message id %d\n", imploded.str().c_str(), message_id);
+        logd("Unsubscribed from filters '%s' with message id %d\n", imploded.str().c_str(), message_id);
     }
 
     // NOTE: mosquitto does not provides result code(s) from unsubscribe; produce vector of successes
@@ -453,7 +453,7 @@ ClientControl::MqttPublishReply * MqttConnection::publish(unsigned timeout, int 
     std::shared_ptr<AsyncResult> result = request->waitForResult(timeout);
     removePendingRequestUnlocked(message_id);
 
-    logd("Published to '%s' QoS %d  id %d\n", topic.c_str(), qos, message_id);
+    logd("Published on topic '%s' QoS %d retain %d with message id %d\n", topic.c_str(), qos, is_retain, message_id);
     return convertToPublishReply(result->rc, result->props);
 }
 

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/AgentControl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/AgentControl.java
@@ -56,8 +56,10 @@ public interface AgentControl {
 
     /**
      * Stops the agent control.
+     *
+     * @param sendShutdown when set shutdown request will be sent to agent and all MQTT connection are closed
      */
-    void stopAgent();
+    void stopAgent(boolean sendShutdown);
 
     /**
      * Gets id of the agent.

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/AgentControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/AgentControlImpl.java
@@ -138,9 +138,11 @@ public class AgentControlImpl implements AgentControl {
     }
 
     @Override
-    public void stopAgent() {
-        closeAllMqttConnections();
-        disconnect();
+    public void stopAgent(boolean sendShutdown) {
+        if (sendShutdown) {
+            closeAllMqttConnections();
+        }
+        disconnect(sendShutdown);
     }
 
     @Override
@@ -311,14 +313,14 @@ public class AgentControlImpl implements AgentControl {
         });
     }
 
-    private void disconnect() {
+    private void disconnect(boolean sendShutdown) {
         if (!isDisconnected.getAndSet(true)) {
-            if (!isShutdownSent.getAndSet(true)) {
+            if (sendShutdown && !isShutdownSent.getAndSet(true)) {
                 shutdownAgent("none");
             }
             channel.shutdown();
             try {
-                channel.awaitTermination(1, TimeUnit.SECONDS);
+                channel.awaitTermination(10, TimeUnit.SECONDS);
             } catch (InterruptedException ex) {
                 Thread.currentThread().interrupt();
             }

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
@@ -187,7 +187,7 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
     public void onUnregisterAgent(@NonNull String agentId) {
         AgentControlImpl agentControl = agents.remove(agentId);
         if (agentControl != null) {
-            agentControl.stopAgent();
+            agentControl.stopAgent(false);
             if (engineEvents != null) {
                 engineEvents.onAgentDeattached(agentControl);
             }
@@ -218,7 +218,7 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
     private void unregisterAllAgent() {
         agents.forEach((agentId, agentControl) -> {
             if (agents.remove(agentId, agentControl)) {
-                agentControl.stopAgent();
+                agentControl.stopAgent(true);
                 if (engineEvents != null) {
                     engineEvents.onAgentDeattached(agentControl);
                 }

--- a/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/AgentControlImplTest.java
+++ b/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/AgentControlImplTest.java
@@ -65,7 +65,7 @@ class AgentControlImplTest {
 
     @AfterEach
     void teardown() {
-        agentControl.stopAgent();
+        agentControl.stopAgent(false);
     }
 
     @Test

--- a/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImplTest.java
+++ b/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImplTest.java
@@ -267,7 +267,7 @@ class EngineControlImplTest {
 
         // THEN
         assertNull(engineControl.getAgent(agentId));
-        verify(agentControl, times(1)).stopAgent();
+        verify(agentControl, times(1)).stopAgent(false);
         verify(engineEvents).onAgentDeattached(eq(agentControl));
     }
 

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -532,7 +532,7 @@ Feature: GGMQ-1
 
 
   @GGMQ-1-T101
-  Scenario Outline: GGMQ-1-T101-<mqtt-v>-<name>: As a customer, I can configure retain flag and retain handling
+  Scenario Outline: GGMQ-1-T101-<mqtt-v>-<name>: As a customer, I can use publish retain flag and subscribe retain handling as expected
     When I create a Greengrass deployment with components
       | aws.greengrass.clientdevices.Auth       | LATEST                                            |
       | aws.greengrass.clientdevices.mqtt.EMQX  | LATEST                                            |
@@ -623,20 +623,30 @@ Feature: GGMQ-1
 
     @mqtt3 @sdk-java
     Examples:
-      | mqtt-v | name     | agent                                      | recipe               | retainHandling-2  |
-      | v3     | sdk-java | aws.greengrass.client.Mqtt5JavaSdkClient   | client_java_sdk.yaml | true              |
+      | mqtt-v | name        | agent                                     | recipe                  | retainHandling-2 |
+      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    | true             |
 
     @mqtt3 @paho-java
     Examples:
-      | mqtt-v | name      | agent                                     | recipe                | retainHandling-2 |
-      | v3     | paho-java | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml | true             |
+      | mqtt-v | name        | agent                                     | recipe                  | retainHandling-2 |
+      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   | true             |
+
+    @mqtt3 @mosquitto-c
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  | retainHandling-2 |
+      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | true             |
 
     @mqtt5 @sdk-java
     Examples:
-      | mqtt-v | name     | agent                                      | recipe               | retainHandling-2  |
-      | v5     | sdk-java | aws.greengrass.client.Mqtt5JavaSdkClient   | client_java_sdk.yaml | false             |
+      | mqtt-v | name        | agent                                     | recipe                  | retainHandling-2 |
+      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    | false            |
 
     @mqtt5 @paho-java
     Examples:
-      | mqtt-v | name      | agent                                     | recipe                | retainHandling-2 |
-      | v5     | paho-java | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml | false            |
+      | mqtt-v | name        | agent                                     | recipe                  | retainHandling-2 |
+      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   | false            |
+
+    @mqtt5 @mosquitto-c
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  | retainHandling-2 |
+      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | false            |

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -58,7 +58,7 @@ Feature: GGMQ-1
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 300 seconds
 
-    And I discover core device broker as "default_broker" from "clientDeviceTest"
+    And I discover core device broker as "default_broker" from "clientDeviceTest" in OTF
     And I connect device "clientDeviceTest" on <agent> to "default_broker" using mqtt "<mqtt-v>"
 
     When I subscribe "clientDeviceTest" to "iot_data_0" with qos 0 and expect status "GRANTED_QOS_0"
@@ -193,17 +193,25 @@ Feature: GGMQ-1
     """
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 300 seconds
-    Then I discover core device broker as "localMqttBroker" from "publisher" in OTF
-    And I connect device "publisher" on <agent> to "localMqttBroker" using mqtt "<mqtt-v>"
+    Then I discover core device broker as "default_broker" from "publisher" in OTF
+
+    And I connect device "publisher" on <agent> to "default_broker" using mqtt "<mqtt-v>"
     And I wait 5 seconds
+
     When I publish from "publisher" to "topic/to/pubsub" with qos 1 and message "Hello world"
-    When I publish from "publisher" to "topic/device1/humidity" with qos 1 and message "device1 humidity"
-    When I publish from "publisher" to "topic/device2/temperature" with qos 1 and message "device2 temperature"
-    When I publish from "publisher" to "topic/with/prefix" with qos 1 and message "topicPrefix message"
     Then I wait 5 seconds
     And I get 1 assertions with context "ReceivedPubsubMessage" and message "Hello world"
+
+    When I publish from "publisher" to "topic/device1/humidity" with qos 1 and message "device1 humidity"
+    Then I wait 5 seconds
     And I get 1 assertions with context "ReceivedPubsubMessage" and message "device1 humidity"
+
+    When I publish from "publisher" to "topic/device2/temperature" with qos 1 and message "device2 temperature"
+    Then I wait 5 seconds
     And I get 1 assertions with context "ReceivedPubsubMessage" and message "device2 temperature"
+
+    When I publish from "publisher" to "topic/with/prefix" with qos 1 and message "topicPrefix message"
+    Then I wait 5 seconds
     And I get 1 assertions with context "ReceivedPubsubMessage" and message "topicPrefix message"
 
     @mqtt3 @sdk-java


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-184
Setup retained message control

**Description of changes:**
- Extend TR101 scenario outline to run with mosquitto client
- Tune logging in mosquitto client to show retain options
- Disable sending request to agent from UnregisterAgent handler of control

**Why is this change necessary:**
Test retain control features with mosquitto client

**How was this change tested:**
Code Build can run scenarios and we did similar manually

**Test results:**
```
[INFO ] 2023-06-07 20:28:23.926 [main] StepTrackingReporting - Passed: 'GGMQ-1-T1-v3-sdk-java: As a customer, I can connect, subscribe/publish at QoS 0 and 1 and receive using client application to MQTT topic'
[ERROR] 2023-06-07 20:28:23.926 [main] StepTrackingReporting - Failed: 'GGMQ-1-T1-v3-mosquitto-c: As a customer, I can connect, subscribe/publish at QoS 0 and 1 and receive using client application to MQTT topic
[INFO ] 2023-06-07 20:28:23.927 [main] StepTrackingReporting - Passed: 'GGMQ-1-T1-v5-sdk-java: As a customer, I can connect, subscribe/publish at QoS 0 and 1 and receive using client application to MQTT topic'
[ERROR] 2023-06-07 20:28:23.927 [main] StepTrackingReporting - Failed: 'GGMQ-1-T1-v5-mosquitto-c: As a customer, I can connect, subscribe/publish at QoS 0 and 1 and receive using client application to MQTT topic
[INFO ] 2023-06-07 20:28:23.927 [main] StepTrackingReporting - Passed: 'GGMQ-1-T8-v3-sdk-java: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic'
[ERROR] 2023-06-07 20:28:23.927 [main] StepTrackingReporting - Failed: 'GGMQ-1-T8-v3-mosquitto-c: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic': Failed at 'I get 1 asserti
[INFO ] 2023-06-07 20:28:23.927 [main] StepTrackingReporting - Passed: 'GGMQ-1-T8-v5-sdk-java: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic'
[INFO ] 2023-06-07 20:28:23.927 [main] StepTrackingReporting - Passed: 'GGMQ-1-T8-v5-mosquitto-c: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic'
[INFO ] 2023-06-07 20:28:23.927 [main] StepTrackingReporting - Passed: 'GGMQ-1-T13-v3: As a customer, I can connect two GGADs and send message from one GGAD to the other based on CDA configuration'
[INFO ] 2023-06-07 20:28:23.927 [main] StepTrackingReporting - Passed: 'GGMQ-1-T13-v5: As a customer, I can connect two GGADs and send message from one GGAD to the other based on CDA configuration'
[ERROR] 2023-06-07 20:28:23.927 [main] StepTrackingReporting - Failed: 'GGMQ-1-T14-v3-sdk-java: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic': Failed at 'I connect device
[ERROR] 2023-06-07 20:28:23.927 [main] StepTrackingReporting - Failed: 'GGMQ-1-T14-v3-mosquitto-c: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic': Failed at 'message "Hello
[ERROR] 2023-06-07 20:28:23.927 [main] StepTrackingReporting - Failed: 'GGMQ-1-T14-v5-sdk-java: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic': Failed at 'the Greengrass de
[INFO ] 2023-06-07 20:28:23.927 [main] StepTrackingReporting - Passed: 'GGMQ-1-T14-v5-mosquitto-c: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic'
[INFO ] 2023-06-07 20:28:23.927 [main] StepTrackingReporting - Passed: 'GGMQ-1-T101-v3-sdk-java: As a customer, I can use publish retain flag and subscribe retain handling as expected'
[INFO ] 2023-06-07 20:28:23.927 [main] StepTrackingReporting - Passed: 'GGMQ-1-T101-v3-paho-java: As a customer, I can use publish retain flag and subscribe retain handling as expected'
[INFO ] 2023-06-07 20:28:23.927 [main] StepTrackingReporting - Passed: 'GGMQ-1-T101-v3-mosquitto-c: As a customer, I can use publish retain flag and subscribe retain handling as expected'
[INFO ] 2023-06-07 20:28:23.927 [main] StepTrackingReporting - Passed: 'GGMQ-1-T101-v5-sdk-java: As a customer, I can use publish retain flag and subscribe retain handling as expected'
[INFO ] 2023-06-07 20:28:23.927 [main] StepTrackingReporting - Passed: 'GGMQ-1-T101-v5-paho-java: As a customer, I can use publish retain flag and subscribe retain handling as expected'
[INFO ] 2023-06-07 20:28:23.927 [main] StepTrackingReporting - Passed: 'GGMQ-1-T101-v5-mosquitto-c: As a customer, I can use publish retain flag and subscribe retain handling as expected'

```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
