### PR TITLE
fix(sdk-java-client): add passing event about disconnect

### DIFF
--- a/uat/README.md
+++ b/uat/README.md
@@ -104,11 +104,11 @@ Download https://d2s8p88vqu9w66.cloudfront.net/releases/greengrass-nucleus-lates
 Execute the UATs by running the following commands from the uat directory of the project.
 
 ```bash
-sudo java -Dggc.archive=<path-to-nucleus-zip> -Dtest.log.path=<path-to-test-results-folder> -Dtags=GGMQ -jar <path-to-test-jar>
+sudo -E java -Dggc.archive=<path-to-nucleus-zip> -Dtest.log.path=<path-to-test-results-folder> -Dtags=GGMQ -jar <path-to-test-jar>
 ```
 An example to run from uat directory:
 ```bash
-sudo java -Dggc.archive=greengrass-nucleus-latest.zip -Dtest.log.path=logs -Dtags="GGMQ" -jar testing-features/target/client-devices-auth-testing-features.jar
+sudo -E java -Dggc.archive=greengrass-nucleus-latest.zip -Dtest.log.path=logs -Dtags="GGMQ" -jar testing-features/target/client-devices-auth-testing-features.jar
 ```
 
 ### Run scenarios on Windows

--- a/uat/custom-components/client-java-sdk/README.md
+++ b/uat/custom-components/client-java-sdk/README.md
@@ -68,5 +68,3 @@ Real UNSUBACK information is not available from that client. Instead hard-coded 
 SUBSCRIBE and UNSUBSCRIBE requests are limited to only one filter due to SDK client API limitation.
 
 Real PUBACK information is not available from that client. Instead hard-coded reason code 0 is used to create a response on gRPC request.
-
-Disconnect reason code 0 will be used in any disconnect gRPC event due to corresponding field missing in MQTT 3.1.1 DISCONNECT.

