### PR TITLE
feat(uat): implement disconnect

### DIFF
--- a/uat/custom-components/client-python-paho/src/grpc_client_server/grpc_discovery_client.py
+++ b/uat/custom-components/client-python-paho/src/grpc_client_server/grpc_discovery_client.py
@@ -4,13 +4,13 @@
 #
 
 """Client of gRPC MqttAgentDiscovery service."""
-# pylint: disable=no-member
+# pylint: disable=no-member,no-name-in-module
 import logging
 
 import grpc
-from grpc_client_server.grpc_generated import mqtt_client_control_pb2_grpc
-from grpc_client_server.grpc_generated import mqtt_client_control_pb2
 from exceptions.grpc_exception import GRPCException
+from grpc_client_server.grpc_generated.mqtt_client_control_pb2 import Mqtt5Disconnect, MqttConnectionId
+from grpc_client_server.grpc_generated import mqtt_client_control_pb2_grpc, mqtt_client_control_pb2
 
 
 GRPC_REQUEST_FAILED = "gRPC request failed"
@@ -94,12 +94,33 @@ class GRPCDiscoveryClient:
         """
         # TODO
 
-    def on_mqtt_disconnect(self):
+    def on_mqtt_disconnect(self, connection_id: int, disconnect_info: Mqtt5Disconnect, error_string: str):
         """
         Called when MQTT connection has been
         disconnected by client or server side.
+        Parameters
+        ----------
+        connection_id - ID of disconnected connection
+        disconnect_info - disconnect information
+        error_string - specific error information
         """
-        # TODO
+        mqtt_connection_id = MqttConnectionId(connectionId=connection_id)
+        request = mqtt_client_control_pb2.OnMqttDisconnectRequest(
+            agentId=self.__agent_id, connectionId=mqtt_connection_id, disconnect=disconnect_info, error=error_string
+        )
+
+        self.__logger.info(
+            "Sending OnMqttDisconnect request agent_id '%s' connection_id %i error '%s'",
+            self.__agent_id,
+            connection_id,
+            error_string,
+        )
+
+        try:
+            self.__stub.OnMqttDisconnect(request)
+        except grpc.RpcError as error:
+            self.__logger.exception(GRPC_REQUEST_FAILED)
+            raise GRPCException(error) from error
 
     def close(self):
         """Closes the gRPC client."""

--- a/uat/custom-components/client-python-paho/src/logger_setup/logger_setup.py
+++ b/uat/custom-components/client-python-paho/src/logger_setup/logger_setup.py
@@ -9,4 +9,8 @@ import logging
 
 def setup_log():
     """Function sets logger formating."""
-    logging.basicConfig(format="%(name)s: [%(levelname)s] %(message)s", level=logging.DEBUG)
+    logging.basicConfig(
+        format="[%(levelname)-5s] %(asctime)s.%(msecs)03d %(name)s - %(message)s",
+        level=logging.INFO,
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )

--- a/uat/custom-components/client-python-paho/src/mqtt_lib/mqtt_connection.py
+++ b/uat/custom-components/client-python-paho/src/mqtt_lib/mqtt_connection.py
@@ -8,6 +8,7 @@
 import asyncio
 import logging
 import socket
+import time
 
 from dataclasses import dataclass
 
@@ -15,6 +16,8 @@ import paho.mqtt.client as mqtt
 
 from paho.mqtt import MQTTException as PahoException
 from paho.mqtt.properties import Properties
+from paho.mqtt.reasoncodes import ReasonCodes
+from paho.mqtt.packettypes import PacketTypes
 
 from grpc_client_server.grpc_discovery_client import GRPCDiscoveryClient
 from mqtt_lib.temp_files_manager import TempFilesManager
@@ -26,8 +29,9 @@ class MqttResult:
     """Class MqttResult"""
 
     reason_code: int
-    flags: dict
-    properties: Properties
+    flags: dict = None
+    properties: Properties = None
+    error_string: str = ""
     mid: int = 0
 
 
@@ -92,8 +96,11 @@ class ConnectResult:  # pylint: disable=too-many-instance-attributes
 class AsyncioHelper:
     """Class Asyncio helper for the Paho MQTT"""
 
+    logger = logging.getLogger("AsyncioHelper")
+
     def __init__(self, loop, client):
         """Construct AsyncioHelper"""
+        self.__logger = AsyncioHelper.logger
         self.misc = None
         self.loop = loop
         self.client = client
@@ -109,17 +116,19 @@ class AsyncioHelper:
             """Loop Reader callback"""
             client.loop_read()
 
+        self.__logger.debug("On socket open")
         self.loop.add_reader(sock, callback)
         self.misc = self.loop.create_task(self.misc_loop())
 
     def on_socket_close(self, client, userdata, sock):  # pylint: disable=unused-argument
         """Client socket close callback"""
-
+        self.__logger.debug("On socket close")
         self.loop.remove_reader(sock)
         self.misc.cancel()
 
     def on_socket_register_write(self, client, userdata, sock):  # pylint: disable=unused-argument
         """Client socket register write"""
+        self.__logger.debug("On socket register write")
 
         def callback():
             client.loop_write()
@@ -128,7 +137,7 @@ class AsyncioHelper:
 
     def on_socket_unregister_write(self, client, userdata, sock):  # pylint: disable=unused-argument
         """Client socket unregister write"""
-
+        self.__logger.debug("On socket unregister write")
         self.loop.remove_writer(sock)
 
     async def misc_loop(self):
@@ -172,8 +181,9 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
         self.__client = self.__create_client(self.__connection_params)
         # TODO delete 2 suppress warnings
         self.__grpc_client = grpc_client  # pylint: disable=unused-private-member
-        self.__connection_id = 0  # pylint: disable=unused-private-member
+        self.__connection_id = 0
         self.__on_connect_future = None
+        self.__on_disconnect_future = None
         self.__asyncio_helper = None  # pylint: disable=unused-private-member
         self.__loop = asyncio.get_running_loop()
 
@@ -184,8 +194,16 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
         ----------
         connection_id - connection id as assigned by MQTT library
         """
