### PR TITLE
feat(uat): added payload format indicator to paho-java-client

### DIFF
--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
@@ -223,10 +223,4 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
             logger.warn("MQTT V3.1.1 doesn't support 'content type'");
         }
     }
-
-    private void checkContentType(String contentType) {
-        if (contentType != null && !contentType.isEmpty()) {
-            logger.warn("MQTT V3 doesn't support 'content type'");
-        }
-    }
 }

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
@@ -226,7 +226,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
 
     private void checkContentType(String contentType) {
         if (contentType != null && !contentType.isEmpty()) {
-            logger.warn("MQTT V3 doesn't support content type");
+            logger.warn("MQTT V3 doesn't support 'content type'");
         }
     }
 }

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
@@ -126,6 +126,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
     public MqttPublishReply publish(long timeout, @NonNull Message message) {
         checkUserProperties(message.getUserProperties());
         checkContentType(message.getContentType());
+        checkPayloadFormatIndicator(message.getPayloadFormatIndicator());
 
         MqttMessage mqttMessage = new MqttMessage();
         mqttMessage.setQos(message.getQos());
@@ -203,7 +204,8 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
         @Override
         public void messageArrived(String topic, MqttMessage mqttMessage) throws Exception {
             GRPCClient.MqttReceivedMessage message = new GRPCClient.MqttReceivedMessage(
-                    mqttMessage.getQos(), mqttMessage.isRetained(), topic, mqttMessage.getPayload(), null, null);
+                    mqttMessage.getQos(), mqttMessage.isRetained(), topic, mqttMessage.getPayload(),
+                    null, null, null);
             executorService.submit(() -> {
                 grpcClient.onReceiveMqttMessage(connectionId, message);
                 logger.atInfo().log("Received MQTT message: connectionId {} topic {} QoS {} retain {}",
@@ -221,6 +223,12 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
     private void checkContentType(String contentType) {
         if (contentType != null && !contentType.isEmpty()) {
             logger.warn("MQTT V3.1.1 doesn't support 'content type'");
+        }
+    }
+
+    private void checkPayloadFormatIndicator(Boolean payloadFormatIndicator) {
+        if (payloadFormatIndicator != null) {
+            logger.warn("MQTT V3.1.1 doesn't support 'payload format indicator'");
         }
     }
 }

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
@@ -223,4 +223,10 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
             logger.warn("MQTT V3.1.1 doesn't support 'content type'");
         }
     }
+
+    private void checkContentType(String contentType) {
+        if (contentType != null && !contentType.isEmpty()) {
+            logger.warn("MQTT V3 doesn't support content type");
+        }
+    }
 }

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/GRPCClient.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/GRPCClient.java
@@ -33,11 +33,14 @@ public interface GRPCClient {
         /** Payload of message. */
         private byte[] payload;
 
-        /** User properties. */
+        /** Optional user properties. */
         private List<Mqtt5Properties> userProperties;
 
         /** Optional content type. */
         private String contentType;
+
+        /** Optional payload format indicator. */
+        private Boolean payloadFormatIndicator;
     }
 
 

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
@@ -112,11 +112,14 @@ public interface MqttConnection {
         /** Payload of message. */
         private byte[] payload;
 
-        /** User properties. */
+        /** Optional user properties. */
         private List<Mqtt5Properties>  userProperties;
 
         /** Optional content type. */
         private String contentType;
+
+        /** Optional payload format indicator. */
+        private Boolean payloadFormatIndicator;
 
         // TODO: add user's properties and so one
     }

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
@@ -294,6 +294,10 @@ class GRPCControlServer {
                 internalMessage.contentType(message.getContentType());
             }
 
