### PR TITLE
fix(uat): fixed reasonCode on publish in paho-client

### DIFF
--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
@@ -49,6 +49,7 @@ public class MqttConnectionImpl implements MqttConnection {
     private final IMqttAsyncClient client;
     private final ExecutorService executorService = Executors.newSingleThreadExecutor();
     private int connectionId = 0;
+    static final int REASON_CODE_SUCCESS = 0;
     private static final long QUIESCE_TIMEOUT = 30_000L;
 
     /**
@@ -156,7 +157,7 @@ public class MqttConnectionImpl implements MqttConnection {
             if (response.getReasonCodes() != null && response.getReasonCodes().length > 0) {
                 builder.setReasonCode(response.getReasonCodes()[0]);
             } else {
-                builder.setReasonCode(0);
+                builder.setReasonCode(REASON_CODE_SUCCESS);
             }
 
             MqttProperties responseProps = response.getResponseProperties();

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
@@ -153,11 +153,10 @@ public class MqttConnectionImpl implements MqttConnection {
             IMqttToken response = client.publish(message.getTopic(), mqttMessage);
             response.waitForCompletion(TimeUnit.SECONDS.toMillis(timeout));
 
-            if (response.getReasonCodes().length > 0) {
+            if (response.getReasonCodes() != null && response.getReasonCodes().length > 0) {
                 builder.setReasonCode(response.getReasonCodes()[0]);
             } else {
-                logger.error("Publish response doesn't have reason code");
-                throw new RuntimeException("Publish response doesn't have reason code");
+                builder.setReasonCode(0);
             }
 
             MqttProperties responseProps = response.getResponseProperties();


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-254
Fixed reasonCode on publish in paho-client

**Description of changes:**
- fixed reasonCode on publish in paho-client

**Why is this change necessary:**
for correct working of clients

**How was this change tested:**
Scenarios run manually and on CI

**Client' log:**
```
Given my device is registered as a Thing....................................passed
And my device is running Greengrass.........................................passed
When I create a Greengrass deployment with components.......................passed
And I create client device "publisher"......................................passed
And I create client device "subscriber".....................................passed
When I associate "subscriber" with ggc......................................passed
When I associate "publisher" with ggc.......................................passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:.passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.client.Mqtt5JavaPahoClient configuration to:.passed
And I deploy the Greengrass deployment configuration........................passed
Then the Greengrass deployment is COMPLETED on the device after 5 minutes...passed
And the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes.passed
Then I discover core device broker as "localMqttBroker1" from "publisher" in OTF.passed
Then I discover core device broker as "localMqttBroker2" from "subscriber" in OTF.passed
And I connect device "publisher" on aws.greengrass.client.Mqtt5JavaPahoClient to "localMqttBroker1" using mqtt "v5".passed
And I connect device "subscriber" on aws.greengrass.client.Mqtt5JavaPahoClient to "localMqttBroker2" using mqtt "v5".passed
And I set MQTT publish retain flag to true..................................passed
When I publish from "publisher" to "iot_data_001" with qos 0 and message "Old retained message".passed
When I publish from "publisher" to "iot_data_001" with qos 0 and message "New retained message".passed
And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_SUBSCRIPTION".passed
When I subscribe "subscriber" to "iot_data_001" with qos 0..................passed
And message "Old retained message" is not received on "subscriber" from "iot_data_001" topic within 5 seconds.passed
And message "New retained message" received on "subscriber" from "iot_data_001" topic within 5 seconds.passed
And I set MQTT publish retain flag to true..................................passed
When I publish from "publisher" to "iot_data_002" with qos 0 and message "Old retained message 002".passed
And I set MQTT publish retain flag to false.................................passed
When I publish from "publisher" to "iot_data_002" with qos 0 and message "New retained message 002".passed
When I subscribe "subscriber" to "iot_data_002" with qos 0..................passed
And message "New retained message 002" is not received on "subscriber" from "iot_data_002" topic within 5 seconds.passed
And message "Old retained message 002" received on "subscriber" from "iot_data_002" topic within 5 seconds.passed
And I set MQTT publish retain flag to true..................................passed
When I publish from "publisher" to "iot_data_0" with qos 0 and message "Hello world0".passed
And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_SUBSCRIPTION".passed
When I subscribe "subscriber" to "iot_data_0" with qos 0....................passed
And message "Hello world0" received on "subscriber" from "iot_data_0" topic within 5 seconds.passed
And I clear message storage.................................................passed
When I subscribe "subscriber" to "iot_data_0" with qos 0....................passed
And message "Hello world0" received on "subscriber" from "iot_data_0" topic within 5 seconds.passed
When I publish from "publisher" to "retained/iot_data_1" with qos 1 and message "Hello world1" and expect status 16.passed
And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_NEW_SUBSCRIPTION".passed
When I subscribe "subscriber" to "retained/iot_data_1" with qos 0...........passed
And message "Hello world1" received on "subscriber" from "retained/iot_data_1" topic within 5 seconds.passed
And I clear message storage.................................................passed
When I subscribe "subscriber" to "retained/iot_data_1" with qos 0...........passed
And message "Hello world1" is not received on "subscriber" from "retained/iot_data_1" topic within 5 seconds.passed
When I publish from "publisher" to "iot_data_2" with qos 0 and message "Hello world2".passed
And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_DO_NOT_SEND_AT_SUBSCRIPTION".passed
When I subscribe "subscriber" to "iot_data_2" with qos 0....................passed
And message "Hello world2" is not received on "subscriber" from "iot_data_2" topic within 5 seconds.passed
And I set MQTT publish retain flag to false.................................passed
When I publish from "publisher" to "iot_data_3" with qos 0 and message "Hello world3".passed
And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_SUBSCRIPTION".passed
When I subscribe "subscriber" to "iot_data_3" with qos 0....................passed
And message "Hello world3" is not received on "subscriber" from "iot_data_3" topic within 5 seconds.passed
When I publish from "publisher" to "iot_data_4" with qos 0 and message "Hello world4".passed
And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_NEW_SUBSCRIPTION".passed
When I subscribe "subscriber" to "iot_data_4" with qos 0....................passed
And message "Hello world4" is not received on "subscriber" from "iot_data_4" topic within 5 seconds.passed
When I publish from "publisher" to "iot_data_5" with qos 0 and message "Hello world5".passed
And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_DO_NOT_SEND_AT_SUBSCRIPTION".passed
When I subscribe "subscriber" to "iot_data_5" with qos 0....................passed
And message "Hello world5" is not received on "subscriber" from "iot_data_5" topic within 5 seconds.passed
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

