### PR TITLE
feat(uat): handle user properties in mosquitto client

### DIFF
--- a/.license/style.xml
+++ b/.license/style.xml
@@ -16,7 +16,7 @@
         <isMultiline>true</isMultiline>
         <padLines>false</padLines>
     </java_style>
-    <batch>
+    <batch_style>
         <firstLine>@REM -------------------------------</firstLine>
         <beforeEachLine>@REM </beforeEachLine>
         <endLine>@REM -------------------------------</endLine>
@@ -25,8 +25,8 @@
         <allowBlankLines>false</allowBlankLines>
         <isMultiline>true</isMultiline>
         <padLines>false</padLines>
-    </batch>
-    <shell>
+    </batch_style>
+    <shell_style>
         <firstLine>#</firstLine>
         <beforeEachLine># </beforeEachLine>
         <endLine>#</endLine>
@@ -35,5 +35,5 @@
         <allowBlankLines>false</allowBlankLines>
         <isMultiline>true</isMultiline>
         <padLines>false</padLines>
-    </shell>
+    </shell_style>
 </additionalHeaders>

--- a/uat/README.md
+++ b/uat/README.md
@@ -1,11 +1,9 @@
 ## Client Devices Auth User Acceptance Tests
-User Acceptance Tests for Client Devices Auth run using `aws-greengrass-testing-standalone` as a library. They 
-execute E2E
-tests which will spin up an instance of Greengrass on your device and execute different sets of tests, by installing
-the `aws.greengrass.clientdevices.Auth` component.
+User Acceptance Tests for Client Devices Auth run using `aws-greengrass-testing-standalone` as a library.
+They execute E2E tests which will spin up an instance of Greengrass on your device and execute different sets of tests, 
+by installing the `aws.greengrass.clientdevices.Auth` component.
 
 ## Install requirements
-TODO
 ```bash
 sudo apt-get install -y maven python3-venv docker.io
 ```
@@ -54,11 +52,10 @@ $Env:AWS_SECRET_ACCESS_KEY=<AWS_SECRET_ACCESS_KEY>
     - add ggc_user to docker group
 
 ### Build the test Jar
-For UATs to run you will need to package your entire application along with `aws-greengrass-testing-standalone` into
-an uber jar. To do run (from the root of the project)
+For UATs to run you will need to package your entire uat project into an uber jar. To do run (from the uat directory of the project)
 
 ```
-mvn -U -ntp clean verify -f uat/pom.xml
+mvn -U -ntp clean verify
 ```
 
 Note: Everytime you make changes to the codebase you will have to rebuild the uber jar for those changes to be present on the final artifact.
@@ -71,17 +68,20 @@ curl -s https://d2s8p88vqu9w66.cloudfront.net/releases/greengrass-nucleus-latest
 ```
 
 ### Run scenarios
-Execute the UATs by running the following commands from the root of the project.
+Execute the UATs by running the following commands from the uat directory of the project.
 
 ```bash
 java -Dggc.archive=<path-to-nucleus-zip> -Dtest.log.path=<path-to-test-results-folder> -Dtags=GGMQ -jar <path-to-test-jar>
-java -Dggc.archive=./greengrass-nucleus-latest.zip -Dtest.log.path=./logs -Dtags=GGMQ -jar uat/testing-features/target/client-devices-auth-testing-features.jar
+```
+An example to run from uat directory:
+```bash
+java -Dggc.archive=greengrass-nucleus-latest.zip -Dtest.log.path=logs -Dtags="GGMQ" -jar testing-features/target/client-devices-auth-testing-features.jar
 ```
 
 On Windows
 Due to mosquitto-based client is not yet build on Windows use a little modified command.
 ```cmd
-java -Dggc.archive=./greengrass-nucleus-latest.zip -Dtest.log.path=./logs -Dtags="@GGMQ and not @mosquitto-c" -jar uat/testing-features/target/client-devices-auth-testing-features.jar
+java -Dggc.archive=greengrass-nucleus-latest.zip -Dtest.log.path=logs -Dtags="@GGMQ and not @mosquitto-c" -jar testing-features/target/client-devices-auth-testing-features.jar
 ```
 
 Command arguments:
@@ -90,5 +90,5 @@ Dggc.archive - path to the nucleus zip that was downloaded<br />
 Dtest.log.path - path where you would like the test results to be stored<br />
 Dtags can be extended, if you would like to test exact scenario, you can do as follows:<br />
 ```bash
-java -Dggc.archive=./greengrass-nucleus-latest.zip -Dtest.log.path=./logs -Dtags="@GGMQ and @GGMQ-1-T1 and @sdk-java and @mqtt3" -jar uat/testing-features/target/client-devices-auth-testing-features.jar
+java -Dggc.archive=greengrass-nucleus-latest.zip -Dtest.log.path=logs -Dtags="@GGMQ-1-T1 and @sdk-java and @mqtt3" -jar testing-features/target/client-devices-auth-testing-features.jar
 ```

--- a/uat/custom-components/client-mosquitto-c/.gitignore
+++ b/uat/custom-components/client-mosquitto-c/.gitignore
@@ -1,3 +1,4 @@
 /build/
 /mosquitto-test-client.amd64.tar.gz
 /proto/
+/target/

--- a/uat/custom-components/client-mosquitto-c/README.md
+++ b/uat/custom-components/client-mosquitto-c/README.md
@@ -12,15 +12,25 @@ Note: required version 2.0 or above of mosquitto
 ```bash
 sudo apt-get install -y docker.io
 ```
-## Build
+## Native build
 ```bash
 CXXFLAGS="-Wall -Wextra -g -O0" cmake -Bbuild -H.