+            if (message.hasPayloadFormatIndicator()) {
+                internalMessage.payloadFormatIndicator(message.getPayloadFormatIndicator());
+            }
+
             MqttPublishReply publishReply = connection.publish(timeout, internalMessage.build());
                 if (publishReply != null) {
                     logger.atInfo().log("Publish response: connectionId {} reason code {} reason string {}",

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
@@ -164,6 +164,12 @@ public class MqttConnectionImpl implements MqttConnection {
             logger.atInfo().log("Publish MQTT payload content type '{}'", contentType);
         }
 
+        Boolean payloadFormatIndicator = message.getPayloadFormatIndicator();
+        if (payloadFormatIndicator != null) {
+            properties.setPayloadFormat(payloadFormatIndicator);
+            logger.atInfo().log("Publish MQTT payload payload format indicator '{}'", payloadFormatIndicator);
+        }
+
         mqttMessage.setProperties(properties);
 
         MqttPublishReply.Builder builder = MqttPublishReply.newBuilder();
@@ -348,12 +354,14 @@ public class MqttConnectionImpl implements MqttConnection {
         @Override
         public void messageArrived(String topic, MqttMessage mqttMessage) {
             MqttProperties receivedProperties = mqttMessage.getProperties();
+
             String contentType = receivedProperties != null ? receivedProperties.getContentType() : null;
+            Boolean payloadFormatIndicator = receivedProperties != null ? receivedProperties.getPayloadFormat() : null;
 
             List<Mqtt5Properties> userProps = convertToMqtt5Properties(receivedProperties);
             GRPCClient.MqttReceivedMessage message = new GRPCClient.MqttReceivedMessage(
                     mqttMessage.getQos(), mqttMessage.isRetained(), topic,
-                    mqttMessage.getPayload(), userProps, contentType);
+                    mqttMessage.getPayload(), userProps, contentType, payloadFormatIndicator);
             executorService.submit(() -> {
                 grpcClient.onReceiveMqttMessage(connectionId, message);
                 logger.atInfo().log("Received MQTT message: connectionId {} topic {} QoS {} retain {}",
@@ -365,6 +373,9 @@ public class MqttConnectionImpl implements MqttConnection {
             }
             if (contentType != null) {
                 logger.atInfo().log("Received MQTT message has content type '{}'", contentType);
+            }
+            if (payloadFormatIndicator != null) {
+                logger.atInfo().log("Received MQTT message has payload format indicator '{}'", contentType);
             }
         }
     }

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
@@ -167,7 +167,7 @@ public class MqttConnectionImpl implements MqttConnection {
         Boolean payloadFormatIndicator = message.getPayloadFormatIndicator();
         if (payloadFormatIndicator != null) {
             properties.setPayloadFormat(payloadFormatIndicator);
-            logger.atInfo().log("Publish MQTT payload payload format indicator '{}'", payloadFormatIndicator);
+            logger.atInfo().log("Publish MQTT payload format indicator '{}'", payloadFormatIndicator);
         }
 
         mqttMessage.setProperties(properties);
@@ -375,7 +375,7 @@ public class MqttConnectionImpl implements MqttConnection {
                 logger.atInfo().log("Received MQTT message has content type '{}'", contentType);
             }
             if (payloadFormatIndicator != null) {
-                logger.atInfo().log("Received MQTT message has payload format indicator '{}'", contentType);
+                logger.atInfo().log("Received MQTT message has payload format indicator '{}'", payloadFormatIndicator);
             }
         }
     }

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
@@ -355,8 +355,12 @@ public class MqttConnectionImpl implements MqttConnection {
         public void messageArrived(String topic, MqttMessage mqttMessage) {
             MqttProperties receivedProperties = mqttMessage.getProperties();
 
-            String contentType = receivedProperties != null ? receivedProperties.getContentType() : null;
-            Boolean payloadFormatIndicator = receivedProperties != null ? receivedProperties.getPayloadFormat() : null;
+            String contentType = null;
+            Boolean payloadFormatIndicator = null;
+            if (receivedProperties != null) {
+                contentType = receivedProperties.getContentType();
+                payloadFormatIndicator = receivedProperties.getPayloadFormat();
+            }
 
             List<Mqtt5Properties> userProps = convertToMqtt5Properties(receivedProperties);
             GRPCClient.MqttReceivedMessage message = new GRPCClient.MqttReceivedMessage(


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-132
added payload format indicator to paho  client

**Description of changes:**
- added payload format indicator to paho  client

**Why is this change necessary:**
to implement Mqtt 5.0 features

**How was this change tested:**
Scenarios run manually and on CI

**Test results:**
*Paho client's logs*:
```
[INFO ] 2023-06-22 18:55:37.022 [main] GRPCLinkImpl - Making gPRC client connection with 127.0.0.1:47619 as best-thing-akezhan...
[INFO ] 2023-06-22 18:55:37.403 [main] GRPCLinkImpl - Client connection with Control is established, local address is 127.0.0.1
[INFO ] 2023-06-22 18:55:37.442 [main] GRPCControlServer - GRPCControlServer created and listed on 127.0.0.1:38373
[INFO ] 2023-06-22 18:55:37.532 [main] GRPCLinkImpl - Handle gRPC requests
[INFO ] 2023-06-22 18:55:37.532 [main] GRPCControlServer - Server awaitTermination
[INFO ] 2023-06-22 18:55:40.601 [grpc-default-executor-0] GRPCControlServer - createMqttConnection: clientId best-thing-akezhan broker a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[INFO ] 2023-06-22 18:55:40.840 [grpc-default-executor-0] MqttConnectionImpl - Connect MQTT userProperties: region, US
[INFO ] 2023-06-22 18:55:40.840 [grpc-default-executor-0] MqttConnectionImpl - Connect MQTT userProperties: type, JSON
[INFO ] 2023-06-22 18:55:47.027 [grpc-default-executor-0] GRPCControlServer - Subscription: filter test/topic QoS 0 noLocal false retainAsPublished false retainHandling 2
[INFO ] 2023-06-22 18:55:47.027 [grpc-default-executor-0] GRPCControlServer - Subscribe: connectionId 1 for 1 filters
[INFO ] 2023-06-22 18:55:47.029 [grpc-default-executor-0] MqttConnectionImpl - Subscribe MQTT userProperties: region, US
[INFO ] 2023-06-22 18:55:47.029 [grpc-default-executor-0] MqttConnectionImpl - Subscribe MQTT userProperties: type, JSON
[INFO ] 2023-06-22 18:55:47.174 [grpc-default-executor-0] GRPCControlServer - Subscribe response: connectionId 1 reason codes [0] reason string 
[INFO ] 2023-06-22 18:55:52.203 [grpc-default-executor-0] GRPCControlServer - Publish: connectionId 1 topic test/topic QoS 1 retain false
[INFO ] 2023-06-22 18:55:52.204 [grpc-default-executor-0] MqttConnectionImpl - Publish MQTT userProperties: region, US
[INFO ] 2023-06-22 18:55:52.204 [grpc-default-executor-0] MqttConnectionImpl - Publish MQTT userProperties: type, JSON
[INFO ] 2023-06-22 18:55:52.204 [grpc-default-executor-0] MqttConnectionImpl - Publish MQTT payload content type: text/plain; charset=utf-8
[INFO ] 2023-06-22 18:55:52.334 [grpc-default-executor-0] GRPCControlServer - Publish response: connectionId 1 reason code 0 reason string 
[INFO ] 2023-06-22 18:55:52.341 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT userProperties: region, US
[INFO ] 2023-06-22 18:55:52.342 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT userProperties: type, JSON
[INFO ] 2023-06-22 18:55:52.342 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT message has content type: text/plain; charset=utf-8
[INFO ] 2023-06-22 18:55:52.357 [pool-3-thread-1] MqttConnectionImpl - Received MQTT message: connectionId 1 topic test/topic QoS 0 retain false
[INFO ] 2023-06-22 18:55:57.354 [grpc-default-executor-0] GRPCControlServer - Unsubscribe: connectionId 1 for [test/topic] filters
[INFO ] 2023-06-22 18:55:57.355 [grpc-default-executor-0] MqttConnectionImpl - Unsubscribe MQTT userProperties: region, US
[INFO ] 2023-06-22 18:55:57.355 [grpc-default-executor-0] MqttConnectionImpl - Unsubscribe MQTT userProperties: type, JSON
[INFO ] 2023-06-22 18:55:57.480 [grpc-default-executor-0] GRPCControlServer - Unsubscribe response: connectionId 1 reason codes [0] reason string 
[INFO ] 2023-06-22 18:56:12.500 [grpc-default-executor-0] GRPCControlServer - closeMqttConnection: connectionId 1 reason 4
[INFO ] 2023-06-22 18:56:12.501 [grpc-default-executor-0] MqttConnectionImpl - Disconnect MQTT userProperties: region, US
[INFO ] 2023-06-22 18:56:12.501 [grpc-default-executor-0] MqttConnectionImpl - Disconnect MQTT userProperties: type, JSON
[INFO ] 2023-06-22 18:56:12.635 [grpc-default-executor-0] GRPCControlServer - shutdownAgent: reason That's it.
[INFO ] 2023-06-22 18:56:12.648 [main] GRPCControlServer - Server awaitTermination done
[INFO ] 2023-06-22 18:56:12.648 [main] GRPCLinkImpl - Shutdown gPRC link
[INFO ] 2023-06-22 18:56:12.662 [main] Main - Execution done successfully
```
*Control's logs*:
```
[INFO ] 2023-06-22 18:55:33.277 [com.aws.greengrass.testing.mqtt.client.control.ExampleControl.main()] ExampleControl - Control: port 47619, with TLS, MQTT v5
[INFO ] 2023-06-22 18:55:33.492 [com.aws.greengrass.testing.mqtt.client.control.ExampleControl.main()] EngineControlImpl - MQTT client control gRPC server started, listening on 47619
[INFO ] 2023-06-22 18:55:37.366 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId best-thing-akezhan
[INFO ] 2023-06-22 18:55:37.447 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId best-thing-akezhan address 127.0.0.1 port 38373
[INFO ] 2023-06-22 18:55:37.450 [grpc-default-executor-0] EngineControlImpl - Created new agent control for best-thing-akezhan on 127.0.0.1:38373
[INFO ] 2023-06-22 18:55:37.488 [grpc-default-executor-0] ExampleControl - Agent best-thing-akezhan is connected
[INFO ] 2023-06-22 18:55:37.491 [pool-2-thread-1] AgentTestScenario - Playing test scenario for agent id best-thing-akezhan
[INFO ] 2023-06-22 18:55:40.499 [pool-2-thread-1] AgentTestScenario - Connect MQTT userProperties: region, US
[INFO ] 2023-06-22 18:55:40.499 [pool-2-thread-1] AgentTestScenario - Connect MQTT userProperties: type, JSON
[INFO ] 2023-06-22 18:55:42.006 [pool-2-thread-1] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
receiveMaximum: 100
maximumQoS: 1
retainAvailable: true
maximumPacketSize: 149504
serverKeepAlive: 60
'
[INFO ] 2023-06-22 18:55:42.006 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-06-22 18:55:42.006 [pool-2-thread-1] AgentTestScenario - MQTT connection with id 1 is established
[INFO ] 2023-06-22 18:55:47.011 [pool-2-thread-1] AgentTestScenario - Subscribe MQTT userProperties: region, US
[INFO ] 2023-06-22 18:55:47.012 [pool-2-thread-1] AgentTestScenario - Subscribe MQTT userProperties: type, JSON
[INFO ] 2023-06-22 18:55:47.013 [pool-2-thread-1] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-06-22 18:55:47.181 [pool-2-thread-1] AgentTestScenario - Subscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-06-22 18:55:52.186 [pool-2-thread-1] AgentTestScenario - Publish MQTT userProperties: region, US
[INFO ] 2023-06-22 18:55:52.186 [pool-2-thread-1] AgentTestScenario - Publish MQTT userProperties: type, JSON
[INFO ] 2023-06-22 18:55:52.188 [pool-2-thread-1] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic test/topic
[INFO ] 2023-06-22 18:55:52.340 [pool-2-thread-1] AgentTestScenario - Published connectionId 1 reason code 0 reason string ''
[INFO ] 2023-06-22 18:55:52.352 [grpc-default-executor-0] GRPCDiscoveryServer - OnReceiveMessage: agentId best-thing-akezhan connectionId 1 topic test/topic QoS 0
[INFO ] 2023-06-22 18:55:52.353 [grpc-default-executor-0] AgentTestScenario - Message received on agentId best-thing-akezhan connectionId 1 topic test/topic QoS 0 content <ByteString@482f0023 size=12 contents="Hello World!">
[INFO ] 2023-06-22 18:55:52.353 [grpc-default-executor-0] AgentTestScenario - Message has user property key region value US
[INFO ] 2023-06-22 18:55:52.353 [grpc-default-executor-0] AgentTestScenario - Message has user property key type value JSON
[INFO ] 2023-06-22 18:55:52.353 [grpc-default-executor-0] AgentTestScenario - Message has content type 'text/plain; charset=utf-8'
[INFO ] 2023-06-22 18:55:57.341 [pool-2-thread-1] AgentTestScenario - Unsubscribe MQTT userProperties: region, US
[INFO ] 2023-06-22 18:55:57.342 [pool-2-thread-1] AgentTestScenario - Unsubscribe MQTT userProperties: type, JSON
[INFO ] 2023-06-22 18:55:57.347 [pool-2-thread-1] AgentControlImpl - UnsubscribeMqtt: unsubscribe on connectionId 1
[INFO ] 2023-06-22 18:55:57.485 [pool-2-thread-1] AgentTestScenario - Unsubscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-06-22 18:56:12.486 [pool-2-thread-1] AgentTestScenario - Disconnect MQTT userProperties: region, US
[INFO ] 2023-06-22 18:56:12.487 [pool-2-thread-1] AgentTestScenario - Disconnect MQTT userProperties: type, JSON
[INFO ] 2023-06-22 18:56:12.624 [pool-2-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 1 closed
[INFO ] 2023-06-22 18:56:12.641 [pool-2-thread-1] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-06-22 18:56:12.657 [grpc-default-executor-0] GRPCDiscoveryServer - UnregisterAgent: agentId best-thing-akezhan reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-06-22 18:56:12.659 [grpc-default-executor-0] ExampleControl - Agent best-thing-akezhan is disconnected
^C[INFO ] 2023-06-22 18:57:25.451 [Thread-1] ExampleControl - *** shutting down gRPC server since JVM is shutting down
```


**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