--- a/uat/custom-components/client-java-sdk/README.md
+++ b/uat/custom-components/client-java-sdk/README.md
@@ -55,14 +55,18 @@ Topic alias maximum is not provided by [ConnAckPacket](https://awslabs.github.io
 ## MQTT v3.1.1 client
 Reason string is not available in MQTT 3.1.1, corresponding fields of gRPC messages will not be set.
 
+Reason string in Mqtt5Disconnect will be filled by string provided by CRT library.
+
 SDK-based client does not provide OS specific error code or string, corresponding fields of gRPC messages will be not set.
 
-SDK-based client provides only session present flag of CONNACK packet. The Connect Return code of CONNACK is missing.
+SDK-based client provides only session present flag of CONNACK packet. The Connect result code of CONNACK is missing.
 
-Real SUBACK information is not available from that client. Instead hard-coded Result Code 0 is used to create a response on gRPC request.
+Real SUBACK information is not available from that client. Instead hard-coded reason code 0 is used to create a response on gRPC request.
 
-Real UNSUBACK information is not available from that client. Instead hard-coded Result Code 0 is used to create a response on gRPC request.
+Real UNSUBACK information is not available from that client. Instead hard-coded reason code 0 is used to create a response on gRPC request.
 
 SUBSCRIBE and UNSUBSCRIBE requests are limited to only one filter due to SDK client API limitation.
 
-Real PUBACK information is not available from that client. Instead hard-coded Result Code 0 is used to create a response on gRPC request.
+Real PUBACK information is not available from that client. Instead hard-coded reason code 0 is used to create a response on gRPC request.
+
+Disconnect reason code 0 will be used in any disconnect gRPC event due to corresponding field missing in MQTT 3.1.1 DISCONNECT.

--- a/uat/custom-components/client-java-sdk/pom.xml
+++ b/uat/custom-components/client-java-sdk/pom.xml
@@ -54,6 +54,12 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk.crt</groupId>
+            <artifactId>aws-crt</artifactId>
+            <version>${aws.crt.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-bom</artifactId>
             <version>${grpc.version}</version>

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt311/client/sdkmqtt/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt311/client/sdkmqtt/Mqtt311ConnectionImpl.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.testing.mqtt311.client.sdkmqtt;
 
 import com.aws.greengrass.testing.mqtt.client.Mqtt5Properties;
 import com.aws.greengrass.testing.mqtt5.client.GRPCClient;
+import com.aws.greengrass.testing.mqtt5.client.GRPCClient.DisconnectInfo;
 import com.aws.greengrass.testing.mqtt5.client.GRPCClient.MqttReceivedMessage;
 import com.aws.greengrass.testing.mqtt5.client.MqttConnection;
 import com.aws.greengrass.testing.mqtt5.client.MqttLib;
@@ -19,6 +20,7 @@ import software.amazon.awssdk.crt.mqtt.MqttClientConnection;
 import software.amazon.awssdk.crt.mqtt.MqttClientConnectionEvents;
 import software.amazon.awssdk.crt.mqtt.MqttMessage;
 import software.amazon.awssdk.crt.mqtt.OnConnectionClosedReturn;
+import software.amazon.awssdk.crt.mqtt.OnConnectionFailureReturn;
 import software.amazon.awssdk.crt.mqtt.OnConnectionSuccessReturn;
 import software.amazon.awssdk.crt.mqtt.QualityOfService;
 import software.amazon.awssdk.iot.AwsIotMqttConnectionBuilder;
@@ -65,7 +67,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
         }
 
         @Override
-        void onConnectionFailure(OnConnectionFailureReturn data) {
+        public void onConnectionFailure(OnConnectionFailureReturn data) {
             isConnected.set(false);
 
             int errorCode = -1;
@@ -105,7 +107,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
             }
 
             logger.atInfo().log("MQTT connection {} connecteed or reconnected sessionPresent {}", connectionId,
-                                isSessionPresent);
+                                sessionPresent);
         }
     };
 

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCDiscoveryClient.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCDiscoveryClient.java
@@ -157,14 +157,29 @@ class GRPCDiscoveryClient implements GRPCClient {
     public void onMqttDisconnect(int connectionId, DisconnectInfo disconnectInfo, String error) {
         OnMqttDisconnectRequest.Builder builder = OnMqttDisconnectRequest.newBuilder()
                         .setAgentId(agentId)
-                        .setConnectionId(MqttConnectionId.newBuilder().setConnectionId(connectionId)
-                        .build());
+                        .setConnectionId(MqttConnectionId.newBuilder().setConnectionId(connectionId).build());
         if (disconnectInfo != null) {
-            Mqtt5Disconnect.Builder disconnectBuilder = Mqtt5Disconnect.newBuilder()
-                .setReasonCode(disconnectInfo.getReasonCode())
-                .setReasonString(disconnectInfo.getReasonString())
-                .setServerReference(disconnectInfo.getServerReference())
-                .setSessionExpiryInterval(disconnectInfo.getSessionExpiryInterval());
+            Mqtt5Disconnect.Builder disconnectBuilder = Mqtt5Disconnect.newBuilder();
+
+            final Integer reasonCode = disconnectInfo.getReasonCode();
+            if (reasonCode != null) {
+                disconnectBuilder.setReasonCode(reasonCode);
+            }
+
+            final Integer sessionExpiryInterval = disconnectInfo.getSessionExpiryInterval();
+            if (sessionExpiryInterval != null) {
+                disconnectBuilder.setSessionExpiryInterval(sessionExpiryInterval);
+            }
+
+            final String reasonString = disconnectInfo.getReasonString();
+            if (reasonString != null) {
+                disconnectBuilder.setReasonString(reasonString);
+            }
+
+            final String serverReference = disconnectInfo.getServerReference();
+            if (serverReference != null) {
+                disconnectBuilder.setServerReference(serverReference);
+            }
 
             final List<Mqtt5Properties> userProperties = disconnectInfo.getUserProperties();
             if (userProperties != null && !userProperties.isEmpty()) {
@@ -173,6 +188,7 @@ class GRPCDiscoveryClient implements GRPCClient {
 
             builder.setDisconnect(disconnectBuilder.build());
         }
+
         if (error != null) {
             builder.setError(error);
         }

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
@@ -42,9 +42,9 @@ class AgentTestScenario implements Runnable {
     // pauses in milliseconds
     private static final long PAUSE_BEFORE_CONNECT = 3_000;
     private static final long PAUSE_BEFORE_SUBSCRIBE = 5_000;
-    private static final long PAUSE_BEFORE_PUBLISH = 5_000;
+    private static final long PAUSE_BEFORE_PUBLISH = 10_000;
     private static final long PAUSE_BEFORE_UNSUBSCRIBE = 5_000;
-    private static final long PAUSE_BEFORE_DISCONNECT = 15_000;
+    private static final long PAUSE_BEFORE_DISCONNECT = 10_000;
 
 
     private static final String MQTT_CLIENT_ID = "MQTT_CLIENT_ID";

--- a/uat/pom.xml
+++ b/uat/pom.xml
@@ -54,7 +54,8 @@
         <grpc.version>1.53.0</grpc.version>
         <os.plugin.version>1.7.1</os.plugin.version>
         <lombok.version>1.18.22</lombok.version>
-        <iot.device.sdk.version>1.11.2</iot.device.sdk.version>
+        <iot.device.sdk.version>1.13.2</iot.device.sdk.version>
+        <aws.crt.version>0.22.2</aws.crt.version>
         <paho.agent.version>1.2.5</paho.agent.version>
         <bouncycastle.version>1.70</bouncycastle.version>
         <tomcat.annotations.api.version>6.0.53</tomcat.annotations.api.version>


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-251
SDK-based client does not call onMqttDisconnect when client disconnected


**Description of changes:**
- Add call to trigger disconnect event
- Resolve issue NPE in onMqttDisconnect
- Add more callbacks to MQTT v3.1.1 client
- Use latest CRT version with new callbacks
- Add exception logging for code called in executorService
- Update two README files
- Update control to make 10 sec pause between subscribe and publish to simplify manual tests

**Why is this change necessary:**
Bug so not allow to send disconnect event to control from sdk-java client

**How was this change tested:**
Manually. 
Use client, control app and local mosquitto broker and terminate it in the middle between client's subscribe and publish.
Check logs in client and control. Ensure control received and logged disconnect event.

**Test results:**
Control:
```
$ ./run_for_mosquitto_311.sh
[INFO ] 2023-06-30 19:15:41.889 [main] ExampleControl - Control: port 47619, with TLS, MQTT v3
[INFO ] 2023-06-30 19:15:42.142 [main] EngineControlImpl - MQTT client control gRPC server started, listening on 47619
[INFO ] 2023-06-30 19:15:57.990 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId sdk-java-agent
[INFO ] 2023-06-30 19:15:58.051 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId sdk-java-agent address 127.0.0.1 port 33007
[INFO ] 2023-06-30 19:15:58.054 [grpc-default-executor-0] EngineControlImpl - Created new agent control for sdk-java-agent on 127.0.0.1:33007
[INFO ] 2023-06-30 19:15:58.097 [grpc-default-executor-0] ExampleControl - Agent sdk-java-agent is connected
[INFO ] 2023-06-30 19:15:58.101 [pool-2-thread-1] AgentTestScenario - Playing test scenario for agent id sdk-java-agent
[INFO ] 2023-06-30 19:16:01.671 [pool-2-thread-1] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
'
[INFO ] 2023-06-30 19:16:01.671 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-06-30 19:16:01.671 [pool-2-thread-1] AgentTestScenario - MQTT connection with id 1 is established
[INFO ] 2023-06-30 19:16:06.681 [pool-2-thread-1] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-06-30 19:16:06.697 [pool-2-thread-1] AgentTestScenario - Subscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-06-30 19:16:08.119 [grpc-default-executor-0] GRPCDiscoveryServer - OnMqttDisconnect: agentId sdk-java-agent connectionId 1 disconnect '' error 'The connection was closed unexpectedly.'
[INFO ] 2023-06-30 19:16:08.120 [grpc-default-executor-0] AgentTestScenario - MQTT disconnected on agentId sdk-java-agent connectionId 1 disconnect '' error 'The connection was closed unexpectedly.'
[INFO ] 2023-06-30 19:16:11.702 [pool-2-thread-1] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic test/topic
[ERROR] 2023-06-30 19:16:11.722 [pool-2-thread-1] AgentTestScenario - gRPC error code UNKNOWN: description: null
io.grpc.StatusRuntimeException: UNKNOWN
	at io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:271) ~[grpc-stub-1.53.0.jar:1.53.0]
	at io.grpc.stub.ClientCalls.getUnchecked(ClientCalls.java:252) ~[grpc-stub-1.53.0.jar:1.53.0]
	at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:165) ~[grpc-stub-1.53.0.jar:1.53.0]
	at com.aws.greengrass.testing.mqtt.client.MqttClientControlGrpc$MqttClientControlBlockingStub.publishMqtt(MqttClientControlGrpc.java:531) ~[aws-greengrass-testing-mqtt-client-control-1.0-SNAPSHOT.jar:?]
	at com.aws.greengrass.testing.mqtt.client.control.implementation.AgentControlImpl.publishMqtt(AgentControlImpl.java:249) ~[aws-greengrass-testing-mqtt-client-control-1.0-SNAPSHOT.jar:?]
	at com.aws.greengrass.testing.mqtt.client.control.implementation.ConnectionControlImpl.publishMqtt(ConnectionControlImpl.java:147) ~[aws-greengrass-testing-mqtt-client-control-1.0-SNAPSHOT.jar:?]
	at com.aws.greengrass.testing.mqtt.client.control.AgentTestScenario.testPublish(AgentTestScenario.java:257) ~[aws-greengrass-testing-mqtt-client-control-1.0-SNAPSHOT.jar:?]
	at com.aws.greengrass.testing.mqtt.client.control.AgentTestScenario.run(AgentTestScenario.java:174) [aws-greengrass-testing-mqtt-client-control-1.0-SNAPSHOT.jar:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:834) [?:?]
[INFO ] 2023-06-30 19:16:15.119 [grpc-default-executor-0] GRPCDiscoveryServer - OnMqttDisconnect: agentId sdk-java-agent connectionId 1 disconnect '' error 'Success.'
[INFO ] 2023-06-30 19:16:15.120 [grpc-default-executor-0] AgentTestScenario - MQTT disconnected on agentId sdk-java-agent connectionId 1 disconnect '' error 'Success.'
[INFO ] 2023-06-30 19:16:15.140 [pool-2-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 1 closed
[INFO ] 2023-06-30 19:16:15.152 [pool-2-thread-1] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-06-30 19:16:15.168 [grpc-default-executor-0] GRPCDiscoveryServer - UnregisterAgent: agentId sdk-java-agent reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-06-30 19:16:15.170 [grpc-default-executor-0] ExampleControl - Agent sdk-java-agent is disconnected
```

Client:
```
[INFO ] 2023-06-30 19:15:57.522 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Making gPRC client connection with 127.0.0.1:47619 as sdk-java-agent...
[INFO ] 2023-06-30 19:15:58.010 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Client connection with Control is established, local address is 127.0.0.1
[INFO ] 2023-06-30 19:15:58.046 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - GRPCControlServer created and listed on 127.0.0.1:33007
[INFO ] 2023-06-30 19:15:58.105 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Handle gRPC requests
[INFO ] 2023-06-30 19:15:58.105 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - Server awaitTermination
[INFO ] 2023-06-30 19:16:01.213 [grpc-default-executor-0] GRPCControlServer - createMqttConnection: clientId client broker server:8883
[INFO ] 2023-06-30 19:16:01.218 [grpc-default-executor-0] Mqtt311ConnectionImpl - Creating AwsIotMqttConnectionBuilder with TLS
[INFO ] 2023-06-30 19:16:01.552 [grpc-default-executor-0] Mqtt311ConnectionImpl - MQTT 3.1.1 connection 1 is establisted
[INFO ] 2023-06-30 19:16:01.552 [Thread-2] Mqtt311ConnectionImpl - MQTT connection 1 connecteed or reconnected sessionPresent false
[INFO ] 2023-06-30 19:16:06.689 [grpc-default-executor-0] GRPCControlServer - Subscription: filter test/topic QoS 0 noLocal false retainAsPublished false retainHandling 2
[INFO ] 2023-06-30 19:16:06.689 [grpc-default-executor-0] GRPCControlServer - Subscribe: connectionId 1 subscriptionId null for 1 filters
[INFO ] 2023-06-30 19:16:06.692 [grpc-default-executor-0] Mqtt311ConnectionImpl - Subscribed on connection 1 for topics filter test/topic QoS AT_MOST_ONCE packet Id 1
[INFO ] 2023-06-30 19:16:06.692 [grpc-default-executor-0] GRPCControlServer - Subscribe response: connectionId 1 reason codes [0] reason string null
[INFO ] 2023-06-30 19:16:08.103 [Thread-2] Mqtt311ConnectionImpl - MQTT connection 1 interrupted, error code 5134: The connection was closed unexpectedly.
[INFO ] 2023-06-30 19:16:08.103 [pool-3-thread-1] GRPCDiscoveryClient - onMqttDisconnect
[INFO ] 2023-06-30 19:16:08.109 [pool-3-thread-1] GRPCDiscoveryClient - Doing gRPC OnMqttDisconnect
[INFO ] 2023-06-30 19:16:08.122 [pool-3-thread-1] GRPCDiscoveryClient - Done gRPC OnMqttDisconnect
[INFO ] 2023-06-30 19:16:11.712 [grpc-default-executor-0] GRPCControlServer - Publish: connectionId 1 topic test/topic QoS 1 retain false
[ERROR] 2023-06-30 19:16:11.713 [grpc-default-executor-0] GRPCControlServer - exception during publish
com.aws.greengrass.testing.mqtt5.client.exceptions.MqttException: MQTT client is not in connected state
	at com.aws.greengrass.testing.mqtt311.client.sdkmqtt.Mqtt311ConnectionImpl.stateCheck(Mqtt311ConnectionImpl.java:396) ~[classes/:?]
	at com.aws.greengrass.testing.mqtt311.client.sdkmqtt.Mqtt311ConnectionImpl.publish(Mqtt311ConnectionImpl.java:231) ~[classes/:?]
	at com.aws.greengrass.testing.mqtt5.client.grpc.GRPCControlServer$MqttClientControlImpl.publishMqtt(GRPCControlServer.java:385) [classes/:?]
	at com.aws.greengrass.testing.mqtt.client.MqttClientControlGrpc$MethodHandlers.invoke(MqttClientControlGrpc.java:667) [classes/:?]
	at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182) [grpc-stub-1.53.0.jar:1.53.0]
	at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:355) [grpc-core-1.53.0.jar:1.53.0]
	at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:867) [grpc-core-1.53.0.jar:1.53.0]
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37) [grpc-core-1.53.0.jar:1.53.0]
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133) [grpc-core-1.53.0.jar:1.53.0]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:834) [?:?]
[INFO ] 2023-06-30 19:16:11.745 [grpc-default-executor-0] GRPCControlServer - closeMqttConnection: connectionId 1 reason 4
[INFO ] 2023-06-30 19:16:15.109 [Thread-2] Mqtt311ConnectionImpl - MQTT connection 1 interrupted, error code 0: Success.
[INFO ] 2023-06-30 19:16:15.109 [pool-3-thread-1] GRPCDiscoveryClient - onMqttDisconnect
[INFO ] 2023-06-30 19:16:15.110 [pool-3-thread-1] GRPCDiscoveryClient - Doing gRPC OnMqttDisconnect
[INFO ] 2023-06-30 19:16:15.111 [Thread-2] Mqtt311ConnectionImpl - MQTT connection 1 closed
[INFO ] 2023-06-30 19:16:15.129 [pool-3-thread-1] GRPCDiscoveryClient - Done gRPC OnMqttDisconnect
[INFO ] 2023-06-30 19:16:15.131 [grpc-default-executor-0] Mqtt311ConnectionImpl - MQTT 3.1.1 connection 1 has been disconnected
[INFO ] 2023-06-30 19:16:15.148 [grpc-default-executor-0] GRPCControlServer - shutdownAgent: reason That's it.
[INFO ] 2023-06-30 19:16:15.162 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - Server awaitTermination done
[INFO ] 2023-06-30 19:16:15.162 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Shutdown gPRC link
[INFO ] 2023-06-30 19:16:15.174 [com.aws.greengrass.testing.mqtt5.client.Main.main()] Main - Execution done successfully
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
