### PR TITLE
feat(uat): add handling content type for RX/TX to mosquitto client; update Control

### DIFF
--- a/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
@@ -246,6 +246,13 @@ Status GRPCControlServer::PublishMqtt(ServerContext *, const MqttPublishRequest 
         return Status(StatusCode::INVALID_ARGUMENT, "missing connectionId");
     }
 
+    std::string content_type;
+    std::string * p_content_type = NULL;
+    if (message.has_contenttype()) {
+        content_type = message.contenttype();
+        p_content_type = &content_type;
+    }
+
     const MqttConnectionId & connection_id_obj = request->connectionid();
     int connection_id = connection_id_obj.connectionid();
 
@@ -259,7 +266,9 @@ Status GRPCControlServer::PublishMqtt(ServerContext *, const MqttPublishRequest 
     }
 
     try {
-        ClientControl::MqttPublishReply * result = connection->publish(timeout, qos, is_retain, topic, message.payload(), message.properties());
+        ClientControl::MqttPublishReply * result = connection->publish(timeout, qos, is_retain, topic,
+                                                                        message.payload(), message.properties(),
+                                                                        p_content_type);
         if (result) {
             if (result->has_reasoncode()) {
                 reply->set_reasoncode(result->reasoncode());

--- a/uat/custom-components/client-mosquitto-c/src/MqttConnection.h
+++ b/uat/custom-components/client-mosquitto-c/src/MqttConnection.h
@@ -95,7 +95,7 @@ public:
      *
      * @param timeout the timeout in seconds to subscribe
      * @param filters the filters of topics subscribe to
-     * @param user_properties the user properties of the SUBCRIBE request
+     * @param user_properties the user properties of the UNSUBCRIBE request
      * @param reply the subscribe reply to update
      * @throw MqttException on errors
      */
@@ -111,13 +111,15 @@ public:
      * @param is_retain the retain flag
      * @param topic the topic to publish
      * @param payload the payload of the message
-     * @param user_properties the user properties of the SUBCRIBE request
+     * @param user_properties the user properties of the PUBLISH request
+     * @param content_type the optional content type
      * @return pointer to allocated gRPC MqttPublishReply
      * @throw MqttException on errors
      */
     ClientControl::MqttPublishReply * publish(unsigned timeout, int qos, bool is_retain, const std::string & topic,
                                                 const std::string & payload,
-                                                const RepeatedPtrField<ClientControl::Mqtt5Properties> & user_properties);
+                                                const RepeatedPtrField<ClientControl::Mqtt5Properties> & user_properties,
+                                                const std::string * content_type);
 
     /**
      * Disconnect from the broker.

--- a/uat/proto/mqtt_client_control.proto
+++ b/uat/proto/mqtt_client_control.proto
@@ -35,6 +35,7 @@ message Mqtt5Message {
     MqttQoS qos = 3;
     bool retain = 4;
     repeated Mqtt5Properties properties = 5;
+    optional string contentType = 6;
 };
 
 // End of common part


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-180
Set payload content type (publish)

**Description of changes:**
- Add contentType field to Mqtt5Message of protocol
- Add handling contentType in mosquitto client for PUBLISH message for both TX and RX sides
- Update application of Control to pass content type to publish request and log content type from received messages

**Why is this change necessary:**

**How was this change tested:**
Currently manually by run Control as application.
In future we will add scenario to test that feature.

**Test results:**
Control:
```
[INFO ] 2023-06-19 19:09:28.925 [com.aws.greengrass.testing.mqtt.client.control.ExampleControl.main()] ExampleControl - Control: port 47619, with TLS, MQTT v5
[INFO ] 2023-06-19 19:09:29.215 [com.aws.greengrass.testing.mqtt.client.control.ExampleControl.main()] EngineControlImpl - MQTT client control gRPC server started, listening on 47619
[INFO ] 2023-06-19 19:09:30.984 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId agent-mosquitto
[INFO ] 2023-06-19 19:09:31.003 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId agent-mosquitto address 127.0.0.1 port 43107
[INFO ] 2023-06-19 19:09:31.006 [grpc-default-executor-0] EngineControlImpl - Created new agent control for agent-mosquitto on 127.0.0.1:43107
[INFO ] 2023-06-19 19:09:31.063 [grpc-default-executor-0] ExampleControl - Agent agent-mosquitto is connected
[INFO ] 2023-06-19 19:09:31.067 [pool-2-thread-1] AgentTestScenario - Playing test scenario for agent id agent-mosquitto
[INFO ] 2023-06-19 19:09:34.084 [pool-2-thread-1] AgentTestScenario - Connect MQTT userProperties: region, US
[INFO ] 2023-06-19 19:09:34.084 [pool-2-thread-1] AgentTestScenario - Connect MQTT userProperties: type, JSON
[INFO ] 2023-06-19 19:09:34.425 [pool-2-thread-1] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
reasonCode: 0
receiveMaximum: 100
maximumQoS: 1
retainAvailable: true
maximumPacketSize: 149504
wildcardSubscriptionsAvailable: true
subscriptionIdentifiersAvailable: false
sharedSubscriptionsAvailable: true
serverKeepAlive: 60
topicAliasMaximum: 8
'
[INFO ] 2023-06-19 19:09:34.425 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-06-19 19:09:34.426 [pool-2-thread-1] AgentTestScenario - MQTT connection with id 1 is established
[INFO ] 2023-06-19 19:09:39.430 [pool-2-thread-1] AgentTestScenario - Subscribe MQTT userProperties: region, US
[INFO ] 2023-06-19 19:09:39.430 [pool-2-thread-1] AgentTestScenario - Subscribe MQTT userProperties: type, JSON
[INFO ] 2023-06-19 19:09:39.438 [pool-2-thread-1] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-06-19 19:09:39.520 [pool-2-thread-1] AgentTestScenario - Subscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-06-19 19:09:44.526 [pool-2-thread-1] AgentTestScenario - Publish MQTT userProperties: region, US
[INFO ] 2023-06-19 19:09:44.527 [pool-2-thread-1] AgentTestScenario - Publish MQTT userProperties: type, JSON
[INFO ] 2023-06-19 19:09:44.533 [pool-2-thread-1] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic test/topic
[INFO ] 2023-06-19 19:09:44.573 [pool-2-thread-1] AgentTestScenario - Published connectionId 1 reason code 0 reason string ''
[INFO ] 2023-06-19 19:09:44.574 [grpc-default-executor-0] GRPCDiscoveryServer - OnReceiveMessage: agentId agent-mosquitto connectionId 1 topic test/topic QoS 0
[INFO ] 2023-06-19 19:09:44.575 [grpc-default-executor-0] AgentTestScenario - Message received on agentId agent-mosquitto connectionId 1 topic test/topic QoS 0 content <ByteString@2d96c133 size=12 contents="Hello World!">
[INFO ] 2023-06-19 19:09:44.575 [grpc-default-executor-0] AgentTestScenario - Message has user property key region value US
[INFO ] 2023-06-19 19:09:44.576 [grpc-default-executor-0] AgentTestScenario - Message has user property key type value JSON
[INFO ] 2023-06-19 19:09:44.576 [grpc-default-executor-0] AgentTestScenario - Message has content type text/plain; charset=utf-8
[INFO ] 2023-06-19 19:09:49.574 [pool-2-thread-1] AgentTestScenario - Unsubscribe MQTT userProperties: region, US
[INFO ] 2023-06-19 19:09:49.574 [pool-2-thread-1] AgentTestScenario - Unsubscribe MQTT userProperties: type, JSON
[INFO ] 2023-06-19 19:09:49.578 [pool-2-thread-1] AgentControlImpl - UnsubscribeMqtt: unsubscribe on connectionId 1
[INFO ] 2023-06-19 19:09:49.630 [pool-2-thread-1] AgentTestScenario - Unsubscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-06-19 19:10:04.631 [pool-2-thread-1] AgentTestScenario - Disconnect MQTT userProperties: region, US
[INFO ] 2023-06-19 19:10:04.631 [pool-2-thread-1] AgentTestScenario - Disconnect MQTT userProperties: type, JSON
[INFO ] 2023-06-19 19:10:04.650 [grpc-default-executor-0] GRPCDiscoveryServer - OnMqttDisconnect: agentId agent-mosquitto connectionId 1 disconnect 'reasonCode: 0
' error ''
[INFO ] 2023-06-19 19:10:04.650 [grpc-default-executor-0] AgentTestScenario - MQTT disconnected on agentId agent-mosquitto connectionId 1 disconnect 'reasonCode: 0
' error ''
[INFO ] 2023-06-19 19:10:04.653 [pool-2-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 1 closed
[INFO ] 2023-06-19 19:10:04.659 [pool-2-thread-1] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-06-19 19:10:04.666 [grpc-default-executor-0] GRPCDiscoveryServer - UnregisterAgent: agentId agent-mosquitto reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-06-19 19:10:04.668 [grpc-default-executor-0] ExampleControl - Agent agent-mosquitto is disconnected
```

Mosquitto client:
```
[DEBUG]: Initialize gRPC library
[DEBUG]: Making gPRC link with 127.0.0.1:47619 as agent_id 'agent-mosquitto'
[DEBUG]: Sending RegisterAgent request with agent_id agent-mosquitto
[DEBUG]: Local address is 127.0.0.1
[DEBUG]: GRPCControlServer created and listed on 127.0.0.1:43107
[DEBUG]: Sending DiscoveryAgent request agent_id 'agent-mosquitto' host:port 127.0.0.1:43107
[DEBUG]: gPRC link established with 127.0.0.1:47619 as agent_id 'agent-mosquitto'
[DEBUG]: Initialize Mosquitto MQTT library
[DEBUG]: Mosquitto library version 2.0.15
[DEBUG]: Handle gRPC requests
[DEBUG]: CreateMqttConnection client_id 'GGMQ-test-device2' broker a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[DEBUG]: Creating Mosquitto MQTT v5 connection for a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[DEBUG]: Copied TX user property region:US
[DEBUG]: Copied TX user property type:JSON
[DEBUG]: Establishing Mosquitto MQTT v5 connection to a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883 in 10 seconds
[DEBUG]: Use provided TLS credentials
[DEBUG]: mosquitto: Client GGMQ-test-device2 sending CONNECT
[DEBUG]: mosquitto: Client GGMQ-test-device2 received CONNACK (0)
[DEBUG]: onConnect rc 0 flags 0 props 0x7f8118010780
[DEBUG]: Establishing MQTT connection to a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883 completed with reason code 0
[DEBUG]: Connection registered with id 1
[DEBUG]: Subscription: filter test/topic QoS 0 noLocal 0 retainAsPublished 0 retainHandling 2
[DEBUG]: SubscribeMqtt connection_id 1
[DEBUG]: Copied TX user property region:US
[DEBUG]: Copied TX user property type:JSON
[DEBUG]: mosquitto: Client GGMQ-test-device2 sending SUBSCRIBE (Mid: 1, Topic: test/topic, QoS: 0, Options: 0x20)
[DEBUG]: mosquitto: Client GGMQ-test-device2 received SUBACK
[DEBUG]: onSubscribe mid 1 qos_count 1 granted_qos 0x7f8118014040 props (nil)
[DEBUG]: Subscribed on filters 'test/topic,' QoS 0 no local 0 retain as published 0 retain handing 2 with message id 1
[DEBUG]: Copied RX reason code 0
[DEBUG]: PublishMqtt connection_id 1 topic test/topic retain 0
[DEBUG]: Copied TX content type "text/plain; charset=utf-8"
[DEBUG]: Copied TX user property region:US
[DEBUG]: Copied TX user property type:JSON
[DEBUG]: mosquitto: Client GGMQ-test-device2 sending PUBLISH (d0, q1, r0, m2, 'test/topic', ... (12 bytes))
[DEBUG]: mosquitto: Client GGMQ-test-device2 received PUBACK (Mid: 2, RC:0)
[DEBUG]: onPublish mid 2 rc 0 props (nil)
[DEBUG]: Published on topic 'test/topic' QoS 1 retain 0 with rc 0 message id 2
[DEBUG]: mosquitto: Client GGMQ-test-device2 received PUBLISH (d0, q0, r0, m0, 'test/topic', ... (12 bytes))
[DEBUG]: onMessage message 0x7f8118015908 props 0x7f8118011f00
[DEBUG]: Copied RX content type "text/plain; charset=utf-8"
[DEBUG]: Copied RX user property region:US
[DEBUG]: Copied RX user property type:JSON
[DEBUG]: Sending OnReceiveMessage request agent_id 'agent-mosquitto' connection_id 1
[DEBUG]: UnsubscribeMqtt connection_id 1
[DEBUG]: Copied TX user property region:US
[DEBUG]: Copied TX user property type:JSON
[DEBUG]: mosquitto: Client GGMQ-test-device2 sending UNSUBSCRIBE (Mid: 3, Topic: test/topic)
[DEBUG]: mosquitto: Client GGMQ-test-device2 received UNSUBACK
[DEBUG]: onUnsubscribe mid 3 props (nil)
[DEBUG]: Unsubscribed from filters 'test/topic,' with message id 3
[DEBUG]: Copied RX reason code 0
[DEBUG]: CloseMqttConnection connection_id 1 reason 4
[DEBUG]: Disconnect Mosquitto MQTT connection with reason code 4
[DEBUG]: Copied TX user property region:US
[DEBUG]: Copied TX user property type:JSON
[DEBUG]: mosquitto: Client GGMQ-test-device2 sending DISCONNECT
[DEBUG]: onDisconnect rc 0 props (nil)
[DEBUG]: Sending OnMqttDisconnect request agent_id 'agent-mosquitto' connection_id 1 error '(null)'
[DEBUG]: Destroy Mosquitto MQTT connection
[DEBUG]: ShutdownAgent with reason 'That's it.'
[DEBUG]: Shutdown gPRC link
[DEBUG]: Sending UnregisterAgent request agent_id 'agent-mosquitto' reason 'Agent shutdown by OTF request 'That's it.''
[DEBUG]: Shutdown MQTT library
[DEBUG]: Shutdown gRPC library
[DEBUG]: Execution done
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