-        # TODO delete suppress warnings
-        self.__connection_id = connection_id  # pylint: disable=unused-private-member
+        self.__connection_id = connection_id
+
+    async def __connect_helper(self, host, port, keep_alive, clean_start):
+        """MQTT Connect async wrapper."""
+        self.__client.connect(
+            host=host,
+            port=port,
+            keepalive=keep_alive,
+            clean_start=clean_start,
+        )
 
     async def start(self, timeout: int) -> ConnectResult:
         """
@@ -196,6 +214,7 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
         Returns connection result
         """
         self.__client.on_connect = self.__on_connect
+        self.__client.on_disconnect = self.__on_disconnect
         self.__asyncio_helper = AsyncioHelper(self.__loop, self.__client)  # pylint: disable=unused-private-member
 
         clean_start = self.__connection_params.clean_session
@@ -204,18 +223,41 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
         if self.__protocol == mqtt.MQTTv311:
             clean_start = mqtt.MQTT_CLEAN_START_FIRST_ONLY
 
+        self.__logger.info("MQTT connection ID %i connecting...", self.__connection_id)
+
         try:
             self.__on_connect_future = self.__loop.create_future()
-            self.__client.connect(
+            start_time = int(time.time())
+
+            connect_awaitable = self.__connect_helper(
                 host=self.__connection_params.host,
                 port=self.__connection_params.port,
-                keepalive=self.__connection_params.keep_alive,
+                keep_alive=self.__connection_params.keep_alive,
                 clean_start=clean_start,
             )
 
-            result = await asyncio.wait_for(self.__on_connect_future, timeout)
+            await asyncio.wait_for(connect_awaitable, timeout)
+
+            passed_time = int(time.time()) - start_time
+            remaining_timeout = max(timeout - passed_time, 0)
+
+            result = await asyncio.wait_for(self.__on_connect_future, remaining_timeout)
             conn_ack_info = MqttConnection.convert_to_conn_ack(result)
-            return ConnectResult(connected=True, conn_ack_info=conn_ack_info, error=None)
+
+            connected = True
+            if conn_ack_info.reason_code == mqtt.MQTT_ERR_SUCCESS:
+                self.__logger.info(
+                    "MQTT connection ID %s connected, client id %s",
+                    self.__connection_id,
+                    self.__connection_params.client_id,
+                )
+            else:
+                connected = False
+                self.__logger.info(
+                    "MQTT connection ID %s failed with error: %s", self.__connection_id, result.error_string
+                )
+
+            return ConnectResult(connected=connected, conn_ack_info=conn_ack_info, error=result.error_string)
         except asyncio.TimeoutError:
             self.__logger.exception("Exception occurred during connect")
             return ConnectResult(connected=False, conn_ack_info=None, error="Connect timeout error")
@@ -225,20 +267,73 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
         except Exception as error:
             self.__logger.exception("Exception occurred during connect")
             raise MQTTException from error
+        finally:
+            self.__on_connect_future = None
 
     def __on_connect(
         self, client, userdata, flags, reason_code, properties=None
     ):  # pylint: disable=unused-argument,too-many-arguments
         """
-        Paho MQTT callback
+        Paho MQTT connect callback
         """
         mqtt_reason_code = reason_code
+        error_string = None
+
         if hasattr(reason_code, "value"):
             mqtt_reason_code = reason_code.value
-        mqtt_result = MqttResult(reason_code=mqtt_reason_code, flags=flags, properties=properties)
+            error_string = str(reason_code)
+        else:
+            error_string = mqtt.error_string(reason_code)
+
+        mqtt_result = MqttResult(
+            reason_code=mqtt_reason_code, flags=flags, properties=properties, error_string=error_string
+        )
         try:
             if self.__on_connect_future is not None:
                 self.__on_connect_future.set_result(mqtt_result)
+        except asyncio.InvalidStateError:
+            pass
+
+    async def disconnect(self, timeout: int, reason: int):
+        """
+        Closes MQTT connection.
+        Parameters
+        ----------
+        timeout - connect operation timeout in seconds
+        reason - disconnect reason code
+        """
+        self.__logger.info("Disconnect MQTT connection with reason code %i", reason)
+        self.__on_disconnect_future = self.__loop.create_future()
+
+        try:
+            if self.__protocol == mqtt.MQTTv5:
+                reason_code_obj = ReasonCodes(PacketTypes.DISCONNECT, identifier=reason)
+                self.__client.disconnect(reasoncode=reason_code_obj)
+            else:
+                self.__client.disconnect()
+
+            result = await asyncio.wait_for(self.__on_disconnect_future, timeout)
+        except TimeoutError as error:
+            raise MQTTException("Couldn't disconnect from MQTT broker") from error
+
+        self.__on_disconnect_future = None
+
+        if result.reason_code != mqtt.MQTT_ERR_SUCCESS:
+            raise MQTTException(f"Couldn't disconnect from MQTT broker - rc {result.reason_code}")
+
+    def __on_disconnect(self, client, userdata, reason_code, properties=None):  # pylint: disable=unused-argument
+        """
+        Paho MQTT disconnect callback
+        """
+        mqtt_reason_code = reason_code
+
+        if hasattr(reason_code, "value"):
+            mqtt_reason_code = reason_code.value
+
+        mqtt_result = MqttResult(reason_code=mqtt_reason_code)
+        try:
+            if self.__on_disconnect_future is not None:
+                self.__on_disconnect_future.set_result(mqtt_result)
         except asyncio.InvalidStateError:
             pass
 
@@ -311,20 +406,27 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
 
         # Clean Session is used only for the MQTT 3
         if self.__protocol == mqtt.MQTTv311:
+            protocol_version_for_log = "3.1.1"
             client = mqtt.Client(
                 connection_params.client_id, protocol=self.__protocol, clean_session=connection_params.clean_session
             )
         else:
+            protocol_version_for_log = "5"
             client = mqtt.Client(connection_params.client_id, protocol=self.__protocol)
+
+        tls_for_log = "without TLS"
 
         if (
             (connection_params.ca_cert is not None)
             and (connection_params.cert is not None)
             and (connection_params.key is not None)
         ):
+            tls_for_log = "with TLS"
             ca_path = self.__temp_files_manager.create_new_temp_file(connection_params.ca_cert)
             cert_path = self.__temp_files_manager.create_new_temp_file(connection_params.cert)
             key_path = self.__temp_files_manager.create_new_temp_file(connection_params.key)
             client.tls_set(ca_certs=ca_path, certfile=cert_path, keyfile=key_path)
+
+        self.__logger.info("Creating MQTT %s client %s", protocol_version_for_log, tls_for_log)
 
         return client


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-138

**Description of changes:**
- Implement Disconnect feature
- Update logger formatting

**Why is this change necessary:**
- Part of Python Paho client implementation

**How was this change tested:**
Manual run of mqtt-client-control and python client.
MQTT connect and disconnect are successful, other commands are not implemented. Linking and shutdown steps are successful.

**Test results:**
Python Paho client output
```
client-python-paho.exe python-paho-mqtt
[DEBUG] 2023-06-19 23:16:26.198 asyncio - Using selector: SelectSelector
[INFO ] 2023-06-19 23:16:26.201 GRPCLib - Initialize gRPC library
[INFO ] 2023-06-19 23:16:26.201 GRPCLink - Making gPRC client connection with 127.0.0.1:47619 as python-paho-mqtt...
[INFO ] 2023-06-19 23:16:26.357 GRPCLink - Client connection with Control is established, local address is 127.0.0.1
[DEBUG] 2023-06-19 23:16:26.358 grpc._cython.cygrpc - Using AsyncIOEngine.POLLER as I/O engine
[INFO ] 2023-06-19 23:16:26.432 MQTTLib - Initialize Paho MQTT library
[INFO ] 2023-06-19 23:16:26.432 GRPCLink - Handle gRPC requests
[INFO ] 2023-06-19 23:16:26.432 GRPCControlServer - Server awaiting termination
[INFO ] 2023-06-19 23:16:29.483 GRPCControlServer - createMqttConnection: clientId Python_Paho_Client broker a3t8vwpkw3sltg-ats.iot.eu-west-1.amazonaws.com:8883
[INFO ] 2023-06-19 23:16:29.500 MqttConnection - Creating MQTT 5 client with TLS
[INFO ] 2023-06-19 23:16:29.501 MqttConnection - MQTT connection ID 0 connecting...
[DEBUG] 2023-06-19 23:16:29.879 AsyncioHelper - On socket open
[DEBUG] 2023-06-19 23:16:29.879 AsyncioHelper - On socket register write
[DEBUG] 2023-06-19 23:16:29.881 AsyncioHelper - On socket unregister write
[INFO ] 2023-06-19 23:16:30.073 MqttConnection - MQTT connection ID 0 connected, client id Python_Paho_Client
[INFO ] 2023-06-19 23:16:35.159 GRPCControlServer - SubscribeMqtt Placeholder TODO
[INFO ] 2023-06-19 23:16:40.174 GRPCControlServer - PublishMqtt Placeholder TODO
[INFO ] 2023-06-19 23:16:45.184 GRPCControlServer - UnsubscribeRequest Placeholder TODO
[INFO ] 2023-06-19 23:17:00.191 GRPCControlServer - CloseMqttConnection connection_id 0 reason 4
[INFO ] 2023-06-19 23:17:00.192 MqttConnection - Disconnect MQTT connection with reason code 4
[DEBUG] 2023-06-19 23:17:00.195 AsyncioHelper - On socket register write
[INFO ] 2023-06-19 23:17:00.197 GRPCDiscoveryClient - Sending OnMqttDisconnect request agent_id 'python-paho-mqtt' connection_id 0 error 'None'
[DEBUG] 2023-06-19 23:17:00.207 AsyncioHelper - On socket unregister write
[DEBUG] 2023-06-19 23:17:00.207 AsyncioHelper - On socket close
[INFO ] 2023-06-19 23:17:00.218 GRPCControlServer - shutdownAgent: reason That's it.
[INFO ] 2023-06-19 23:17:00.221 GRPCControlServer - Server termination done
[INFO ] 2023-06-19 23:17:00.222 GRPCLink - Shutdown gPRC link
[INFO ] 2023-06-19 23:17:00.234 Main - Execution done successfully
```
Mqtt Client Control output
```
java -Dmqtt_client_id=Python_Paho_Client -Dmqtt_broker_addr=a3t8vwpkw3sltg-ats.iot.eu-west-1.amazonaws.com -Dmqtt_client_ca_file=creds_aws/rootCA.pem -Dmqtt_client_cert_file=creds_aws/thingCert.crt -Dmqtt_client_key_file=creds_aws/privKey.key -jar target/aws-greengrass-testing-mqtt-client-control.jar 47619 true true
[INFO ] 2023-06-19 23:16:21.580 [main] ExampleControl - Control: port 47619, with TLS, MQTT v5
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
[INFO ] 2023-06-19 23:16:23.007 [main] EngineControlImpl - MQTT client control gRPC server started, listening on 47619
[INFO ] 2023-06-19 23:16:26.343 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId python-paho-mqtt
[INFO ] 2023-06-19 23:16:26.364 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId python-paho-mqtt address 127.0.0.1 port 59036
[INFO ] 2023-06-19 23:16:26.368 [grpc-default-executor-0] EngineControlImpl - Created new agent control for python-paho-mqtt on 127.0.0.1:59036
[INFO ] 2023-06-19 23:16:26.420 [grpc-default-executor-0] ExampleControl - Agent python-paho-mqtt is connected
[INFO ] 2023-06-19 23:16:26.429 [pool-2-thread-1] AgentTestScenario - Playing test scenario for agent id python-paho-mqtt
[INFO ] 2023-06-19 23:16:30.144 [pool-2-thread-1] AgentControlImpl - Created connection with id 0 CONNACK 'sessionPresent: false
reasonCode: 0
receiveMaximum: 100
maximumQoS: 1
retainAvailable: true
maximumPacketSize: 149504
wildcardSubscriptionsAvailable: true
subscriptionIdentifiersAvailable: false
sharedSubscriptionsAvailable: true
serverKeepAlive: 60
topicAliasMaximum: 8
'
[INFO ] 2023-06-19 23:16:30.144 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 0 created
[INFO ] 2023-06-19 23:16:30.147 [pool-2-thread-1] AgentTestScenario - MQTT connection with id 0 is established
[INFO ] 2023-06-19 23:16:35.154 [pool-2-thread-1] AgentControlImpl - SubscribeMqtt: subscribe on connection 0
[INFO ] 2023-06-19 23:16:35.162 [pool-2-thread-1] AgentTestScenario - Subscribe response: connectionId 0 reason codes [] reason string ''
[INFO ] 2023-06-19 23:16:40.170 [pool-2-thread-1] AgentControlImpl - PublishMqtt: publishing on connectionId 0 topic test/topic
[INFO ] 2023-06-19 23:16:40.176 [pool-2-thread-1] AgentTestScenario - Published connectionId 0 reason code 0 reason string ''
[INFO ] 2023-06-19 23:16:45.181 [pool-2-thread-1] AgentControlImpl - UnsubscribeMqtt: unsubscribe on connectionId 0
[INFO ] 2023-06-19 23:16:45.186 [pool-2-thread-1] AgentTestScenario - Unsubscribe response: connectionId 0 reason codes [] reason string ''
[INFO ] 2023-06-19 23:17:00.203 [grpc-default-executor-0] GRPCDiscoveryServer - OnMqttDisconnect: agentId python-paho-mqtt connectionId 0 disconnect 'reasonCode: 0
' error ''
[INFO ] 2023-06-19 23:17:00.204 [grpc-default-executor-0] AgentTestScenario - MQTT disconnected on agentId python-paho-mqtt connectionId 0 disconnect 'reasonCode: 0
' error ''
[INFO ] 2023-06-19 23:17:00.210 [pool-2-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 0 closed
[INFO ] 2023-06-19 23:17:00.220 [pool-2-thread-1] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-06-19 23:17:00.227 [grpc-default-executor-0] GRPCDiscoveryServer - UnregisterAgent: agentId python-paho-mqtt reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-06-19 23:17:00.229 [grpc-default-executor-0] ExampleControl - Agent python-paho-mqtt is disconnected
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
