### PR TITLE
fix(uat): deleted paho and mosquitto-c clients from t2

### DIFF
--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -233,30 +233,10 @@ Feature: GGMQ-1
       | mqtt-v | name     | agent                                        | recipe                  | iot_data_1-publish | subscribe-status-q1 |
       | v3     | sdk-java | aws.greengrass.client.Mqtt5JavaSdkClient     | client_java_sdk.yaml    | 0                  | GRANTED_QOS_0       |
 
-    @mqtt3 @mosquitto-c
-    Examples:
-      | mqtt-v | name        | agent                                     | recipe                  | iot_data_1-publish | subscribe-status-q1 |
-      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | 0                | GRANTED_QOS_1       |
-
-    @mqtt3 @paho-java
-    Examples:
-      | mqtt-v | name      | agent                                       | recipe                  | iot_data_1-publish | subscribe-status-q1 |
-      | v3     | paho-java | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   | 0                  | GRANTED_QOS_0       |
-
     @mqtt5 @sdk-java
     Examples:
       | mqtt-v | name     | agent                                        | recipe                  | iot_data_1-publish | subscribe-status-q1 |
       | v5     | sdk-java | aws.greengrass.client.Mqtt5JavaSdkClient     | client_java_sdk.yaml    | 135                | GRANTED_QOS_1       |
-
-    @mqtt5 @mosquitto-c
-    Examples:
-      | mqtt-v | name        | agent                                     | recipe                  | iot_data_1-publish | subscribe-status-q1 |
-      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | 135                | GRANTED_QOS_1       |
-
-    @mqtt5 @paho-java
-    Examples:
-      | mqtt-v | name      | agent                                       | recipe                  | iot_data_1-publish | subscribe-status-q1 |
-      | v5     | paho-java | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   | 135                | GRANTED_QOS_1       |
 
 
   @GGMQ-1-T8


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-257
deleted paho and mosquitto-c clients from t2

**Description of changes:**
- deleted paho and mosquitto-c clients from t2

**Why is this change necessary:**
In GGMQ-1-T2 we testing ability to publish with different qos

**How was this change tested:**
Scenarios run manually and on CI

**Test results:**
For all clients and all versions:
```
Given my device is registered as a Thing....................................passed
And my device is running Greengrass.........................................passed
When I create a Greengrass deployment with components.......................passed
And I create client device "clientDeviceTest"...............................passed
When I associate "clientDeviceTest" with ggc................................passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:.passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.client.Mqtt5JavaPahoClient configuration to:.passed
And I deploy the Greengrass deployment configuration........................passed
Then the Greengrass deployment is COMPLETED on the device after 5 minutes...passed
And the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes.passed
And I discover core device broker as "default_broker" from "clientDeviceTest" in OTF.passed
And I connect device "clientDeviceTest" on aws.greengrass.client.Mqtt5JavaPahoClient to "default_broker" using mqtt "v3".passed
When I subscribe "clientDeviceTest" to "iot_data_0" with qos 0 and expect status "GRANTED_QOS_0".passed
When I subscribe "clientDeviceTest" to "iot_data_1" with qos 1 and expect status "GRANTED_QOS_0".passed
When I publish from "clientDeviceTest" to "iot_data_0" with qos 0 and message "Test message0".passed
And message "Test message0" is not received on "clientDeviceTest" from "iot_data_0" topic within 10 seconds.passed
When I publish from "clientDeviceTest" to "iot_data_1" with qos 1 and message "Test message1" and expect status 0.passed
And message "Test message1" is not received on "clientDeviceTest" from "iot_data_1" topic within 10 seconds.passed
And I disconnect device "clientDeviceTest" with reason code 0...............passed
When I create a Greengrass deployment with components.......................passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:.passed
And I deploy the Greengrass deployment configuration........................passed
Then the Greengrass deployment is COMPLETED on the device after 120 seconds.passed
And the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes.passed
And I discover core device broker as "default_broker" from "clientDeviceTest" in OTF.passed
And I connect device "clientDeviceTest" on aws.greengrass.client.Mqtt5JavaPahoClient to "default_broker" using mqtt "v3".passed
When I subscribe "clientDeviceTest" to "iot_data_3" with qos 0 and expect status "GRANTED_QOS_0".passed
When I subscribe "clientDeviceTest" to "iot_data_4" with qos 1 and expect status "GRANTED_QOS_0".passed
When I publish from "clientDeviceTest" to "iot_data_3" with qos 0 and message "Test message3".passed
And message "Test message3" is not received on "clientDeviceTest" from "iot_data_3" topic within 10 seconds.passed
When I publish from "clientDeviceTest" to "iot_data_4" with qos 1 and message "Test message4".passed
And message "Test message4" received on "clientDeviceTest" from "iot_data_4" topic within 10 seconds.passed
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

