### PR TITLE
feat(uat): add 'retain as published' handling and T103 as well

### DIFF
--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/addon/EventFilter.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/addon/EventFilter.java
@@ -192,7 +192,7 @@ public final class EventFilter {
          *
          * @param retain the retain flag of the message
          */
-        public Builder withRetain(boolean retain) {
+        public Builder withRetain(Boolean retain) {
             this.retain = retain;
             return this;
         }

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -412,7 +412,7 @@ public class MqttControlSteps {
      *
      * @param retain the new values of publish 'retain' flag.
      */
-    @And("I set MQTT publish retain flag to {booleanValue}")
+    @And("I set MQTT publish 'retain' flag to {booleanValue}")
     public void setPublishRetain(Boolean retain) {
         this.publishRetain = retain;
         log.info("Publish 'retain' flag set to {}", retain);

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -100,6 +100,7 @@ public class MqttControlSteps {
     private static final boolean DEFAULT_CONNECT_CLEAR_SESSION = true;
 
     private static final boolean DEFAULT_PUBLISH_RETAIN = false;
+    private static final Boolean DEFAULT_RECEIVED_RETAIN = null;
 
     private static final Integer DEFAULT_SUBSCRIPTION_ID = null;        // NOTE: do not set for IoT Core broker !!!
     private static final boolean DEFAULT_SUBSCRIBE_NO_LOCAL = false;
@@ -136,6 +137,9 @@ public class MqttControlSteps {
 
     /** Actual value of publish retain option. */
     private boolean publishRetain = DEFAULT_PUBLISH_RETAIN;
+
+    /** Actual expected value of retain flag in received messages. */
+    private Boolean receivedRetain = DEFAULT_RECEIVED_RETAIN;
 
 
     /** Actual list of user properties to transmit. */
@@ -332,9 +336,29 @@ public class MqttControlSteps {
         log.info("Thing {} was disconnected with reason code {}", clientDeviceId, reasonCode);
     }
 
+    /**
+     * Convert boolean string to value.
+     *
+     * @param value the string value of boolean
+     */
     @SuppressWarnings("PMD.UnnecessaryAnnotationValueElement")
     @ParameterType(value = "true|True|TRUE|false|False|FALSE")
     public Boolean booleanValue(String value) {
+        return Boolean.valueOf(value);
+    }
+
+    /**
+     * Convert boolean or null string to nullable value.
+     *
+     * @param value the string value of boolean or null
+     */
+    @SuppressWarnings("PMD.UnnecessaryAnnotationValueElement")
+    @ParameterType(value = "true|True|TRUE|false|False|FALSE|null|NULL")
+    public Boolean booleanOrNullValue(String value) {
+        if ("null".equals(value) || "NULL".equals(value)) {
+            return null;
+        }
+
         return Boolean.valueOf(value);
     }
 
@@ -346,6 +370,7 @@ public class MqttControlSteps {
     @And("I set MQTT timeout to {int} second(s)")
     public void setMqttTimeoutSec(int mqttTimeoutSec) {
         this.mqttTimeoutSec = mqttTimeoutSec;
+        log.info("MQTT timeout set to {} second(s)", mqttTimeoutSec);
     }
 
     /**
@@ -353,9 +378,10 @@ public class MqttControlSteps {
      *
      * @param subscribeNoLocal the new values of 'no local' flag.
      */
-    @And("I set MQTT subscribe no local flag to {booleanValue}")
+    @And("I set MQTT subscribe 'no local' flag to {booleanValue}")
     public void setSubscribeNoLocal(Boolean subscribeNoLocal) {
         this.subscribeNoLocal = subscribeNoLocal;
+        log.info("Subscribe 'no local' flag set to {}", subscribeNoLocal);
     }
 
     /**
@@ -363,9 +389,10 @@ public class MqttControlSteps {
      *
      * @param subscribeRetainAsPublished the new values of 'retain as published' flag.
      */
-    @And("I set MQTT subscribe retain as published flag to {booleanValue}")
+    @And("I set MQTT subscribe 'retain as published' flag to {booleanValue}")
     public void setSubscribeRetainAsPublished(Boolean subscribeRetainAsPublished) {
         this.subscribeRetainAsPublished = subscribeRetainAsPublished;
+        log.info("Subscribe 'retain as published' flag set to {}", subscribeRetainAsPublished);
     }
 
 
@@ -374,9 +401,10 @@ public class MqttControlSteps {
      *
      * @param subscribeRetainHandling the new values of 'retain handling' property.
      */
-    @And("I set MQTT subscribe retain handling property to {string}")
+    @And("I set MQTT subscribe 'retain handling' property to {string}")
     public void setSubscribeRetainHandling(String subscribeRetainHandling) {
         this.subscribeRetainHandling = Mqtt5RetainHandling.valueOf(subscribeRetainHandling);
+        log.info("Subscribe 'retain handling' property set to {}", subscribeRetainHandling);
     }
 
     /**
@@ -387,6 +415,18 @@ public class MqttControlSteps {
     @And("I set MQTT publish retain flag to {booleanValue}")
     public void setPublishRetain(Boolean retain) {
         this.publishRetain = retain;
+        log.info("Publish 'retain' flag set to {}", retain);
+    }
+
+    /**
+     * Sets MQTT receive 'retain' flag.
+     *
+     * @param retain the new values of receive 'retain' flag.
+     */
+    @And("I set the 'retain' flag in expected received messages to {booleanOrNullValue}")
+    public void setReceivedRetain(Boolean retain) {
+        this.receivedRetain = retain;
+        log.info("Expected 'retain' flag in received messages set to {}", retain);
     }
 
     /**
@@ -568,7 +608,7 @@ public class MqttControlSteps {
      */
     @SuppressWarnings("PMD.UseObjectForClearerAPI")
     @And("message {string} received on {string} from {string} topic within {int} {word}")
-    public void receive(String message, String clientDeviceId, String topicString, int value, String unit)
+    public void receivedMessage(String message, String clientDeviceId, String topicString, int value, String unit)
                             throws TimeoutException, InterruptedException {
         receive(message, clientDeviceId, topicString, value, unit, true);
     }
@@ -588,7 +628,7 @@ public class MqttControlSteps {
      */
     @SuppressWarnings("PMD.UseObjectForClearerAPI")
     public void receive(String message, String clientDeviceId, String topicString, int value,
-                        String unit, Boolean isExpectedMessage)
+                        String unit, boolean isExpectedMessage)
                             throws TimeoutException, InterruptedException {
         // getting connectionControl by clientDeviceId
         final String clientDeviceThingName = getClientDeviceThingName(clientDeviceId);
@@ -602,13 +642,14 @@ public class MqttControlSteps {
                                         .withConnectionControl(connectionControl)
                                         .withTopic(topic)
                                         .withContent(message)
+                                        .withRetain(receivedRetain)
                                         .build();
         // convert time units
         TimeUnit timeUnit = TimeUnit.valueOf(unit.toUpperCase());
 
         // awaiting for message
-        log.info("Awaiting for MQTT message {} on topic {} on Thing {} for {} {}", message, topic,
-                    clientDeviceThingName, value, unit);
+        log.info("Awaiting for MQTT message '{}' with retain {} on topic '{}' on Thing '{}' for {} {}", message,
+                    receivedRetain, topic, clientDeviceThingName, value, unit);
         List<Event> events = new ArrayList<>();
         try {
             events = eventStorage.awaitEvents(eventFilter, value, timeUnit);

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -231,6 +231,8 @@ Feature: GGMQ-1
     Then I wait 5 seconds
     And I get 1 assertions with context "ReceivedPubsubMessage" and message "topicPrefix message"
 
+    And I disconnect device "publisher" with reason code 0
+
     @mqtt3 @sdk-java
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
@@ -365,6 +367,9 @@ Feature: GGMQ-1
 
     When I publish from "localMqttPublisher" to "${iotCoreSubscriber}topic/with/prefix" with qos 1 and message "Hello world2"
     Then message "Hello world2" received on "iotCoreSubscriber" from "prefix/${iotCoreSubscriber}topic/with/prefix" topic within 10 seconds
+
+    And I disconnect device "iotCoreSubscriber" with reason code 0
+    And I disconnect device "localMqttPublisher" with reason code 0
 
     @mqtt3 @sdk-java
     Examples:
@@ -547,6 +552,9 @@ Feature: GGMQ-1
     When I publish from "publisher" to "iot_data_1" with qos 1 and message "Hello world 3"
     Then message "Hello world 3" received on "subscriber" from "iot_data_1" topic within 10 seconds
 
+    And I disconnect device "subscriber" with reason code 0
+    And I disconnect device "publisher" with reason code 0
+
     # WARNING: AWS IoT device SDK Java v2 MQTT v3 client in software.amazon.awssdk.crt.mqtt.MqttClientConnection
     #  missing API to getting actual reason code of SUBACK/PUBACK/UNSUBACK, client always return reason code 0 on publish and subscribe.
     #  It makes sdk-java client useless for T13
@@ -689,6 +697,9 @@ Feature: GGMQ-1
     When I publish from "iotCorePublisher" to "${localMqttSubscriber}topic/with/prefix" with qos 1 and message "Hello world2"
     Then message "Hello world2" received on "localMqttSubscriber" from "prefix/${localMqttSubscriber}topic/with/prefix" topic within 10 seconds
 
+    And I disconnect device "iotCorePublisher" with reason code 0
+    And I disconnect device "localMqttSubscriber" with reason code 0
+
     @mqtt3 @sdk-java
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
@@ -827,6 +838,8 @@ Feature: GGMQ-1
     Then message "Hello world" received on "subscriber" from "pubsub/topic/to/publish/on" topic within 10 seconds
     Then message "Hello world" received on "subscriber" from "prefix/pubsub/topic/to/publish/on" topic within 10 seconds
 
+    And I disconnect device "subscriber" with reason code 0
+
     @mqtt3 @sdk-java
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
@@ -927,6 +940,9 @@ Feature: GGMQ-1
     When I publish from "publisher" to "iot_data_1" with qos 0 and message "Hello world1"
     When I subscribe "subscriber" to "iot_data_1" with qos 0
     And message "Hello world1" is not received on "subscriber" from "iot_data_1" topic within 5 seconds
+
+    And I disconnect device "subscriber" with reason code 0
+    And I disconnect device "publisher" with reason code 0
 
     @mqtt3 @sdk-java
     Examples:
@@ -1059,6 +1075,9 @@ Feature: GGMQ-1
     When I subscribe "subscriber" to "iot_data_5" with qos 0
     And message "Hello world5" is not received on "subscriber" from "iot_data_5" topic within 5 seconds
 
+    And I disconnect device "subscriber" with reason code 0
+    And I disconnect device "publisher" with reason code 0
+
     @mqtt5 @sdk-java
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
@@ -1168,20 +1187,20 @@ Feature: GGMQ-1
     When I publish from "publisher" to "iot_data_1" with qos 0 and message "Hello world4"
     And message "Hello world4" received on "subscriber" from "iot_data_1" topic within 5 seconds
 
-    And I disconnect device "publisher" with reason code 0
     And I disconnect device "subscriber" with reason code 0
+    And I disconnect device "publisher" with reason code 0
 
     @mqtt5 @sdk-java
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
       | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
 
-    @mqtt5 @paho-java
-    Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
-
     @mqtt5 @mosquitto-c
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
       | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
+
+    @mqtt5 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1140,13 +1140,13 @@ Feature: GGMQ-1
     And I set MQTT subscribe 'retain as published' flag to false
     When I subscribe "subscriber" to "iot_data_0" with qos 0
 
-    And I set MQTT publish retain flag to false
+    And I set MQTT publish 'retain' flag to false
     And I set the 'retain' flag in expected received messages to false
 
     When I publish from "publisher" to "iot_data_0" with qos 0 and message "Hello world1"
     And message "Hello world1" received on "subscriber" from "iot_data_0" topic within 5 seconds
 
-    And I set MQTT publish retain flag to true
+    And I set MQTT publish 'retain' flag to true
     When I publish from "publisher" to "iot_data_0" with qos 0 and message "Hello world2"
     And message "Hello world2" received on "subscriber" from "iot_data_0" topic within 5 seconds
 
@@ -1157,13 +1157,13 @@ Feature: GGMQ-1
     And I set MQTT subscribe 'retain as published' flag to true
     When I subscribe "subscriber" to "iot_data_1" with qos 0
 
-    And I set MQTT publish retain flag to false
+    And I set MQTT publish 'retain' flag to false
     And I set the 'retain' flag in expected received messages to false
 
     When I publish from "publisher" to "iot_data_1" with qos 0 and message "Hello world3"
     And message "Hello world3" received on "subscriber" from "iot_data_1" topic within 5 seconds
 
-    And I set MQTT publish retain flag to true
+    And I set MQTT publish 'retain' flag to true
     And I set the 'retain' flag in expected received messages to true
     When I publish from "publisher" to "iot_data_1" with qos 0 and message "Hello world4"
     And message "Hello world4" received on "subscriber" from "iot_data_1" topic within 5 seconds

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -916,13 +916,13 @@ Feature: GGMQ-1
     And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
     And I connect device "subscriber" on <agent> to "localMqttBroker2" using mqtt "<mqtt-v>"
 
-    And I set MQTT publish retain flag to true
+    And I set MQTT publish 'retain' flag to true
 
     When I publish from "publisher" to "iot_data_0" with qos 0 and message "Hello world0"
     When I subscribe "subscriber" to "iot_data_0" with qos 0
     And message "Hello world0" received on "subscriber" from "iot_data_0" topic within 5 seconds
 
-    And I set MQTT publish retain flag to false
+    And I set MQTT publish 'retain' flag to false
 
     When I publish from "publisher" to "iot_data_1" with qos 0 and message "Hello world1"
     When I subscribe "subscriber" to "iot_data_1" with qos 0
@@ -955,6 +955,7 @@ Feature: GGMQ-1
     And I create client device "subscriber"
     When I associate "subscriber" with ggc
     When I associate "publisher" with ggc
+
     And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:
     """
 {
@@ -1002,26 +1003,26 @@ Feature: GGMQ-1
     And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
     And I connect device "subscriber" on <agent> to "localMqttBroker2" using mqtt "<mqtt-v>"
 
-    And I set MQTT publish retain flag to true
+    And I set MQTT publish 'retain' flag to true
     When I publish from "publisher" to "iot_data_001" with qos 0 and message "Old retained message"
     When I publish from "publisher" to "iot_data_001" with qos 0 and message "New retained message"
-    And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_SUBSCRIPTION"
+    And I set MQTT subscribe 'retain handling' property to "MQTT5_RETAIN_SEND_AT_SUBSCRIPTION"
     When I subscribe "subscriber" to "iot_data_001" with qos 0
     And message "Old retained message" is not received on "subscriber" from "iot_data_001" topic within 5 seconds
     And message "New retained message" received on "subscriber" from "iot_data_001" topic within 5 seconds
 
-    And I set MQTT publish retain flag to true
+    And I set MQTT publish 'retain' flag to true
     When I publish from "publisher" to "iot_data_002" with qos 0 and message "Old retained message 002"
-    And I set MQTT publish retain flag to false
+    And I set MQTT publish 'retain' flag to false
     When I publish from "publisher" to "iot_data_002" with qos 0 and message "New retained message 002"
     When I subscribe "subscriber" to "iot_data_002" with qos 0
     And message "New retained message 002" is not received on "subscriber" from "iot_data_002" topic within 5 seconds
     And message "Old retained message 002" received on "subscriber" from "iot_data_002" topic within 5 seconds
 
-    And I set MQTT publish retain flag to true
+    And I set MQTT publish 'retain' flag to true
 
     When I publish from "publisher" to "iot_data_0" with qos 0 and message "Hello world0"
-    And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_SUBSCRIPTION"
+    And I set MQTT subscribe 'retain handling' property to "MQTT5_RETAIN_SEND_AT_SUBSCRIPTION"
     When I subscribe "subscriber" to "iot_data_0" with qos 0
     And message "Hello world0" received on "subscriber" from "iot_data_0" topic within 5 seconds
     And I clear message storage
@@ -1029,7 +1030,7 @@ Feature: GGMQ-1
     And message "Hello world0" received on "subscriber" from "iot_data_0" topic within 5 seconds
 
     When I publish from "publisher" to "retained/iot_data_1" with qos 1 and message "Hello world1" and expect status 16
-    And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_NEW_SUBSCRIPTION"
+    And I set MQTT subscribe 'retain handling' property to "MQTT5_RETAIN_SEND_AT_NEW_SUBSCRIPTION"
     When I subscribe "subscriber" to "retained/iot_data_1" with qos 0
     And message "Hello world1" received on "subscriber" from "retained/iot_data_1" topic within 5 seconds
     And I clear message storage
@@ -1037,24 +1038,24 @@ Feature: GGMQ-1
     And message "Hello world1" is not received on "subscriber" from "retained/iot_data_1" topic within 5 seconds
 
     When I publish from "publisher" to "iot_data_2" with qos 0 and message "Hello world2"
-    And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_DO_NOT_SEND_AT_SUBSCRIPTION"
+    And I set MQTT subscribe 'retain handling' property to "MQTT5_RETAIN_DO_NOT_SEND_AT_SUBSCRIPTION"
     When I subscribe "subscriber" to "iot_data_2" with qos 0
     And message "Hello world2" is not received on "subscriber" from "iot_data_2" topic within 5 seconds
 
-    And I set MQTT publish retain flag to false
+    And I set MQTT publish 'retain' flag to false
 
     When I publish from "publisher" to "iot_data_3" with qos 0 and message "Hello world3"
-    And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_SUBSCRIPTION"
+    And I set MQTT subscribe 'retain handling' property to "MQTT5_RETAIN_SEND_AT_SUBSCRIPTION"
     When I subscribe "subscriber" to "iot_data_3" with qos 0
     And message "Hello world3" is not received on "subscriber" from "iot_data_3" topic within 5 seconds
 
     When I publish from "publisher" to "iot_data_4" with qos 0 and message "Hello world4"
-    And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_NEW_SUBSCRIPTION"
+    And I set MQTT subscribe 'retain handling' property to "MQTT5_RETAIN_SEND_AT_NEW_SUBSCRIPTION"
     When I subscribe "subscriber" to "iot_data_4" with qos 0
     And message "Hello world4" is not received on "subscriber" from "iot_data_4" topic within 5 seconds
 
     When I publish from "publisher" to "iot_data_5" with qos 0 and message "Hello world5"
-    And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_DO_NOT_SEND_AT_SUBSCRIPTION"
+    And I set MQTT subscribe 'retain handling' property to "MQTT5_RETAIN_DO_NOT_SEND_AT_SUBSCRIPTION"
     When I subscribe "subscriber" to "iot_data_5" with qos 0
     And message "Hello world5" is not received on "subscriber" from "iot_data_5" topic within 5 seconds
 
@@ -1072,3 +1073,115 @@ Feature: GGMQ-1
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
       | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
+
+
+  @GGMQ-1-T103
+  Scenario Outline: GGMQ-1-T103-<mqtt-v>-<name>: As a customer, I can use retain as published flag
+    When I create a Greengrass deployment with components
+      | aws.greengrass.clientdevices.Auth       | LATEST                                  |
+      | aws.greengrass.clientdevices.mqtt.EMQX  | LATEST                                  |
+      | aws.greengrass.clientdevices.IPDetector | LATEST                                  |
+      | <agent>                                 | classpath:/local-store/recipes/<recipe> |
+    And I create client device "publisher"
+    And I create client device "subscriber"
+    When I associate "subscriber" with ggc
+    When I associate "publisher" with ggc
+
+    And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:
+    """
+{
+    "MERGE":{
+        "deviceGroups":{
+            "formatVersion":"2021-03-05",
+            "definitions":{
+                "MyPermissiveDeviceGroup":{
+                    "selectionRule":"thingName: ${publisher} OR thingName: ${subscriber}",
+                    "policyName":"MyPermissivePolicy"
+                }
+            },
+            "policies":{
+                "MyPermissivePolicy":{
+                    "AllowAll":{
+                        "statementDescription":"Allow client devices to perform all actions.",
+                        "operations":[
+                            "*"
+                        ],
+                        "resources":[
+                            "*"
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}
+    """
+    And I update my Greengrass deployment configuration, setting the component <agent> configuration to:
+    """
+{
+    "MERGE":{
+        "controlAddresses":"${mqttControlAddresses}",
+        "controlPort":"${mqttControlPort}"
+    }
+}
+    """
+    And I deploy the Greengrass deployment configuration
+    Then the Greengrass deployment is COMPLETED on the device after 5 minutes
+    And the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes
+
+    Then I discover core device broker as "localMqttBroker1" from "publisher" in OTF
+    Then I discover core device broker as "localMqttBroker2" from "subscriber" in OTF
+    And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
+    And I connect device "subscriber" on <agent> to "localMqttBroker2" using mqtt "<mqtt-v>"
+
+    # 1. test case when subscribe 'retain as published' is false.
+    #  In that case 'retain' flag on receive should be false regardless 'retain' value on publish.
+
+    And I set MQTT subscribe 'retain as published' flag to false
+    When I subscribe "subscriber" to "iot_data_0" with qos 0
+
+    And I set MQTT publish retain flag to false
+    And I set the 'retain' flag in expected received messages to false
+
+    When I publish from "publisher" to "iot_data_0" with qos 0 and message "Hello world1"
+    And message "Hello world1" received on "subscriber" from "iot_data_0" topic within 5 seconds
+
+    And I set MQTT publish retain flag to true
+    When I publish from "publisher" to "iot_data_0" with qos 0 and message "Hello world2"
+    And message "Hello world2" received on "subscriber" from "iot_data_0" topic within 5 seconds
+
+
+    # 2. test case when subscribe 'retain as published' is true.
+    #  In that case 'retain' flag on receive should be equal to 'retain' value on publish.
+
+    And I set MQTT subscribe 'retain as published' flag to true
+    When I subscribe "subscriber" to "iot_data_1" with qos 0
+
+    And I set MQTT publish retain flag to false
+    And I set the 'retain' flag in expected received messages to false
+
+    When I publish from "publisher" to "iot_data_1" with qos 0 and message "Hello world3"
+    And message "Hello world3" received on "subscriber" from "iot_data_1" topic within 5 seconds
+
+    And I set MQTT publish retain flag to true
+    And I set the 'retain' flag in expected received messages to true
+    When I publish from "publisher" to "iot_data_1" with qos 0 and message "Hello world4"
+    And message "Hello world4" received on "subscriber" from "iot_data_1" topic within 5 seconds
+
+    And I disconnect device "publisher" with reason code 0
+    And I disconnect device "subscriber" with reason code 0
+
+    @mqtt5 @sdk-java
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
+
+    @mqtt5 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
+
+    @mqtt5 @mosquitto-c
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-240
Implement Retain As published flag

**Description of changes:**
- Add GGMQ-1-T103 scenario outline to test 'retain as published' feature
- Update MqttControlSteps by adding receivedRetain variable and use it in receive steps 
- Update EventFilter to allow reset retain matching
- Tune logging of MqttControlSteps
- Tune steps sentences
- Add  explicit disconnect for all devices


**Why is this change necessary:**
We should be able to test 'retain as published' flag has effect

**How was this change tested:**
Run scenarios including new GGMQ-1-T103 on codeBuild

**Test results:**
```
[INFO ] 2023-06-20 22:06:20.328 [main] StepTrackingReporting - Passed: 'GGMQ-1-T1-v3-sdk-java: As a customer, I can connect, subscribe/publish at QoS 0 and 1 and receive using client application to MQTT topic'
[INFO ] 2023-06-20 22:06:20.328 [main] StepTrackingReporting - Passed: 'GGMQ-1-T1-v3-mosquitto-c: As a customer, I can connect, subscribe/publish at QoS 0 and 1 and receive using client application to MQTT topic'
[INFO ] 2023-06-20 22:06:20.328 [main] StepTrackingReporting - Passed: 'GGMQ-1-T1-v3-paho-java: As a customer, I can connect, subscribe/publish at QoS 0 and 1 and receive using client application to MQTT topic'
[INFO ] 2023-06-20 22:06:20.328 [main] StepTrackingReporting - Passed: 'GGMQ-1-T1-v5-sdk-java: As a customer, I can connect, subscribe/publish at QoS 0 and 1 and receive using client application to MQTT topic'
[INFO ] 2023-06-20 22:06:20.328 [main] StepTrackingReporting - Passed: 'GGMQ-1-T1-v5-mosquitto-c: As a customer, I can connect, subscribe/publish at QoS 0 and 1 and receive using client application to MQTT topic'
[INFO ] 2023-06-20 22:06:20.328 [main] StepTrackingReporting - Passed: 'GGMQ-1-T1-v5-paho-java: As a customer, I can connect, subscribe/publish at QoS 0 and 1 and receive using client application to MQTT topic'

[INFO ] 2023-06-20 22:06:20.329 [main] StepTrackingReporting - Passed: 'GGMQ-1-T8-v3-sdk-java: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic'
[INFO ] 2023-06-20 22:06:20.329 [main] StepTrackingReporting - Passed: 'GGMQ-1-T8-v3-mosquitto-c: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic'
[INFO ] 2023-06-20 22:06:20.329 [main] StepTrackingReporting - Passed: 'GGMQ-1-T8-v3-paho-java: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic'
[INFO ] 2023-06-20 22:06:20.329 [main] StepTrackingReporting - Passed: 'GGMQ-1-T8-v5-sdk-java: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic'
[INFO ] 2023-06-20 22:06:20.329 [main] StepTrackingReporting - Passed: 'GGMQ-1-T8-v5-mosquitto-c: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic'
[INFO ] 2023-06-20 22:06:20.329 [main] StepTrackingReporting - Passed: 'GGMQ-1-T8-v5-paho-java: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic'

[INFO ] 2023-06-20 22:06:20.329 [main] StepTrackingReporting - Passed: 'GGMQ-1-T9-v3-sdk-java: As a customer,I can configure local MQTT messages to be forwarded to an IoT Core MQTT topic'
[INFO ] 2023-06-20 22:06:20.329 [main] StepTrackingReporting - Passed: 'GGMQ-1-T9-v3-mosquitto-c: As a customer,I can configure local MQTT messages to be forwarded to an IoT Core MQTT topic'
[ERROR] 2023-06-20 22:06:20.329 [main] StepTrackingReporting - Failed: 'GGMQ-1-T9-v3-paho-java: As a customer,I can configure local MQTT messages to be forwarded to an IoT Core MQTT topic': Failed at 'my device is registered as a Thing'
[INFO ] 2023-06-20 22:06:20.329 [main] StepTrackingReporting - Passed: 'GGMQ-1-T9-v5-sdk-java: As a customer,I can configure local MQTT messages to be forwarded to an IoT Core MQTT topic'
[INFO ] 2023-06-20 22:06:20.329 [main] StepTrackingReporting - Passed: 'GGMQ-1-T9-v5-mosquitto-c: As a customer,I can configure local MQTT messages to be forwarded to an IoT Core MQTT topic'
[ERROR] 2023-06-20 22:06:20.329 [main] StepTrackingReporting - Failed: 'GGMQ-1-T9-v5-paho-java: As a customer,I can configure local MQTT messages to be forwarded to an IoT Core MQTT topic': Failed at 'the Greengrass deployment is COMPLETED on the device after 5 minutes'

[INFO ] 2023-06-20 22:06:20.329 [main] StepTrackingReporting - Passed: 'GGMQ-1-T13-v3-sdk-java: As a customer, I can connect two GGADs and send message from one GGAD to the other based on CDA configuration'
[INFO ] 2023-06-20 22:06:20.329 [main] StepTrackingReporting - Passed: 'GGMQ-1-T13-v3-mosquitto-c: As a customer, I can connect two GGADs and send message from one GGAD to the other based on CDA configuration'
[ERROR] 2023-06-20 22:06:20.330 [main] StepTrackingReporting - Failed: 'GGMQ-1-T13-v3-paho-java: As a customer, I can connect two GGADs and send message from one GGAD to the other based on CDA configuration': Failed at 'the Greengrass deployment is COMPLETED on the device after 5 minutes'
[INFO ] 2023-06-20 22:06:20.330 [main] StepTrackingReporting - Passed: 'GGMQ-1-T13-v5-sdk-java: As a customer, I can connect two GGADs and send message from one GGAD to the other based on CDA configuration'
[INFO ] 2023-06-20 22:06:20.330 [main] StepTrackingReporting - Passed: 'GGMQ-1-T13-v5-mosquitto-c: As a customer, I can connect two GGADs and send message from one GGAD to the other based on CDA configuration'
[INFO ] 2023-06-20 22:06:20.330 [main] StepTrackingReporting - Passed: 'GGMQ-1-T13-v5-paho-java: As a customer, I can connect two GGADs and send message from one GGAD to the other based on CDA configuration'

[INFO ] 2023-06-20 22:06:20.330 [main] StepTrackingReporting - Passed: 'GGMQ-1-T14-v3-sdk-java: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic'
[INFO ] 2023-06-20 22:06:20.330 [main] StepTrackingReporting - Passed: 'GGMQ-1-T14-v3-mosquitto-c: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic'
[INFO ] 2023-06-20 22:06:20.330 [main] StepTrackingReporting - Passed: 'GGMQ-1-T14-v3-paho-java: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic'
[INFO ] 2023-06-20 22:06:20.330 [main] StepTrackingReporting - Passed: 'GGMQ-1-T14-v5-sdk-java: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic'
[INFO ] 2023-06-20 22:06:20.330 [main] StepTrackingReporting - Passed: 'GGMQ-1-T14-v5-mosquitto-c: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic'
[INFO ] 2023-06-20 22:06:20.330 [main] StepTrackingReporting - Passed: 'GGMQ-1-T14-v5-paho-java: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic'

[ERROR] 2023-06-20 22:06:20.330 [main] StepTrackingReporting - Failed: 'GGMQ-1-T15-v3-sdk-java: As a customer, I can configure Pubsub messages to be forwarded to local MQTT topic': Failed at 'the Greengrass deployment is COMPLETED on the device after 5 minutes'
[INFO ] 2023-06-20 22:06:20.330 [main] StepTrackingReporting - Passed: 'GGMQ-1-T15-v3-mosquitto-c: As a customer, I can configure Pubsub messages to be forwarded to local MQTT topic'
[INFO ] 2023-06-20 22:06:20.330 [main] StepTrackingReporting - Passed: 'GGMQ-1-T15-v3-paho-java: As a customer, I can configure Pubsub messages to be forwarded to local MQTT topic'
[INFO ] 2023-06-20 22:06:20.330 [main] StepTrackingReporting - Passed: 'GGMQ-1-T15-v5-sdk-java: As a customer, I can configure Pubsub messages to be forwarded to local MQTT topic'
[ERROR] 2023-06-20 22:06:20.331 [main] StepTrackingReporting - Failed: 'GGMQ-1-T15-v5-mosquitto-c: As a customer, I can configure Pubsub messages to be forwarded to local MQTT topic': Failed at 'the Greengrass deployment is COMPLETED on the device after 5 minutes'
[INFO ] 2023-06-20 22:06:20.331 [main] StepTrackingReporting - Passed: 'GGMQ-1-T15-v5-paho-java: As a customer, I can configure Pubsub messages to be forwarded to local MQTT topic'

[INFO ] 2023-06-20 22:06:20.331 [main] StepTrackingReporting - Passed: 'GGMQ-1-T101-v3-sdk-java: As a customer, I can use publish retain flag'
[INFO ] 2023-06-20 22:06:20.331 [main] StepTrackingReporting - Passed: 'GGMQ-1-T101-v3-mosquitto-c: As a customer, I can use publish retain flag'
[INFO ] 2023-06-20 22:06:20.331 [main] StepTrackingReporting - Passed: 'GGMQ-1-T101-v3-paho-java: As a customer, I can use publish retain flag'

[INFO ] 2023-06-20 22:06:20.331 [main] StepTrackingReporting - Passed: 'GGMQ-1-T102-v5-sdk-java: As a customer, I can use publish retain flag and subscribe retain handling as expected'
[INFO ] 2023-06-20 22:06:20.331 [main] StepTrackingReporting - Passed: 'GGMQ-1-T102-v5-mosquitto-c: As a customer, I can use publish retain flag and subscribe retain handling as expected'
[INFO ] 2023-06-20 22:06:20.331 [main] StepTrackingReporting - Passed: 'GGMQ-1-T102-v5-paho-java: As a customer, I can use publish retain flag and subscribe retain handling as expected'

[INFO ] 2023-06-20 22:06:20.331 [main] StepTrackingReporting - Passed: 'GGMQ-1-T103-v5-sdk-java: As a customer, I can use retain as published flag'
[ERROR] 2023-06-20 22:06:20.331 [main] StepTrackingReporting - Failed: 'GGMQ-1-T103-v5-mosquitto-c: As a customer, I can use retain as published flag': Failed at 'my device is registered as a Thing'
[INFO ] 2023-06-20 22:06:20.331 [main] StepTrackingReporting - Passed: 'GGMQ-1-T103-v5-paho-java: As a customer, I can use retain as published flag'
```


**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