-cmake --build build -j 4 --target all
+cmake --build build -j `nproc` --target all
 ```
 
-## Run
+## Docker buid
+```bash
+scripts/produce_docker_container.sh
+```
+
+## Native Run
 ```bash
 build/src/mosquitto-test-client agent-mosquitto 47619 127.0.0.1
+```
+
+## Docker run
+```bash
+docker run --rm --name=client-mosquitto-c client-mosquitto-c:runner-amd64 agent-mosquitto 47619 172.17.0.1 127.0.0.1
 ```
 
 ## Description

--- a/uat/custom-components/client-mosquitto-c/pom.xml
+++ b/uat/custom-components/client-mosquitto-c/pom.xml
@@ -80,9 +80,9 @@
                     <mapping>
                         <cpp>JAVA_STYLE</cpp>
                         <h>JAVA_STYLE</h>
-                        <bat>BATCH</bat>
+                        <bat>BATCH_STYLE</bat>
                         <proto>JAVA_STYLE</proto>
-                        <txt>SHELL</txt>
+                        <txt>SHELL_STYLE</txt>
                     </mapping>
                 </configuration>
                 <executions>

--- a/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
@@ -206,7 +206,7 @@ Status GRPCControlServer::CloseMqttConnection(ServerContext *, const MqttCloseRe
     }
 
     try {
-        connection->disconnect(timeout, reason);
+        connection->disconnect(timeout, reason, &request->properties());
         delete connection;
         return Status::OK;
     } catch (MqttException & ex) {

--- a/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
@@ -368,12 +368,10 @@ Status GRPCControlServer::SubscribeMqtt(ServerContext *, const MqttSubscribeRequ
     }
 
     try {
-        std::vector<int> reason_codes = connection->subscribe(timeout, subscription_id_ptr, filters, common_qos, common_retain_handling, common_no_local, common_retain_as_published, request->properties());
-        for (int reason_code : reason_codes) {
-            logd("subscribe reason code %d\n", reason_code);
-            reply->add_reasoncodes(reason_code);
-        }
-
+        connection->subscribe(timeout, subscription_id_ptr, filters, common_qos,
+                                common_retain_handling, common_no_local,
+                                common_retain_as_published, request->properties(),
+                                reply);
         return Status::OK;
     } catch (MqttException & ex) {
         loge("SubscribeMqtt: exception during subscribing\n");
@@ -412,10 +410,7 @@ Status GRPCControlServer::UnsubscribeMqtt(ServerContext *, const MqttUnsubscribe
 
     std::vector<std::string> filters(request->filters().begin(), request->filters().end());
     try {
-        std::vector<int> reason_codes = connection->unsubscribe(timeout, filters, request->properties());
-        for (int reason_code : reason_codes) {
-            reply->add_reasoncodes(reason_code);
-        }
+        connection->unsubscribe(timeout, filters, request->properties(), reply);
         return Status::OK;
     } catch (MqttException & ex) {
         loge("UnsubscribeMqtt: exception during unsubscribing\n");

--- a/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
@@ -125,7 +125,7 @@ Status GRPCControlServer::CreateMqttConnection(ServerContext *, const MqttConnec
     int keepalive = request->keepalive();
     if (keepalive != KEEPALIVE_OFF && (keepalive < KEEPALIVE_MIN || keepalive > KEEPALIVE_MAX)) {
         loge("CreateMqttConnection: invalid keepalive, must be in range [%u, %u]\n", KEEPALIVE_MIN, KEEPALIVE_MAX);
-        return Status(StatusCode::INVALID_ARGUMENT, "invalid keepalive, must be in range [1, 65535]");
+        return Status(StatusCode::INVALID_ARGUMENT, "invalid keepalive, must be in range [5, 65535]");
     }
 
     int timeout = request->timeout();
@@ -165,7 +165,7 @@ Status GRPCControlServer::CreateMqttConnection(ServerContext *, const MqttConnec
     }
 
     try {
-        MqttConnection * connection = m_mqtt->createConnection(m_client, client_id, host, port, keepalive, request->cleansession(), ca_char, cert_char, key_char, v5);
+        MqttConnection * connection = m_mqtt->createConnection(m_client, client_id, host, port, keepalive, request->cleansession(), ca_char, cert_char, key_char, v5, request->properties());
         ClientControl::Mqtt5ConnAck * conn_ack = connection->start(timeout);
         int connection_id = m_mqtt->registerConnection(connection);
 

--- a/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
@@ -259,7 +259,7 @@ Status GRPCControlServer::PublishMqtt(ServerContext *, const MqttPublishRequest 
     }
 
     try {
-        ClientControl::MqttPublishReply * result = connection->publish(timeout, qos, is_retain, topic, message.payload());
+        ClientControl::MqttPublishReply * result = connection->publish(timeout, qos, is_retain, topic, message.payload(), message.properties());
         if (result) {
             if (result->has_reasoncode()) {
                 reply->set_reasoncode(result->reasoncode());
@@ -368,7 +368,7 @@ Status GRPCControlServer::SubscribeMqtt(ServerContext *, const MqttSubscribeRequ
     }
 
     try {
-        std::vector<int> reason_codes = connection->subscribe(timeout, subscription_id_ptr, filters, common_qos, common_retain_handling, common_no_local, common_retain_as_published);
+        std::vector<int> reason_codes = connection->subscribe(timeout, subscription_id_ptr, filters, common_qos, common_retain_handling, common_no_local, common_retain_as_published, request->properties());
         for (int reason_code : reason_codes) {
             logd("subscribe reason code %d\n", reason_code);
             reply->add_reasoncodes(reason_code);
@@ -412,7 +412,7 @@ Status GRPCControlServer::UnsubscribeMqtt(ServerContext *, const MqttUnsubscribe
 
     std::vector<std::string> filters(request->filters().begin(), request->filters().end());
     try {
-        std::vector<int> reason_codes = connection->unsubscribe(timeout, filters);
+        std::vector<int> reason_codes = connection->unsubscribe(timeout, filters, request->properties());
         for (int reason_code : reason_codes) {
             reply->add_reasoncodes(reason_code);
         }

--- a/uat/custom-components/client-mosquitto-c/src/MqttConnection.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/MqttConnection.cpp
@@ -364,7 +364,6 @@ void MqttConnection::subscribe(unsigned timeout, const int * subscription_id,
     int rc = result->rc;
     if (rc != MOSQ_ERR_SUCCESS) {
         loge("subscribe callback failed with code %d: %s\n", rc, mosquitto_strerror(rc));
-        destroyUnlocked();
         mosquitto_property_free_all(&properties);
         throw MqttException("couldn't subscribe", rc);
     }
@@ -433,7 +432,6 @@ void MqttConnection::unsubscribe(unsigned timeout, const std::vector<std::string
     if (rc != MOSQ_ERR_SUCCESS) {
         loge("unsubscribe callback failed with code %d: %s\n", rc, mosquitto_strerror(rc));
         mosquitto_property_free_all(&properties);
-        destroyUnlocked();
         throw MqttException("couldn't unsubscribe", rc);
     }
 
@@ -894,6 +892,3 @@ void MqttConnection::updateMqttSubscribeReply(const std::vector<int> & granted_q
         }
     }
 }
-
-
-// destroy ?

--- a/uat/custom-components/client-mosquitto-c/src/MqttConnection.h
+++ b/uat/custom-components/client-mosquitto-c/src/MqttConnection.h
@@ -19,6 +19,7 @@ namespace ClientControl {
     class Mqtt5Message;
     class MqttPublishReply;
     class Mqtt5Properties;
+    class MqttSubscribeReply;
 }
 class PendingRequest;
 class GRPCDiscoveryClient;
@@ -80,12 +81,13 @@ public:
      * @param no_local the common no local value for all filters
      * @param retain_as_published the common retain as published vlaue for all filters
      * @param user_properties the user properties of the SUBCRIBE request
-     * @return the vector of reason codes for each filter
+     * @param reply the subscribe reply to update
      * @throw MqttException on errors
      */
-    std::vector<int> subscribe(unsigned timeout, const int * subscription_id, const std::vector<std::string> & filters,
-                                int qos, int retain_handling, bool no_local, bool retain_as_published,
-                                const RepeatedPtrField<ClientControl::Mqtt5Properties> & user_properties);
+    void subscribe(unsigned timeout, const int * subscription_id, const std::vector<std::string> & filters,
+                    int qos, int retain_handling, bool no_local, bool retain_as_published,
+                    const RepeatedPtrField<ClientControl::Mqtt5Properties> & user_properties,
+                    ClientControl::MqttSubscribeReply * reply);
 
 
     /**
@@ -94,11 +96,12 @@ public:
      * @param timeout the timeout in seconds to subscribe
      * @param filters the filters of topics subscribe to
      * @param user_properties the user properties of the SUBCRIBE request
-     * @return the vector of reason codes for each filter
+     * @param reply the subscribe reply to update
      * @throw MqttException on errors
      */
-    std::vector<int> unsubscribe(unsigned timeout, const std::vector<std::string> & filters,
-                                    const RepeatedPtrField<ClientControl::Mqtt5Properties> & user_properties);
+    void unsubscribe(unsigned timeout, const std::vector<std::string> & filters,
+                        const RepeatedPtrField<ClientControl::Mqtt5Properties> & user_properties,
+                        ClientControl::MqttSubscribeReply * reply);
 
     /**
      * Publishes MQTT message.
@@ -163,6 +166,7 @@ private:
     static std::string saveToTempFile(const std::string & content);
 
     void convertUserProperties(const RepeatedPtrField<ClientControl::Mqtt5Properties> * user_properties, mosquitto_property ** conn_properties);
+    void updateMqttSubscribeReply(const std::vector<int> & granted_qos, const mosquitto_property * props,  ClientControl::MqttSubscribeReply * reply);
 
     void destroyLocked();
     void destroyUnlocked();

--- a/uat/custom-components/client-mosquitto-c/src/MqttConnection.h
+++ b/uat/custom-components/client-mosquitto-c/src/MqttConnection.h
@@ -47,7 +47,7 @@ public:
      * @param cert pointer to client's certificate content, can be NULL
      * @param key pointer to client's key content, can be NULL
      * @param v5 use MQTT v5.0
-     * @param user_properties the user properties of the connect request
+     * @param user_properties the user properties of the CONNECT request
      * @throw MqttException on errors
      */
     MqttConnection(GRPCDiscoveryClient & grpc_client, const std::string & client_id, const std::string & host,
@@ -111,10 +111,12 @@ public:
     /**
      * Disconnect from the broker.
      *
+     * @param timeout the timeout in seconds to disconnect
      * @param reason_code the MQTT disconnect reason code
+     * @param user_properties the optional user properties of the DISCONNECT request
      * @throw MqttException on errors
      */
-    void disconnect(unsigned timeout, unsigned char reason_code);
+    void disconnect(unsigned timeout, unsigned char reason_code, const RepeatedPtrField<ClientControl::Mqtt5Properties> * user_properties);
 
 
 private:
@@ -150,6 +152,8 @@ private:
 
     static void removeFile(std::string & file);
     static std::string saveToTempFile(const std::string & content);
+
+    void convertUserProperties(const RepeatedPtrField<ClientControl::Mqtt5Properties> * user_properties, mosquitto_property ** conn_properties);
 
     void destroyLocked();
     void destroyUnlocked();

--- a/uat/custom-components/client-mosquitto-c/src/MqttConnection.h
+++ b/uat/custom-components/client-mosquitto-c/src/MqttConnection.h
@@ -79,10 +79,13 @@ public:
      * @param retain_handling the common retain handling value for all filters
      * @param no_local the common no local value for all filters
      * @param retain_as_published the common retain as published vlaue for all filters
+     * @param user_properties the user properties of the SUBCRIBE request
      * @return the vector of reason codes for each filter
      * @throw MqttException on errors
      */
-    std::vector<int> subscribe(unsigned timeout, const int * subscription_id, const std::vector<std::string> & filters, int qos, int retain_handling, bool no_local, bool retain_as_published);
+    std::vector<int> subscribe(unsigned timeout, const int * subscription_id, const std::vector<std::string> & filters,
+                                int qos, int retain_handling, bool no_local, bool retain_as_published,
+                                const RepeatedPtrField<ClientControl::Mqtt5Properties> & user_properties);
 
 
     /**
@@ -90,10 +93,12 @@ public:
      *
      * @param timeout the timeout in seconds to subscribe
      * @param filters the filters of topics subscribe to
+     * @param user_properties the user properties of the SUBCRIBE request
      * @return the vector of reason codes for each filter
      * @throw MqttException on errors
      */
-    std::vector<int> unsubscribe(unsigned timeout, const std::vector<std::string> & filters);
+    std::vector<int> unsubscribe(unsigned timeout, const std::vector<std::string> & filters,
+                                    const RepeatedPtrField<ClientControl::Mqtt5Properties> & user_properties);
 
     /**
      * Publishes MQTT message.
@@ -103,10 +108,13 @@ public:
      * @param is_retain the retain flag
      * @param topic the topic to publish
      * @param payload the payload of the message
+     * @param user_properties the user properties of the SUBCRIBE request
      * @return pointer to allocated gRPC MqttPublishReply
      * @throw MqttException on errors
      */
-    ClientControl::MqttPublishReply * publish(unsigned timeout, int qos, bool is_retain, const std::string & topic, const std::string & payload);
+    ClientControl::MqttPublishReply * publish(unsigned timeout, int qos, bool is_retain, const std::string & topic,
+                                                const std::string & payload,
+                                                const RepeatedPtrField<ClientControl::Mqtt5Properties> & user_properties);
 
     /**
      * Disconnect from the broker.
@@ -116,7 +124,8 @@ public:
      * @param user_properties the optional user properties of the DISCONNECT request
      * @throw MqttException on errors
      */
-    void disconnect(unsigned timeout, unsigned char reason_code, const RepeatedPtrField<ClientControl::Mqtt5Properties> * user_properties);
+    void disconnect(unsigned timeout, unsigned char reason_code,
+                    const RepeatedPtrField<ClientControl::Mqtt5Properties> * user_properties);
 
 
 private:

--- a/uat/custom-components/client-mosquitto-c/src/MqttConnection.h
+++ b/uat/custom-components/client-mosquitto-c/src/MqttConnection.h
@@ -9,12 +9,16 @@
 #include <vector>
 #include <unordered_map>
 #include <mutex>
+#include <google/protobuf/repeated_field.h>
+
+using google::protobuf::RepeatedPtrField;
 
 namespace ClientControl {
     class Mqtt5ConnAck;
     class Mqtt5Disconnect;
     class Mqtt5Message;
     class MqttPublishReply;
+    class Mqtt5Properties;
 }
 class PendingRequest;
 class GRPCDiscoveryClient;
@@ -43,9 +47,12 @@ public:
      * @param cert pointer to client's certificate content, can be NULL
      * @param key pointer to client's key content, can be NULL
      * @param v5 use MQTT v5.0
+     * @param user_properties the user properties of the connect request
      * @throw MqttException on errors
      */
-    MqttConnection(GRPCDiscoveryClient & grpc_client, const std::string & client_id, const std::string & host, unsigned short port, unsigned short keepalive, bool clean_session, const char * ca, const char * cert, const char * key, bool v5);
+    MqttConnection(GRPCDiscoveryClient & grpc_client, const std::string & client_id, const std::string & host,
+                    unsigned short port, unsigned short keepalive, bool clean_session, const char * ca,
+                    const char * cert, const char * key, bool v5, const RepeatedPtrField<ClientControl::Mqtt5Properties> & user_properties);
     ~MqttConnection();
 
 
@@ -162,6 +169,8 @@ private:
     std::string m_ca;
     std::string m_cert;
     std::string m_key;
+
+    mosquitto_property * m_conn_properties;
 
     struct mosquitto * m_mosq;
 

--- a/uat/custom-components/client-mosquitto-c/src/MqttLib.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/MqttLib.cpp
@@ -30,8 +30,11 @@ MqttLib::~MqttLib() {
     logd("Shutdown MQTT library\n");
 }
 
-MqttConnection * MqttLib::createConnection(GRPCDiscoveryClient & grpc_client, const std::string & client_id, const std::string & host, unsigned short port, unsigned short keepalive, bool clean_session, const char * ca, const char * cert, const char * key, bool v5) {
-    return new MqttConnection(grpc_client, client_id, host, port, keepalive, clean_session, ca, cert, key, v5);
+MqttConnection * MqttLib::createConnection(GRPCDiscoveryClient & grpc_client, const std::string & client_id,
+                                            const std::string & host, unsigned short port, unsigned short keepalive,
+                                            bool clean_session, const char * ca, const char * cert, const char * key,
+                                            bool v5, const RepeatedPtrField<ClientControl::Mqtt5Properties> & user_properties) {
+    return new MqttConnection(grpc_client, client_id, host, port, keepalive, clean_session, ca, cert, key, v5, user_properties);
 }
 
 

--- a/uat/custom-components/client-mosquitto-c/src/MqttLib.h
+++ b/uat/custom-components/client-mosquitto-c/src/MqttLib.h
@@ -9,9 +9,17 @@
 #include <string>
 #include <mutex>
 #include <unordered_map>
+#include <google/protobuf/repeated_field.h>
+
+using google::protobuf::RepeatedPtrField;
+
+namespace ClientControl {
+    class Mqtt5Properties;
+}
 
 class MqttConnection;
 class GRPCDiscoveryClient;
+
 
 /**
  * MQTT library class.
@@ -34,10 +42,14 @@ public:
      * @param cert pointer to client's certificate content, can be NULL
      * @param key pointer to client's key content, can be NULL
      * @param v5 use MQTT v5.0
+     * @param user_properties the user properties of the connect request
      * @return MqttConnection on success
      * @throw MqttException on errors
      */
-    MqttConnection * createConnection(GRPCDiscoveryClient & grpc_client, const std::string & client_id, const std::string & host, unsigned short port, unsigned short keepalive, bool clean_session, const char * ca, const char * cert, const char * key, bool v5);
+    MqttConnection * createConnection(GRPCDiscoveryClient & grpc_client, const std::string & client_id,
+                                        const std::string & host, unsigned short port, unsigned short keepalive,
+                                        bool clean_session, const char * ca, const char * cert, const char * key,
+                                        bool v5, const RepeatedPtrField<ClientControl::Mqtt5Properties> & user_properties);
 
 
     int registerConnection(MqttConnection * connection);

--- a/uat/custom-components/client-python-paho/pom.xml
+++ b/uat/custom-components/client-python-paho/pom.xml
@@ -103,9 +103,9 @@
                         </licenseSet>
                     </licenseSets>
                     <mapping>
-                        <py>SHELL</py>
-                        <bat>BATCH</bat>
-                        <sh>SHELL</sh>
+                        <py>SHELL_STYLE</py>
+                        <bat>BATCH_STYLE</bat>
+                        <sh>SHELL_STYLE</sh>
                     </mapping>
                 </configuration>
                 <executions>

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/ExampleControl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/ExampleControl.java
@@ -64,6 +64,7 @@ public class ExampleControl {
         this.useTLS = useTLS;
         this.mqtt50 = mqtt50;
         this.port = port;
+        logger.atInfo().log("Control: port {}, {} TLS, MQTT v{}", port, useTLS ? "with" : "without", mqtt50 ? 5 : 3);
         this.engineControl = new EngineControlImpl();
         this.eventStorage = new EventStorageImpl();
     }

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/ConnectionControl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/ConnectionControl.java
@@ -72,12 +72,25 @@ public interface ConnectionControl {
      * Do MQTT subscription(s).
      *
      * @param subscriptionId optional subscription id
-     * @param subscriptions MQTT v5.0 subscriptions
-     * @param mqtt5Properties MQTT v5.0 properties
+     * @param subscriptions MQTT subscriptions
      * @return reply to subscribe
      * @throws StatusRuntimeException on errors
      */
-    MqttSubscribeReply subscribeMqtt(Integer subscriptionId, List<Mqtt5Properties> mqtt5Properties,
+    default MqttSubscribeReply subscribeMqtt(Integer subscriptionId, @NonNull Mqtt5Subscription... subscriptions) {
+        final List<Mqtt5Properties> userProperties = null;
+        return subscribeMqtt(subscriptionId, userProperties, subscriptions);
+    }
+
+    /**
+     * Do MQTT subscription(s).
+     *
+     * @param subscriptionId optional subscription id
+     * @param userProperties optional MQTT v5.0 user properties
+     * @param subscriptions MQTT subscriptions
+     * @return reply to subscribe
+     * @throws StatusRuntimeException on errors
+     */
+    MqttSubscribeReply subscribeMqtt(Integer subscriptionId, List<Mqtt5Properties> userProperties,
                                      @NonNull Mqtt5Subscription... subscriptions);
 
     /**
@@ -97,7 +110,20 @@ public interface ConnectionControl {
      * @return reply to unsubscribe
      * @throws StatusRuntimeException on errors
      */
-    MqttSubscribeReply unsubscribeMqtt(@NonNull String... filters);
+    default MqttSubscribeReply unsubscribeMqtt(@NonNull String... filters) {
+        final List<Mqtt5Properties> userProperties = null;
+        return unsubscribeMqtt(userProperties, filters);
+    }
+
+    /**
+     * Remove MQTT subscription(s).
+     *
+     * @param userProperties optional MQTT v5.0 user properties
+     * @param filters topic filters to unsubscribe
+     * @return reply to unsubscribe
+     * @throws StatusRuntimeException on errors
+     */
+    MqttSubscribeReply unsubscribeMqtt(List<Mqtt5Properties> userProperties, @NonNull String... filters);
 
     /**
      * Close MQTT connection to the broker.
@@ -105,5 +131,16 @@ public interface ConnectionControl {
      * @param reason reason code of disconnection as specified by MQTT v5.0 in DISCONNECT packet
      * @throws StatusRuntimeException on errors
      */
-    void closeMqttConnection(int reason);
+    default void closeMqttConnection(int reason) {
+        closeMqttConnection(reason, null);
+    }
+
+    /**
+     * Close MQTT connection to the broker.
+     *
+     * @param reason reason code of disconnection as specified by MQTT v5.0 in DISCONNECT packet
+     * @param userProperties optional MQTT v5.0 user properties
+     * @throws StatusRuntimeException on errors
+     */
+    void closeMqttConnection(int reason, List<Mqtt5Properties> userProperties);
 }

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/ConnectionControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/ConnectionControlImpl.java
@@ -91,51 +91,59 @@ public class ConnectionControlImpl implements ConnectionControl {
     }
 
     @Override
-    public void closeMqttConnection(int reason) {
-        MqttCloseRequest closeRequest = MqttCloseRequest.newBuilder()
+    public void closeMqttConnection(int reason, List<Mqtt5Properties> userProperties) {
+        MqttCloseRequest.Builder builder = MqttCloseRequest.newBuilder()
                     .setConnectionId(MqttConnectionId.newBuilder().setConnectionId(connectionId).build())
                     .setTimeout(timeout)
-                    .setReason(reason)
-                    .build();
-        agentControl.closeMqttConnection(closeRequest);
+                    .setReason(reason);
+
+        if (userProperties != null) {
+            builder.addAllProperties(userProperties);
+        }
+
+        agentControl.closeMqttConnection(builder.build());
     }
 
     @Override
-    public MqttSubscribeReply subscribeMqtt(Integer subscriptionId, List<Mqtt5Properties> mqtt5Properties,
+    public MqttSubscribeReply subscribeMqtt(Integer subscriptionId, List<Mqtt5Properties> userProperties,
                                             @NonNull Mqtt5Subscription... subscriptions) {
         MqttSubscribeRequest.Builder builder = MqttSubscribeRequest.newBuilder()
-                .setConnectionId(MqttConnectionId.newBuilder().setConnectionId(connectionId).build())
-                .setTimeout(timeout)
-                .addAllSubscriptions(Arrays.asList(subscriptions));
+                    .setConnectionId(MqttConnectionId.newBuilder().setConnectionId(connectionId).build())
+                    .setTimeout(timeout)
+                    .addAllSubscriptions(Arrays.asList(subscriptions));
 
         if (subscriptionId != null) {
             builder.setSubscriptionId(subscriptionId);
         }
-        if (mqtt5Properties != null) {
-            builder.addAllProperties(mqtt5Properties);
+
+        if (userProperties != null) {
+            builder.addAllProperties(userProperties);
         }
 
         return agentControl.subscribeMqtt(builder.build());
     }
 
     @Override
-    public MqttSubscribeReply unsubscribeMqtt(@NonNull String... filters) {
-        MqttUnsubscribeRequest unsubscribeRequest =  MqttUnsubscribeRequest.newBuilder()
+    public MqttSubscribeReply unsubscribeMqtt(List<Mqtt5Properties> userProperties, @NonNull String... filters) {
+        MqttUnsubscribeRequest.Builder builder = MqttUnsubscribeRequest.newBuilder()
                     .setConnectionId(MqttConnectionId.newBuilder().setConnectionId(connectionId).build())
                     .setTimeout(timeout)
-                    .addAllFilters(Arrays.asList(filters))
-                    .build();
+                    .addAllFilters(Arrays.asList(filters));
 
-        return agentControl.unsubscribeMqtt(unsubscribeRequest);
+        if (userProperties != null) {
+            builder.addAllProperties(userProperties);
+        }
+
+        return agentControl.unsubscribeMqtt(builder.build());
     }
 
     @Override
     public MqttPublishReply publishMqtt(@NonNull Mqtt5Message message) {
         MqttPublishRequest publishRequest = MqttPublishRequest.newBuilder()
-            .setConnectionId(MqttConnectionId.newBuilder().setConnectionId(connectionId).build())
-            .setTimeout(timeout)
-            .setMsg(message)
-            .build();
+                .setConnectionId(MqttConnectionId.newBuilder().setConnectionId(connectionId).build())
+                .setTimeout(timeout)
+                .setMsg(message)
+                .build();
         return agentControl.publishMqtt(publishRequest);
     }
 

--- a/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/ConnectionControlImplTest.java
+++ b/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/ConnectionControlImplTest.java
@@ -123,7 +123,7 @@ class ConnectionControlImplTest {
         when(agent.subscribeMqtt(any(MqttSubscribeRequest.class))).thenReturn(reply);
 
         // WHEN
-        final MqttSubscribeReply actual = connectionControl.subscribeMqtt(subscriptionId, null, subscription);
+        final MqttSubscribeReply actual = connectionControl.subscribeMqtt(subscriptionId, subscription);
 
         // THEN
         assertSame(reply, actual);

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -12,6 +12,7 @@ import com.aws.greengrass.testing.model.TestContext;
 import com.aws.greengrass.testing.modules.model.AWSResourcesContext;
 import com.aws.greengrass.testing.mqtt.client.Mqtt5Disconnect;
 import com.aws.greengrass.testing.mqtt.client.Mqtt5Message;
+import com.aws.greengrass.testing.mqtt.client.Mqtt5Properties;
 import com.aws.greengrass.testing.mqtt.client.Mqtt5RetainHandling;
 import com.aws.greengrass.testing.mqtt.client.Mqtt5Subscription;
 import com.aws.greengrass.testing.mqtt.client.MqttConnectRequest;
@@ -136,6 +137,10 @@ public class MqttControlSteps {
     /** Actual value of publish retain option. */
     private boolean publishRetain = DEFAULT_PUBLISH_RETAIN;
 
+
+    /** Actual list of user properties to transmit. */
+    private static final List<Mqtt5Properties> txUserProperties = null;
+
     private final Map<String, List<MqttBrokerConnectionInfo>> brokers = new HashMap<>();
     private final Map<String, MqttProtoVersion> mqttVersions = new HashMap<>();
 
@@ -160,6 +165,7 @@ public class MqttControlSteps {
 
         @Override
         public void onMqttDisconnect(ConnectionControl connectionControl, Mqtt5Disconnect disconnect, String error) {
+            // TODO: also add to eventStore
             log.info("MQTT client disconnected. Error: {}", error);
         }
     };
@@ -322,7 +328,7 @@ public class MqttControlSteps {
         ConnectionControl connectionControl = getConnectionControl(clientDeviceThingName);
 
         // do disconnect
-        connectionControl.closeMqttConnection(reasonCode);
+        connectionControl.closeMqttConnection(reasonCode, txUserProperties);
         log.info("Thing {} was disconnected with reason code {}", clientDeviceId, reasonCode);
     }
 
@@ -448,7 +454,7 @@ public class MqttControlSteps {
                 subscribeRetainAsPublished,
                 subscribeRetainHandling);
         MqttSubscribeReply mqttSubscribeReply = connectionControl.subscribeMqtt(DEFAULT_SUBSCRIPTION_ID,
-                                                                                null, mqtt5Subscription);
+                                                                                txUserProperties, mqtt5Subscription);
         if (mqttSubscribeReply == null) {
             throw new RuntimeException("Do not receive reply to MQTT subscribe request");
         }
@@ -664,7 +670,7 @@ public class MqttControlSteps {
         // do unsubscribe
         log.info("Create MQTT unsubscription for Thing {} to topics filter {}", clientDeviceThingName, filter);
 
-        MqttSubscribeReply mqttUnsubscribeReply = connectionControl.unsubscribeMqtt(filter);
+        MqttSubscribeReply mqttUnsubscribeReply = connectionControl.unsubscribeMqtt(txUserProperties, filter);
 
         List<Integer> reasons = mqttUnsubscribeReply.getReasonCodesList();
         if (reasons == null) {
@@ -709,15 +715,20 @@ public class MqttControlSteps {
         final IotThingSpec thingSpec = getClientDeviceThingSpec(clientDeviceThingName);
 
         // TODO: use values from scenario instead of defaults for keepAlive, cleanSession
-        return MqttConnectRequest.newBuilder()
+        MqttConnectRequest.Builder builder = MqttConnectRequest.newBuilder()
                                  .setClientId(clientDeviceThingName)
                                  .setHost(host)
                                  .setPort(port)
                                  .setKeepalive(DEFAULT_MQTT_KEEP_ALIVE)
                                  .setCleanSession(DEFAULT_CONNECT_CLEAR_SESSION)
                                  .setTls(buildTlsSettings(thingSpec, caList))
-                                 .setProtocolVersion(version)
-                                 .build();
+                                 .setProtocolVersion(version);
+
+        if (txUserProperties != null) {
+             builder.addAllProperties(txUserProperties);
+        }
+
+        return builder.build();
     }
 
     private IotThingSpec getClientDeviceThingSpec(String clientDeviceThingName) {
@@ -858,12 +869,17 @@ public class MqttControlSteps {
 
     private Mqtt5Message buildMqtt5Message(int qos, boolean retain, @NonNull String topic, @NonNull String content) {
         MqttQoS mqttQoS = getMqttQoS(qos);
-        return Mqtt5Message.newBuilder()
+        Mqtt5Message.Builder builder = Mqtt5Message.newBuilder()
                             .setTopic(topic)
                             .setPayload(ByteString.copyFromUtf8(content))
                             .setQos(mqttQoS)
-                            .setRetain(retain)
-                            .build();
+                            .setRetain(retain);
+
+        if (txUserProperties != null) {
+             builder.addAllProperties(txUserProperties);
+        }
+
+        return builder.build();
     }
 
     private void initMqttVersions() {


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-178
Set/unset user property(es) in mosquitto client

**Description of changes:**
- Add handling of MQTT v5.0 properties in all requests and responses of mosquitto client
- Update control to be able to get and provide MQTT v5.0 user properties for connect/disconnect subscribe/unsubscribe publish and receiving messages
- Update mqtt steps by adding user property list currently is null
- Tune error handling in mosquitto client
- Do not pass user properties from control app if MQTT v3 is selected
- Fix mistypes in log lines
- Update readme files to provide actual commands
- Change license check styles names by adding suffix _style

**Why is this change necessary:**
User properties should be transmitted as well as received in mosquitto client

**How was this change tested:**
By running control as an application

**Test result:**
Please check Copied RX/TX user property lines
```
$ build/src/mosquitto-test-client agent-mosquitto 47619 127.0.0.1 
[DEBUG]: Initialize gRPC library
[DEBUG]: Making gPRC link with 127.0.0.1:47619 as agent_id 'agent-mosquitto'
[DEBUG]: Sending RegisterAgent request with agent_id agent-mosquitto
[DEBUG]: Local address is 127.0.0.1
[DEBUG]: GRPCControlServer created and listed on 127.0.0.1:39049
[DEBUG]: Sending DiscoveryAgent request agent_id 'agent-mosquitto' host:port 127.0.0.1:39049
[DEBUG]: gPRC link established with 127.0.0.1:47619 as agent_id 'agent-mosquitto'
[DEBUG]: Initialize Mosquitto MQTT library
[DEBUG]: Mosquitto library version 2.0.15
[DEBUG]: Handle gRPC requests
[DEBUG]: CreateMqttConnection client_id 'GGMQ-test-device2' broker a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[DEBUG]: Creating Mosquitto MQTT v5 connection for a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[DEBUG]: Copied TX user property region:US
[DEBUG]: Copied TX user property type:JSON
[DEBUG]: Establishing Mosquitto MQTT v5 connection to a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883 in 10 seconds
[DEBUG]: Use provided TLS credentials
[DEBUG]: mosquitto: Client GGMQ-test-device2 sending CONNECT
[DEBUG]: mosquitto: Client GGMQ-test-device2 received CONNACK (0)
[DEBUG]: onConnect rc 0 flags 0 props 0x7f84c8010780
[DEBUG]: Establishing MQTT connection to a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883 completed with reason code 0
[DEBUG]: Connection registered with id 1
[DEBUG]: Subscription: filter test/topic QoS 0 noLocal 0 retainAsPublished 0 retainHandling 2
[DEBUG]: SubscribeMqtt connection_id 1
[DEBUG]: Copied TX user property region:US
[DEBUG]: Copied TX user property type:JSON
[DEBUG]: mosquitto: Client GGMQ-test-device2 sending SUBSCRIBE (Mid: 1, Topic: test/topic, QoS: 0, Options: 0x20)
[DEBUG]: mosquitto: Client GGMQ-test-device2 received SUBACK
[DEBUG]: onSubscribe mid 1 qos_count 1 granted_qos 0x7f84c8014040 props (nil)
[DEBUG]: Subscribed on filters 'test/topic,' QoS 0 no local 0 retain as published 0 retain handing 2 with message id 1
[DEBUG]: Copied RX reason code 0
[DEBUG]: PublishMqtt connection_id 1 topic test/topic retain 0
[DEBUG]: Copied TX user property region:US
[DEBUG]: Copied TX user property type:JSON
[DEBUG]: mosquitto: Client GGMQ-test-device2 sending PUBLISH (d0, q1, r0, m2, 'test/topic', ... (12 bytes))
[DEBUG]: mosquitto: Client GGMQ-test-device2 received PUBACK (Mid: 2, RC:0)
[DEBUG]: onPublish mid 2 rc 0 props (nil)
[DEBUG]: mosquitto: Client GGMQ-test-device2 received PUBLISH (d0, q0, r0, m0, 'test/topic', ... (12 bytes))
[DEBUG]: onMessage message 0x7f84c8015908 props 0x7f84c8011f00
[DEBUG]: Published on topic 'test/topic' QoS 1 retain 0 with rc 0 message id 2
[DEBUG]: Copied RX user property region:US
[DEBUG]: Copied RX user property type:JSON
[DEBUG]: Sending OnReceiveMessage request agent_id 'agent-mosquitto' connection_id 1
[DEBUG]: UnsubscribeMqtt connection_id 1
[DEBUG]: Copied TX user property region:US
[DEBUG]: Copied TX user property type:JSON
[DEBUG]: mosquitto: Client GGMQ-test-device2 sending UNSUBSCRIBE (Mid: 3, Topic: test/topic)
[DEBUG]: mosquitto: Client GGMQ-test-device2 received UNSUBACK
[DEBUG]: onUnsubscribe mid 3 props (nil)
[DEBUG]: Unsubscribed from filters 'test/topic,' with message id 3
[DEBUG]: Copied RX reason code 0
[DEBUG]: CloseMqttConnection connection_id 1 reason 4
[DEBUG]: Disconnect Mosquitto MQTT connection with reason code 4
[DEBUG]: Copied TX user property region:US
[DEBUG]: Copied TX user property type:JSON
[DEBUG]: mosquitto: Client GGMQ-test-device2 sending DISCONNECT
[DEBUG]: onDisconnect rc 0 props (nil)
[DEBUG]: Sending OnMqttDisconnect request agent_id 'agent-mosquitto' connection_id 1 error '(null)'
[DEBUG]: Destroy Mosquitto MQTT connection
[DEBUG]: ShutdownAgent with reason 'That's it.'
[DEBUG]: Shutdown gPRC link
[DEBUG]: Sending UnregisterAgent request agent_id 'agent-mosquitto' reason 'Agent shutdown by OTF request 'That's it.''
[DEBUG]: Shutdown MQTT library
[DEBUG]: Shutdown gRPC library
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
