### PR TITLE
feat(uat): added user properties to missing methods

### DIFF
--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
@@ -95,21 +95,6 @@ public interface MqttConnection {
     }
 
     /**
-     * Useful information from SUBACK packet.
-     */
-    @Getter
-    @AllArgsConstructor
-    class SubAckInfo {
-        /** Reason codes. */
-        private List<Integer> reasonCodes;
-
-        private String reasonString;
-
-        /** User properties. */
-        private List<Mqtt5Properties>  userProperties;
-    }
-
-    /**
      * Contains information about publishing MQTT v5.0 message.
      */
     @Getter
@@ -134,17 +119,6 @@ public interface MqttConnection {
     }
 
     /**
-     * Useful information from UNSUBACK packet.
-     * Actually is the same as SubAckInfo.
-     */
-    class UnsubAckInfo extends SubAckInfo {
-        public UnsubAckInfo(List<Integer> reasonCodes, String reasonString, List<Mqtt5Properties>  userProperties) {
-            super(reasonCodes, reasonString, userProperties);
-        }
-    }
-
-
-    /**
      * Starts MQTT connection.
      *
      * @param connectionParams connect parameters
@@ -159,7 +133,7 @@ public interface MqttConnection {
      *
      * @param timeout subscribe operation timeout in seconds
      * @param subscriptions list of subscriptions
-     * @param userProperties  Map of user's properties MQTT v5.0
+     * @param userProperties  list of user's properties MQTT v5.0
      * @return useful information from SUBACK packet
      */
     MqttSubscribeReply subscribe(long timeout, @NonNull List<Subscription> subscriptions,
@@ -170,9 +144,10 @@ public interface MqttConnection {
      *
      * @param timeout disconnect operation timeout in seconds
      * @param reasonCode reason why connection is closed
+     * @param userProperties  list of user's properties MQTT v5.0
      * @exception MqttException on errors
      */
-    void disconnect(long timeout, int reasonCode) throws MqttException;
+    void disconnect(long timeout, int reasonCode, List<Mqtt5Properties> userProperties) throws MqttException;
 
     /**
      * Publishes MQTT message.

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
@@ -330,7 +330,7 @@ class GRPCControlServer {
 
             logger.atInfo().log("closeMqttConnection: connectionId {} reason {}", connectionId, reason);
             try {
-                connection.disconnect(timeout, reason);
+                connection.disconnect(timeout, reason, request.getPropertiesList());
             } catch (MqttException ex) {
                 logger.atError().withThrowable(ex).log("exception during disconnect");
                 responseObserver.onError(ex);

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttLibImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttLibImpl.java
@@ -115,7 +115,7 @@ public class MqttLibImpl implements MqttLib {
                 // delete if value is up to date, otherwise leave for next round
                 if (connections.remove(key, connection)) {
                     connection.disconnect(MqttConnection.DEFAULT_DISCONNECT_TIMEOUT,
-                            MqttConnection.DEFAULT_DISCONNECT_REASON);
+                            MqttConnection.DEFAULT_DISCONNECT_REASON, null);
                 }
             } catch (MqttException ex) {
                 logger.atError().withThrowable(ex).log("Failed during disconnect");

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt311/client/sdkmqtt/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt311/client/sdkmqtt/Mqtt311ConnectionImpl.java
@@ -139,6 +139,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
     @Override
     public void disconnect(long timeout, int reasonCode, List<Mqtt5Properties> userProperties) throws MqttException {
 
+        checkUserProperties(userProperties);
         if (!isClosing.getAndSet(true)) {
             CompletableFuture<Void> disconnnectFuture = connection.disconnect();
             try {
@@ -175,6 +176,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
                     throws MqttException {
 
         stateCheck();
+        checkUserProperties(message.getUserProperties());
 
         final QualityOfService qos = QualityOfService.getEnumValueFromInteger(message.getQos());
         final String topic = message.getTopic();
@@ -202,6 +204,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
             throws MqttException {
 
         stateCheck();
+        checkUserProperties(userProperties);
 
         if (subscriptionId != null) {
             throw new IllegalArgumentException("MQTT v3.1.1 doesn't support subscription id");
@@ -238,6 +241,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
             throws MqttException {
 
         stateCheck();
+        checkUserProperties(userProperties);
 
         if (filters.size() != 1) {
             throw new IllegalArgumentException("Iot device SDK MQTT v3.1.1 client does not support to unsubscribe from "
@@ -270,6 +274,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
      * @throws MqttException on errors
      */
     private MqttClientConnection createConnection(MqttLib.ConnectionParams connectionParams) throws MqttException {
+        checkUserProperties(connectionParams.getUserProperties());
 
         try (AwsIotMqttConnectionBuilder builder = getConnectionBuilder(connectionParams)) {
             builder.withEndpoint(connectionParams.getHost())
@@ -339,5 +344,11 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
     private static ConnectResult buildConnectResult(boolean success, Boolean sessionPresent) {
         ConnAckInfo connAckInfo = new ConnAckInfo(sessionPresent);
         return new ConnectResult(success, connAckInfo, null);
+    }
+
+    private void checkUserProperties(List<Mqtt5Properties> userProperties) {
+        if (userProperties != null && !userProperties.isEmpty()) {
+            logger.warn("MQTT V3 doesn't support user properties");
+        }
     }
 }


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-131
Added user properties to missing methods

**Description of changes:**
- added user properties to missing methods
- deleted unnecessary class
- added warning log to mqtt3 connection implemention

**Why is this change necessary:**
for correct working of clients

**How was this change tested:**
Scenarios run manually and on CI

**Client' log:**
```
[INFO ] 2023-06-15 19:03:11.668 [main] GRPCLinkImpl - Making gPRC client connection with 127.0.0.1:47619 as best-thing-akezhan...
[INFO ] 2023-06-15 19:03:12.158 [main] GRPCLinkImpl - Client connection with Control is established, local address is 127.0.0.1
[INFO ] 2023-06-15 19:03:12.185 [main] GRPCControlServer - GRPCControlServer created and listed on 127.0.0.1:35723
[INFO ] 2023-06-15 19:03:12.286 [main] GRPCLinkImpl - Handle gRPC requests
[INFO ] 2023-06-15 19:03:12.286 [main] GRPCControlServer - Server awaitTermination
[INFO ] 2023-06-15 19:03:15.323 [grpc-default-executor-0] GRPCControlServer - createMqttConnection: clientId best-thing-akezhan broker a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[INFO ] 2023-06-15 19:03:21.796 [grpc-default-executor-0] GRPCControlServer - Subscription: filter test/topic QoS 0 noLocal false retainAsPublished false retainHandling 2
[INFO ] 2023-06-15 19:03:21.796 [grpc-default-executor-0] GRPCControlServer - Subscribe: connectionId 1 for 1 filters
[INFO ] 2023-06-15 19:03:21.949 [grpc-default-executor-0] GRPCControlServer - Subscribe response: connectionId 1 reason codes [0] reason string 
[INFO ] 2023-06-15 19:03:26.980 [grpc-default-executor-0] GRPCControlServer - Publish: connectionId 1 topic test/topic QoS 1 retain false
[INFO ] 2023-06-15 19:03:27.096 [grpc-default-executor-0] GRPCControlServer - Publish response: connectionId 1 reason code 0 reason string 
[INFO ] 2023-06-15 19:03:27.105 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT userProperties: region, US
[INFO ] 2023-06-15 19:03:27.106 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT userProperties: type, JSON
[INFO ] 2023-06-15 19:03:27.125 [pool-3-thread-1] MqttConnectionImpl - Received MQTT message: connectionId 1 topic test/topic QoS 0 retain false
[INFO ] 2023-06-15 19:03:32.120 [grpc-default-executor-0] GRPCControlServer - Unsubscribe: connectionId 1 for [test/topic] filters
[INFO ] 2023-06-15 19:03:32.253 [grpc-default-executor-0] GRPCControlServer - Unsubscribe response: connectionId 1 reason codes [0] reason string 
[INFO ] 2023-06-15 19:03:47.271 [grpc-default-executor-0] GRPCControlServer - closeMqttConnection: connectionId 1 reason 4
[INFO ] 2023-06-15 19:03:47.409 [grpc-default-executor-0] GRPCControlServer - shutdownAgent: reason That's it.
[INFO ] 2023-06-15 19:03:47.435 [main] GRPCControlServer - Server awaitTermination done
[INFO ] 2023-06-15 19:03:47.435 [main] GRPCLinkImpl - Shutdown gPRC link
[INFO ] 2023-06-15 19:03:47.451 [main] Main - Execution done successfully
```
**Control' log:**
```
INFO ] 2023-06-15 19:03:01.742 [com.aws.greengrass.testing.mqtt.client.control.ExampleControl.main()] ExampleControl - Control: port 47619, with TLS, MQTT v5
[INFO ] 2023-06-15 19:03:01.896 [com.aws.greengrass.testing.mqtt.client.control.ExampleControl.main()] EngineControlImpl - MQTT client control gRPC server started, listening on 47619
[INFO ] 2023-06-15 19:03:12.124 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId best-thing-akezhan
[INFO ] 2023-06-15 19:03:12.189 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId best-thing-akezhan address 127.0.0.1 port 35723
[INFO ] 2023-06-15 19:03:12.193 [grpc-default-executor-0] EngineControlImpl - Created new agent control for best-thing-akezhan on 127.0.0.1:35723
[INFO ] 2023-06-15 19:03:12.230 [grpc-default-executor-0] ExampleControl - Agent best-thing-akezhan is connected
[INFO ] 2023-06-15 19:03:12.238 [pool-2-thread-1] AgentTestScenario - Playing test scenario for agent id best-thing-akezhan
[INFO ] 2023-06-15 19:03:16.765 [pool-2-thread-1] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
receiveMaximum: 100
maximumQoS: 1
retainAvailable: true
maximumPacketSize: 149504
serverKeepAlive: 60
'
[INFO ] 2023-06-15 19:03:16.765 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-06-15 19:03:16.765 [pool-2-thread-1] AgentTestScenario - MQTT connection with id 1 is established
[INFO ] 2023-06-15 19:03:21.778 [pool-2-thread-1] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-06-15 19:03:21.953 [pool-2-thread-1] AgentTestScenario - Subscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-06-15 19:03:26.967 [pool-2-thread-1] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic test/topic
[INFO ] 2023-06-15 19:03:27.103 [pool-2-thread-1] AgentTestScenario - Published connectionId 1 reason code 0 reason string ''
[INFO ] 2023-06-15 19:03:27.120 [grpc-default-executor-0] GRPCDiscoveryServer - OnReceiveMessage: agentId best-thing-akezhan connectionId 1 topic test/topic QoS 0
[INFO ] 2023-06-15 19:03:27.121 [grpc-default-executor-0] AgentTestScenario - Message received on agentId best-thing-akezhan connectionId 1 topic test/topic QoS 0 content <ByteString@64fe2c6c size=12 contents="Hello World!">
[INFO ] 2023-06-15 19:03:32.112 [pool-2-thread-1] AgentControlImpl - UnsubscribeMqtt: unsubscribe on connectionId 1
[INFO ] 2023-06-15 19:03:32.256 [pool-2-thread-1] AgentTestScenario - Unsubscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-06-15 19:03:47.394 [pool-2-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 1 closed
[INFO ] 2023-06-15 19:03:47.417 [pool-2-thread-1] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-06-15 19:03:47.446 [grpc-default-executor-0] GRPCDiscoveryServer - UnregisterAgent: agentId best-thing-akezhan reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-06-15 19:03:47.448 [grpc-default-executor-0] ExampleControl - Agent best-thing-akezhan is disconnected
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

