### PR TITLE
feat(uat): add payload format indicator; content type; fix bugs

### DIFF
--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
@@ -87,7 +87,7 @@ public class MqttConnectionImpl implements MqttConnection {
 
     @Override
     public MqttSubscribeReply subscribe(long timeout, @NonNull List<Subscription> subscriptions,
-                                        List<Mqtt5Properties>  userProperties) {
+                                        List<Mqtt5Properties> userProperties) {
         MqttSubscription[] mqttSubscriptions = new MqttSubscription[subscriptions.size()];
         MqttMessageListener[] listeners = new MqttMessageListener[subscriptions.size()];
         for (int i = 0; i < subscriptions.size(); i++) {
@@ -357,7 +357,7 @@ public class MqttConnectionImpl implements MqttConnection {
 
     private List<UserProperty> convertToUserProperties(List<Mqtt5Properties> properties) {
         List<UserProperty> userProperties = new ArrayList<>();
-        properties.forEach(p ->  userProperties.add(new UserProperty(p.getKey(), p.getValue())));
+        properties.forEach(p -> userProperties.add(new UserProperty(p.getKey(), p.getValue())));
         return userProperties;
     }
 
@@ -371,7 +371,7 @@ public class MqttConnectionImpl implements MqttConnection {
 
     private static List<Mqtt5Properties> convertToMqtt5Properties(List<UserProperty> properties) {
         List<Mqtt5Properties> userProperties = new ArrayList<>();
-        properties.forEach(p ->  userProperties.add(Mqtt5Properties.newBuilder()
+        properties.forEach(p -> userProperties.add(Mqtt5Properties.newBuilder()
                 .setKey(p.getKey()).setValue(p.getValue()).build()));
         return userProperties;
     }

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt311/client/sdkmqtt/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt311/client/sdkmqtt/Mqtt311ConnectionImpl.java
@@ -76,8 +76,8 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
                 final String topic = message.getTopic();
                 final boolean isRetain = message.getRetain();
 
-                MqttReceivedMessage msg = new MqttReceivedMessage(qos, isRetain, topic, message.getPayload(),
-                        null);
+                MqttReceivedMessage msg = new MqttReceivedMessage(qos, isRetain, topic, message.getPayload(), null,
+                                                                    null, null);
                 executorService.submit(() -> {
                     grpcClient.onReceiveMqttMessage(connectionId, msg);
                 });
@@ -177,6 +177,14 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
 
         stateCheck();
         checkUserProperties(message.getUserProperties());
+
+        if (message.getContentType() != null) {
+            logger.atWarn().log("MQTT v3.1.1 does not support content type");
+        }
+
+        if (message.getPayloadFormatIndicator() != null) {
+            logger.atWarn().log("MQTT v3.1.1 does not support payload format indicator");
+        }
 
         final QualityOfService qos = QualityOfService.getEnumValueFromInteger(message.getQos());
         final String topic = message.getTopic();
@@ -347,7 +355,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
 
     private void checkUserProperties(List<Mqtt5Properties> userProperties) {
         if (userProperties != null && !userProperties.isEmpty()) {
-            logger.warn("MQTT V3 doesn't support user properties");
+            logger.warn("MQTT v3.1.1 doesn't support user properties");
         }
     }
 }

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/GRPCClient.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/GRPCClient.java
@@ -33,8 +33,14 @@ public interface GRPCClient {
         /** Payload of message. */
         private byte[] payload;
 
-        /** User properties. */
+        /** Optional user properties. */
         private List<Mqtt5Properties> userProperties;
+
+        /** Optional content type. */
+        private String contentType;
+
+        /** Optional payload format indicator. */
+        private Boolean payloadFormatIndicator;
 
         // TODO: add other properties
     }

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
@@ -125,8 +125,14 @@ public interface MqttConnection {
         /** Payload of message. */
         private byte[] payload;
 
-        /** User properties. */
+        /** Optional user properties. */
         private List<Mqtt5Properties> userProperties;
+
+        /** Optional content type. */
+        private String contentType;
+
+        /** Optional payload format indicator. */
+        private Boolean payloadFormatIndicator;
     }
 
     /**

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
@@ -372,6 +372,14 @@ class GRPCControlServer {
                 internalMessage.userProperties(message.getPropertiesList());
             }
 
+            if (message.hasContentType()) {
+                internalMessage.contentType(message.getContentType());
+            }
+
+            if (message.hasPayloadFormatIndicator()) {
+                internalMessage.payloadFormatIndicator(message.getPayloadFormatIndicator());
+            }
+
             MqttPublishReply.Builder builder = MqttPublishReply.newBuilder();
             try {
                 MqttConnection.PubAckInfo pubAckInfo = connection.publish(timeout, internalMessage.build());


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-219
https://klika-tech.atlassian.net/browse/GGMQ-218

Set payload content type in PUBLISH tx/rx
Set payload format indicator in PUBLISH tx/rx


**Description of changes:**
- Implement handling of content type in PUBLISH for both TX and RX directions
- Implement handling of payload format indicator in PUBLISH for both TX and RX directions
- Added stub with warning for MQTT v3.1.1 client
- Fix bug in CONNECT when user properties does not used
- Fix bug in SUBSCRIBE when user properties set multiple times
- Simplify code related to user properties handling

**Why is this change necessary:**
Implementation of new features of MQTT v5.0

**How was this change tested:**
Manually using control application and checking log output.

**Test results:**
Control app
```
[INFO ] 2023-06-22 16:59:42.482 [com.aws.greengrass.testing.mqtt.client.control.ExampleControl.main()] ExampleControl - Control: port 47619, with TLS, MQTT v5
[INFO ] 2023-06-22 16:59:42.855 [com.aws.greengrass.testing.mqtt.client.control.ExampleControl.main()] EngineControlImpl - MQTT client control gRPC server started, listening on 47619
[INFO ] 2023-06-22 16:59:52.363 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId sdk-java-agent
[INFO ] 2023-06-22 16:59:52.445 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId sdk-java-agent address 127.0.0.1 port 42597
[INFO ] 2023-06-22 16:59:52.453 [grpc-default-executor-0] EngineControlImpl - Created new agent control for sdk-java-agent on 127.0.0.1:42597
[INFO ] 2023-06-22 16:59:52.514 [grpc-default-executor-0] ExampleControl - Agent sdk-java-agent is connected
[INFO ] 2023-06-22 16:59:52.526 [pool-2-thread-1] AgentTestScenario - Playing test scenario for agent id sdk-java-agent
[INFO ] 2023-06-22 16:59:55.587 [pool-2-thread-1] AgentTestScenario - Connect MQTT userProperties: region, US
[INFO ] 2023-06-22 16:59:55.587 [pool-2-thread-1] AgentTestScenario - Connect MQTT userProperties: type, JSON
[INFO ] 2023-06-22 16:59:56.426 [pool-2-thread-1] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
reasonCode: 0
receiveMaximum: 100
maximumQoS: 1
retainAvailable: true
maximumPacketSize: 149504
wildcardSubscriptionsAvailable: true
subscriptionIdentifiersAvailable: false
sharedSubscriptionsAvailable: true
serverKeepAlive: 60
'
[INFO ] 2023-06-22 16:59:56.426 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-06-22 16:59:56.426 [pool-2-thread-1] AgentTestScenario - MQTT connection with id 1 is established
[INFO ] 2023-06-22 17:00:01.439 [pool-2-thread-1] AgentTestScenario - Subscribe MQTT userProperties: region, US
[INFO ] 2023-06-22 17:00:01.439 [pool-2-thread-1] AgentTestScenario - Subscribe MQTT userProperties: type, JSON
[INFO ] 2023-06-22 17:00:01.452 [pool-2-thread-1] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-06-22 17:00:01.575 [pool-2-thread-1] AgentTestScenario - Subscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-06-22 17:00:06.588 [pool-2-thread-1] AgentTestScenario - Publish MQTT userProperties: region, US
[INFO ] 2023-06-22 17:00:06.588 [pool-2-thread-1] AgentTestScenario - Publish MQTT userProperties: type, JSON
[INFO ] 2023-06-22 17:00:06.605 [pool-2-thread-1] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic test/topic
[INFO ] 2023-06-22 17:00:06.690 [pool-2-thread-1] AgentTestScenario - Published connectionId 1 reason code 0 reason string ''
[INFO ] 2023-06-22 17:00:06.707 [grpc-default-executor-0] GRPCDiscoveryServer - OnReceiveMessage: agentId sdk-java-agent connectionId 1 topic test/topic QoS 0
[INFO ] 2023-06-22 17:00:06.709 [grpc-default-executor-0] AgentTestScenario - Message received on agentId sdk-java-agent connectionId 1 topic test/topic QoS 0 content <ByteString@11ad5ecd size=12 contents="Hello World!">
[INFO ] 2023-06-22 17:00:06.710 [grpc-default-executor-0] AgentTestScenario - Message has user property key region value US
[INFO ] 2023-06-22 17:00:06.711 [grpc-default-executor-0] AgentTestScenario - Message has user property key type value JSON
[INFO ] 2023-06-22 17:00:06.712 [grpc-default-executor-0] AgentTestScenario - Message has content type 'text/plain; charset=utf-8'
[INFO ] 2023-06-22 17:00:06.712 [grpc-default-executor-0] AgentTestScenario - Message has payload format indicator true
[INFO ] 2023-06-22 17:00:11.691 [pool-2-thread-1] AgentTestScenario - Unsubscribe MQTT userProperties: region, US
[INFO ] 2023-06-22 17:00:11.691 [pool-2-thread-1] AgentTestScenario - Unsubscribe MQTT userProperties: type, JSON
[INFO ] 2023-06-22 17:00:11.711 [pool-2-thread-1] AgentControlImpl - UnsubscribeMqtt: unsubscribe on connectionId 1
[INFO ] 2023-06-22 17:00:11.784 [pool-2-thread-1] AgentTestScenario - Unsubscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-06-22 17:00:26.785 [pool-2-thread-1] AgentTestScenario - Disconnect MQTT userProperties: region, US
[INFO ] 2023-06-22 17:00:26.785 [pool-2-thread-1] AgentTestScenario - Disconnect MQTT userProperties: type, JSON
[INFO ] 2023-06-22 17:00:26.824 [grpc-default-executor-0] GRPCDiscoveryServer - OnMqttDisconnect: agentId sdk-java-agent connectionId 1 disconnect '' error 'Mqtt5 client connection interrupted by user request.'
[INFO ] 2023-06-22 17:00:26.824 [grpc-default-executor-0] AgentTestScenario - MQTT disconnected on agentId sdk-java-agent connectionId 1 disconnect '' error 'Mqtt5 client connection interrupted by user request.'
[INFO ] 2023-06-22 17:00:26.835 [pool-2-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 1 closed
[INFO ] 2023-06-22 17:00:26.857 [pool-2-thread-1] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-06-22 17:00:26.879 [grpc-default-executor-0] GRPCDiscoveryServer - UnregisterAgent: agentId sdk-java-agent reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-06-22 17:00:26.883 [grpc-default-executor-0] ExampleControl - Agent sdk-java-agent is disconnected
```

SDK client:
```
[INFO ] 2023-06-22 16:59:51.655 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Making gPRC client connection with 127.0.0.1:47619 as sdk-java-agent...
[INFO ] 2023-06-22 16:59:52.393 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Client connection with Control is established, local address is 127.0.0.1
[INFO ] 2023-06-22 16:59:52.439 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - GRPCControlServer created and listed on 127.0.0.1:42597
[INFO ] 2023-06-22 16:59:52.532 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Handle gRPC requests
[INFO ] 2023-06-22 16:59:52.532 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - Server awaitTermination
[INFO ] 2023-06-22 16:59:55.723 [grpc-default-executor-0] GRPCControlServer - createMqttConnection: clientId GGMQ-test-device2 broker a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[INFO ] 2023-06-22 16:59:55.731 [grpc-default-executor-0] MqttConnectionImpl - Creating Mqtt5Client with TLS
[INFO ] 2023-06-22 16:59:56.037 [grpc-default-executor-0] MqttConnectionImpl - CONNECT MQTT userProperties: region, US
[INFO ] 2023-06-22 16:59:56.037 [grpc-default-executor-0] MqttConnectionImpl - CONNECT MQTT userProperties: type, JSON
[INFO ] 2023-06-22 16:59:56.042 [Thread-2] MqttConnectionImpl - MQTT connectionId 1 connecting...
[INFO ] 2023-06-22 16:59:56.277 [Thread-2] MqttConnectionImpl - MQTT connectionId 1 connected, client id GGMQ-test-device2
[INFO ] 2023-06-22 17:00:01.479 [grpc-default-executor-0] GRPCControlServer - Subscription: filter test/topic QoS 0 noLocal false retainAsPublished false retainHandling 2
[INFO ] 2023-06-22 17:00:01.480 [grpc-default-executor-0] GRPCControlServer - Subscribe: connectionId 1 subscriptionId null for 1 filters
[INFO ] 2023-06-22 17:00:01.485 [grpc-default-executor-0] MqttConnectionImpl - SUBSCRIBE MQTT userProperties: region, US
[INFO ] 2023-06-22 17:00:01.485 [grpc-default-executor-0] MqttConnectionImpl - SUBSCRIBE MQTT userProperties: type, JSON
[INFO ] 2023-06-22 17:00:01.563 [grpc-default-executor-0] GRPCControlServer - Subscribe response: connectionId 1 reason codes [0] reason string null
[INFO ] 2023-06-22 17:00:06.640 [grpc-default-executor-0] GRPCControlServer - Publish: connectionId 1 topic test/topic QoS 1 retain false
[INFO ] 2023-06-22 17:00:06.645 [grpc-default-executor-0] MqttConnectionImpl - TX PUBLISH MQTT userProperties: region, US
[INFO ] 2023-06-22 17:00:06.645 [grpc-default-executor-0] MqttConnectionImpl - TX PUBLISH MQTT userProperties: type, JSON
[INFO ] 2023-06-22 17:00:06.645 [grpc-default-executor-0] MqttConnectionImpl - Publish content type: text/plain; charset=utf-8
[INFO ] 2023-06-22 17:00:06.646 [grpc-default-executor-0] MqttConnectionImpl - Publish payload format indicator: true
[INFO ] 2023-06-22 17:00:06.680 [grpc-default-executor-0] GRPCControlServer - Publish response: connectionId 1 reason code 0 reason string null
[INFO ] 2023-06-22 17:00:06.681 [Thread-2] MqttConnectionImpl - Received MQTT userProperties: region, US
[INFO ] 2023-06-22 17:00:06.681 [Thread-2] MqttConnectionImpl - Received MQTT userProperties: type, JSON
[INFO ] 2023-06-22 17:00:06.682 [Thread-2] MqttConnectionImpl - RX content type: text/plain; charset=utf-8
[INFO ] 2023-06-22 17:00:06.682 [Thread-2] MqttConnectionImpl - RX payload format indicator: true
[INFO ] 2023-06-22 17:00:06.686 [Thread-2] MqttConnectionImpl - Received MQTT message: connectionId 1 topic test/topic QoS 0 retain false
[INFO ] 2023-06-22 17:00:11.726 [grpc-default-executor-0] GRPCControlServer - Unsubscribe: connectionId 1 for [test/topic] filters
[INFO ] 2023-06-22 17:00:11.728 [grpc-default-executor-0] MqttConnectionImpl - UNSUBSCRIBE MQTT userProperties: region, US
[INFO ] 2023-06-22 17:00:11.729 [grpc-default-executor-0] MqttConnectionImpl - UNSUBSCRIBE MQTT userProperties: type, JSON
[INFO ] 2023-06-22 17:00:11.778 [grpc-default-executor-0] GRPCControlServer - Unsubscribe response: connectionId 1 reason codes [0] reason string null
[INFO ] 2023-06-22 17:00:26.800 [grpc-default-executor-0] GRPCControlServer - closeMqttConnection: connectionId 1 reason 4
[INFO ] 2023-06-22 17:00:26.801 [grpc-default-executor-0] MqttConnectionImpl - TX DISCONNECT MQTT userProperties: region, US
[INFO ] 2023-06-22 17:00:26.801 [grpc-default-executor-0] MqttConnectionImpl - TX DISCONNECT MQTT userProperties: type, JSON
[INFO ] 2023-06-22 17:00:26.804 [Thread-2] MqttConnectionImpl - MQTT connectionId 1 disconnected error 'Mqtt5 client connection interrupted by user request.' disconnectPacket 'null'
[INFO ] 2023-06-22 17:00:26.805 [Thread-2] MqttConnectionImpl - MQTT connectionId 1 stopped
[INFO ] 2023-06-22 17:00:26.850 [grpc-default-executor-0] GRPCControlServer - shutdownAgent: reason That's it.
[INFO ] 2023-06-22 17:00:26.871 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - Server awaitTermination done
[INFO ] 2023-06-22 17:00:26.871 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Shutdown gPRC link
[INFO ] 2023-06-22 17:00:26.888 [com.aws.greengrass.testing.mqtt5.client.Main.main()] Main - Execution done successfully
```
**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
