### PR TITLE
feat(uat): implement request/response in mosquitto client and control app

### DIFF
--- a/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
@@ -164,8 +164,15 @@ Status GRPCControlServer::CreateMqttConnection(ServerContext *, const MqttConnec
         key_char = key.c_str();
     }
 
+    bool rri;
+    bool * p_rri = NULL;
+    if (request->has_requestresponseinformation()) {
+        rri = request->requestresponseinformation();
+        p_rri = &rri;
+    }
+
     try {
-        MqttConnection * connection = m_mqtt->createConnection(m_client, client_id, host, port, keepalive, request->cleansession(), ca_char, cert_char, key_char, v5, request->properties());
+        MqttConnection * connection = m_mqtt->createConnection(m_client, client_id, host, port, keepalive, request->cleansession(), ca_char, cert_char, key_char, v5, request->properties(), p_rri);
         ClientControl::Mqtt5ConnAck * conn_ack = connection->start(timeout);
         int connection_id = m_mqtt->registerConnection(connection);
 

--- a/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
@@ -267,6 +267,20 @@ Status GRPCControlServer::PublishMqtt(ServerContext *, const MqttPublishRequest 
         p_message_expiry_interval = &message_expiry_interval;
     }
 
+    std::string response_topic;
+    std::string * p_response_topic = NULL;
+    if (message.has_responsetopic()) {
+        response_topic = message.responsetopic();
+        p_response_topic = &response_topic;
+    }
+
+    std::string correlation_data;
+    std::string * p_correlation_data = NULL;
+    if (message.has_correlationdata()) {
+        correlation_data = message.correlationdata();
+        p_correlation_data = &correlation_data;
+    }
+
     const MqttConnectionId & connection_id_obj = request->connectionid();
     int connection_id = connection_id_obj.connectionid();
 
@@ -283,7 +297,8 @@ Status GRPCControlServer::PublishMqtt(ServerContext *, const MqttPublishRequest 
         ClientControl::MqttPublishReply * result = connection->publish(timeout, qos, is_retain, topic,
                                                                         message.payload(), message.properties(),
                                                                         p_content_type, p_payload_format_indicator,
-                                                                        p_message_expiry_interval);
+                                                                        p_message_expiry_interval, p_response_topic,
+                                                                        p_correlation_data);
         if (result) {
             if (result->has_reasoncode()) {
                 reply->set_reasoncode(result->reasoncode());

--- a/uat/custom-components/client-mosquitto-c/src/MqttConnection.h
+++ b/uat/custom-components/client-mosquitto-c/src/MqttConnection.h
@@ -115,6 +115,8 @@ public:
      * @param content_type the optional content type
      * @param payload_format_indicator the pointer to optional value of 'payload format indicator' of the message
      * @param message_expiry_interval the pointer to optinal value of 'message expiry interval'
+     * @param response_topic the pointer to optional response topic
+     * @param correlation_data the pointer to optional binary correlation data
      * @return pointer to allocated gRPC MqttPublishReply
      * @throw MqttException on errors
      */
@@ -122,7 +124,8 @@ public:
                                                 const std::string & payload,
                                                 const RepeatedPtrField<ClientControl::Mqtt5Properties> & user_properties,
                                                 const std::string * content_type, const bool * payload_format_indicator,
-                                                const int * message_expiry_interval);
+                                                const int * message_expiry_interval, const std::string * response_topic,
+                                                const std::string * correlation_data);
 
     /**
      * Disconnect from the broker.

--- a/uat/custom-components/client-mosquitto-c/src/MqttConnection.h
+++ b/uat/custom-components/client-mosquitto-c/src/MqttConnection.h
@@ -49,11 +49,14 @@ public:
      * @param key pointer to client's key content, can be NULL
      * @param v5 use MQTT v5.0
      * @param user_properties the user properties of the CONNECT request
+     * @param request_response_information pointer to optional request response information flag
      * @throw MqttException on errors
      */
     MqttConnection(GRPCDiscoveryClient & grpc_client, const std::string & client_id, const std::string & host,
                     unsigned short port, unsigned short keepalive, bool clean_session, const char * ca,
-                    const char * cert, const char * key, bool v5, const RepeatedPtrField<ClientControl::Mqtt5Properties> & user_properties);
+                    const char * cert, const char * key, bool v5,
+                    const RepeatedPtrField<ClientControl::Mqtt5Properties> & user_properties,
+                    const bool * request_response_information);
     ~MqttConnection();
 
 
@@ -196,6 +199,7 @@ private:
     std::string m_key;
 
     mosquitto_property * m_conn_properties;
+    bool * m_request_response_information;
 
     struct mosquitto * m_mosq;
 

--- a/uat/custom-components/client-mosquitto-c/src/MqttLib.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/MqttLib.cpp
@@ -33,8 +33,9 @@ MqttLib::~MqttLib() {
 MqttConnection * MqttLib::createConnection(GRPCDiscoveryClient & grpc_client, const std::string & client_id,
                                             const std::string & host, unsigned short port, unsigned short keepalive,
                                             bool clean_session, const char * ca, const char * cert, const char * key,
-                                            bool v5, const RepeatedPtrField<ClientControl::Mqtt5Properties> & user_properties) {
-    return new MqttConnection(grpc_client, client_id, host, port, keepalive, clean_session, ca, cert, key, v5, user_properties);
+                                            bool v5, const RepeatedPtrField<ClientControl::Mqtt5Properties> & user_properties,
+                                            const bool * rri) {
+    return new MqttConnection(grpc_client, client_id, host, port, keepalive, clean_session, ca, cert, key, v5, user_properties, rri);
 }
 
 

--- a/uat/custom-components/client-mosquitto-c/src/MqttLib.h
+++ b/uat/custom-components/client-mosquitto-c/src/MqttLib.h
@@ -43,13 +43,15 @@ public:
      * @param key pointer to client's key content, can be NULL
      * @param v5 use MQTT v5.0
      * @param user_properties the user properties of the connect request
+     * @param request_response_information pointer to optional request response information flag
      * @return MqttConnection on success
      * @throw MqttException on errors
      */
     MqttConnection * createConnection(GRPCDiscoveryClient & grpc_client, const std::string & client_id,
                                         const std::string & host, unsigned short port, unsigned short keepalive,
                                         bool clean_session, const char * ca, const char * cert, const char * key,
-                                        bool v5, const RepeatedPtrField<ClientControl::Mqtt5Properties> & user_properties);
+                                        bool v5, const RepeatedPtrField<ClientControl::Mqtt5Properties> & user_properties,
+                                        const bool * request_response_information);
 
 
     int registerConnection(MqttConnection * connection);

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
@@ -69,6 +69,8 @@ class AgentTestScenario implements Runnable {
     private static final boolean CLEAN_SESSION = true;
     private static final int CONNECT_TIMEOUT = 30;
 
+    private static final Boolean REQUEST_RESPONSE_INFORMATION = true;
+
     private static final int DISCONNECT_REASON = 4;
 
     private static final String PUBLISH_TOPIC = "test/topic";
@@ -198,7 +200,7 @@ class AgentTestScenario implements Runnable {
                 // close MQTT connection
                 List<Mqtt5Properties> userProperties = null;
                 if (mqtt50) {
-                    userProperties = createMqtt5Properties("Disconnect");
+                    userProperties = createMqtt5Properties("DISCONNECT");
                 }
                 connectionControl.closeMqttConnection(DISCONNECT_REASON, userProperties);
             }
@@ -220,7 +222,12 @@ class AgentTestScenario implements Runnable {
                                                 : MqttProtoVersion.MQTT_PROTOCOL_V_311);
 
         if (mqtt50) {
-            builder.addAllProperties(createMqtt5Properties("Connect"));
+            builder.addAllProperties(createMqtt5Properties("CONNECT"));
+
+            if (REQUEST_RESPONSE_INFORMATION != null) {
+                builder.setRequestResponseInformation(REQUEST_RESPONSE_INFORMATION);
+                logger.atInfo().log("Set CONNECT request response information {}", REQUEST_RESPONSE_INFORMATION);
+            }
         }
 
         if (useTLS) {
@@ -238,7 +245,7 @@ class AgentTestScenario implements Runnable {
 
         List<Mqtt5Properties> userProperties = null;
         if (mqtt50) {
-            userProperties = createMqtt5Properties("Subscribe");
+            userProperties = createMqtt5Properties("SUBSCRIBE");
         }
 
         MqttSubscribeReply reply = connectionControl.subscribeMqtt(SUBSCRIPTION_ID, userProperties, subscription);
@@ -283,30 +290,30 @@ class AgentTestScenario implements Runnable {
         if (mqtt50) {
             if (payloadFormatIndicator != null) {
                 builder.setPayloadFormatIndicator(payloadFormatIndicator);
-                logger.atInfo().log("Set payload format indicator {}", payloadFormatIndicator);
+                logger.atInfo().log("Set PUBLISH payload format indicator {}", payloadFormatIndicator);
             }
 
             if (messageExpiryInterval != null) {
                 builder.setMessageExpiryInterval(messageExpiryInterval);
-                logger.atInfo().log("Set message expiry interval {}", messageExpiryInterval);
+                logger.atInfo().log("Set PUBLISH message expiry interval {}", messageExpiryInterval);
             }
 
             if (responseTopic != null) {
                 builder.setResponseTopic(responseTopic);
-                logger.atInfo().log("Set response topic {}", responseTopic);
+                logger.atInfo().log("Set PUBLISH response topic {}", responseTopic);
             }
 
             if (correlationData != null) {
                 ByteString byteString = ByteString.copyFrom(correlationData);
                 builder.setCorrelationData(byteString);
-                logger.atInfo().log("Set correlation data {}", byteString);
+                logger.atInfo().log("Set PUBLISH correlation data {}", byteString);
             }
 
-            builder.addAllProperties(createMqtt5Properties("Publish"));
+            builder.addAllProperties(createMqtt5Properties("PUBLISH"));
 
             if (contentType != null) {
                 builder.setContentType(contentType);
-                logger.atInfo().log("Set content type {}", contentType);
+                logger.atInfo().log("Set PUBLISH content type {}", contentType);
             }
         }
 
@@ -318,14 +325,14 @@ class AgentTestScenario implements Runnable {
         properties.add(Mqtt5Properties.newBuilder().setKey("region").setValue("US").build());
         properties.add(Mqtt5Properties.newBuilder().setKey("type").setValue("JSON").build());
         properties.forEach(p -> logger.atInfo()
-                .log("{} Set user property: {}, {}", commandName, p.getKey(), p.getValue()));
+                .log("Set {} user property: {}, {}", commandName, p.getKey(), p.getValue()));
         return properties;
     }
 
     private void testUnsubscribe(ConnectionControl connectionControl) {
         List<Mqtt5Properties> userProperties = null;
         if (mqtt50) {
-            userProperties = createMqtt5Properties("Unsubscribe");
+            userProperties = createMqtt5Properties("UNSUBSCRIBE");
         }
         MqttSubscribeReply reply = connectionControl.unsubscribeMqtt(userProperties, SUBSCRIBE_FILTER);
         logger.atInfo().log("Unsubscribe response: connectionId {} reason codes {} reason string '{}'",
@@ -383,4 +390,3 @@ class AgentTestScenario implements Runnable {
         return null;
     }
 }
-

--- a/uat/proto/mqtt_client_control.proto
+++ b/uat/proto/mqtt_client_control.proto
@@ -221,7 +221,7 @@ message MqttConnectRequest {
     repeated Mqtt5Properties properties = 8;            // CONNECT packet MQTT 5 properties
     optional TLSSettings tls = 9;                       // TLS settings for secured connection
     optional Mqtt5Message willMessage = 10;             // will message to set
-    optional int32 requestResponseInformation = 11;     // request Response Information
+    optional bool requestResponseInformation = 11;      // request Response Information
 }
 
 // Response to connect request

--- a/uat/proto/mqtt_client_control.proto
+++ b/uat/proto/mqtt_client_control.proto
@@ -38,6 +38,8 @@ message Mqtt5Message {
     optional string contentType = 6;
     optional bool payloadFormatIndicator = 7;
     optional int32 messageExpiryInterval = 8;
+    optional string responseTopic = 9;
+    optional bytes correlationData = 10;
 };
 
 // End of common part
@@ -219,6 +221,7 @@ message MqttConnectRequest {
     repeated Mqtt5Properties properties = 8;            // CONNECT packet MQTT 5 properties
     optional TLSSettings tls = 9;                       // TLS settings for secured connection
     optional Mqtt5Message willMessage = 10;             // will message to set
+    optional int32 requestResponseInformation = 11;     // request Response Information
 }
 
 // Response to connect request

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -7,6 +7,7 @@ Feature: GGMQ-1
     Given my device is registered as a Thing
     And my device is running Greengrass
 
+
   @GGMQ-1-T1
   Scenario Outline: GGMQ-1-T1-<mqtt-v>-<name>: As a customer, I can connect, subscribe/publish at QoS 0 and 1 and receive using client application to MQTT topic
     When I create a Greengrass deployment with components
@@ -71,22 +72,20 @@ Feature: GGMQ-1
     When I publish from "clientDeviceTest" to "iot_data_1" with qos 1 and message "Test message1"
     And message "Test message1" received on "clientDeviceTest" from "iot_data_1" topic within 10 seconds
 
-    And I disconnect device "clientDeviceTest" with reason code 0
-
     @mqtt3 @sdk-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q1 |
-      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    | GRANTED_QOS_0       |
+      | mqtt-v | name        | agent                                     | recipe                    | subscribe-status-q1 |
+      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml      | GRANTED_QOS_0       |
 
     @mqtt3 @mosquitto-c @SkipOnWindows
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q1 |
-      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | GRANTED_QOS_1       |
+      | mqtt-v | name        | agent                                     | recipe                    | subscribe-status-q1 |
+      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml   | GRANTED_QOS_1       |
 
     @mqtt3 @paho-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q1 |
-      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   | GRANTED_QOS_0       |
+      | mqtt-v | name        | agent                                     | recipe                    | subscribe-status-q1 |
+      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml     | GRANTED_QOS_0       |
 
     @mqtt3 @paho-python @SkipOnWindows
     Examples:
@@ -95,23 +94,24 @@ Feature: GGMQ-1
 
     @mqtt5 @sdk-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q1 |
-      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    | GRANTED_QOS_1       |
+      | mqtt-v | name        | agent                                     | recipe                    | subscribe-status-q1 |
+      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml      | GRANTED_QOS_1       |
 
     @mqtt5 @mosquitto-c @SkipOnWindows
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q1 |
-      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | GRANTED_QOS_1       |
+      | mqtt-v | name        | agent                                     | recipe                    | subscribe-status-q1 |
+      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml   | GRANTED_QOS_1       |
 
     @mqtt5 @paho-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q1 |
-      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   | GRANTED_QOS_1       |
+      | mqtt-v | name        | agent                                     | recipe                    | subscribe-status-q1 |
+      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml     | GRANTED_QOS_1       |
 
     @mqtt5 @paho-python @SkipOnWindows
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  | subscribe-status-q1 |
       | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | GRANTED_QOS_1       |
+
 
   @GGMQ-1-T2
   Scenario Outline: GGMQ-1-T2-<mqtt-v>-<name>: GGAD can publish to an MQTT topic at QoS 0 and QoS 1 based on CDA configuration
@@ -240,8 +240,8 @@ Feature: GGMQ-1
 
     @mqtt3 @sdk-java
     Examples:
-      | mqtt-v | name     | agent                                        | recipe                  | iot_data_1-publish | subscribe-status-q1 |
-      | v3     | sdk-java | aws.greengrass.client.Mqtt5JavaSdkClient     | client_java_sdk.yaml    | 0                  | GRANTED_QOS_0       |
+      | mqtt-v | name     | agent                                        | recipe                    | iot_data_1-publish | subscribe-status-q1 |
+      | v3     | sdk-java | aws.greengrass.client.Mqtt5JavaSdkClient     | client_java_sdk.yaml      | 0                  | GRANTED_QOS_0       |
 
     @mqtt3 @paho-python @SkipOnWindows
     Examples:
@@ -250,13 +250,14 @@ Feature: GGMQ-1
 
     @mqtt5 @sdk-java
     Examples:
-      | mqtt-v | name     | agent                                        | recipe                  | iot_data_1-publish | subscribe-status-q1 |
-      | v5     | sdk-java | aws.greengrass.client.Mqtt5JavaSdkClient     | client_java_sdk.yaml    | 135                | GRANTED_QOS_1       |
+      | mqtt-v | name     | agent                                        | recipe                    | iot_data_1-publish | subscribe-status-q1 |
+      | v5     | sdk-java | aws.greengrass.client.Mqtt5JavaSdkClient     | client_java_sdk.yaml      | 135                | GRANTED_QOS_1       |
 
     @mqtt5 @paho-python @SkipOnWindows
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  | iot_data_1-publish | subscribe-status-q1 |
       | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | 0                  | GRANTED_QOS_1       |
+
 
   @GGMQ-1-T8
   Scenario Outline: GGMQ-1-T8-<mqtt-v>-<name>: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic
@@ -386,22 +387,20 @@ Feature: GGMQ-1
     Then I wait 5 seconds
     And I get 1 assertions with context "ReceivedPubsubMessage" and message "topicPrefix message"
 
-    And I disconnect device "publisher" with reason code 0
-
     @mqtt3 @sdk-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient    | client_java_sdk.yaml    |
 
     @mqtt3 @mosquitto-c @SkipOnWindows
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml |
 
     @mqtt3 @paho-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
     @mqtt3 @paho-python @SkipOnWindows
     Examples:
@@ -410,23 +409,24 @@ Feature: GGMQ-1
 
     @mqtt5 @sdk-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient    | client_java_sdk.yaml    |
 
     @mqtt5 @mosquitto-c @SkipOnWindows
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml |
 
     @mqtt5 @paho-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
     @mqtt5 @paho-python @SkipOnWindows
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
+
 
   @GGMQ-1-T9
   Scenario Outline: GGMQ-1-T9-<mqtt-v>-<name>: As a customer,I can configure local MQTT messages to be forwarded to an IoT Core MQTT topic
@@ -533,23 +533,20 @@ Feature: GGMQ-1
     When I publish from "localMqttPublisher" to "${iotCoreSubscriber}topic/with/prefix" with qos 1 and message "Hello world2"
     Then message "Hello world2" received on "iotCoreSubscriber" from "prefix/${iotCoreSubscriber}topic/with/prefix" topic within 10 seconds
 
-    And I disconnect device "iotCoreSubscriber" with reason code 0
-    And I disconnect device "localMqttPublisher" with reason code 0
-
     @mqtt3 @sdk-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient    | client_java_sdk.yaml    |
 
     @mqtt3 @mosquitto-c @SkipOnWindows
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml |
 
     @mqtt3 @paho-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
     @mqtt3 @paho-python @SkipOnWindows
     Examples:
@@ -558,18 +555,18 @@ Feature: GGMQ-1
 
     @mqtt5 @sdk-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient    | client_java_sdk.yaml    |
 
     @mqtt5 @mosquitto-c @SkipOnWindows
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml |
 
     @mqtt5 @paho-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
     @mqtt5 @paho-python @SkipOnWindows
     Examples:
@@ -735,21 +732,21 @@ Feature: GGMQ-1
     #  It makes sdk-java client useless for T13
     @mqtt3 @sdk-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
-      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    | GRANTED_QOS_0       | GRANTED_QOS_0         | 0                  |
+      | mqtt-v | name        | agent                                     | recipe                    | subscribe-status-na | subscribe-status-good | publish-status-nms |
+      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml      | GRANTED_QOS_0       | GRANTED_QOS_0         | 0                  |
 
     @mqtt3 @mosquitto-c @SkipOnWindows
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
-      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | UNSPECIFIED_ERROR   | GRANTED_QOS_1         | 0                  |
+      | mqtt-v | name        | agent                                     | recipe                    | subscribe-status-na | subscribe-status-good | publish-status-nms |
+      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml   | UNSPECIFIED_ERROR   | GRANTED_QOS_1         | 0                  |
 
     # WARNING: Paho Java MQTT v3 client in org.eclipse.paho.client.mqttv3.IMqttAsyncClient
     #  missing API to getting actual reason code of SUBACK/PUBACK/UNSUBACK, client always return reason code 0 on publish and subscribe.
     #  It makes paho-java client useless for T13
     @mqtt3 @paho-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
-      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   | GRANTED_QOS_0       | GRANTED_QOS_0         | 0                  |
+      | mqtt-v | name        | agent                                     | recipe                    | subscribe-status-na | subscribe-status-good | publish-status-nms |
+      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml     | GRANTED_QOS_0       | GRANTED_QOS_0         | 0                  |
 
     @mqtt3 @paho-python @SkipOnWindows
     Examples:
@@ -758,23 +755,24 @@ Feature: GGMQ-1
 
     @mqtt5 @sdk-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
-      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    | NOT_AUTHORIZED      | GRANTED_QOS_1         | 16                 |
+      | mqtt-v | name        | agent                                     | recipe                    | subscribe-status-na | subscribe-status-good | publish-status-nms |
+      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml      | NOT_AUTHORIZED      | GRANTED_QOS_1         | 16                 |
 
     @mqtt5 @mosquitto-c @SkipOnWindows
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
-      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | NOT_AUTHORIZED      | GRANTED_QOS_1         | 16                 |
+      | mqtt-v | name        | agent                                     | recipe                    | subscribe-status-na | subscribe-status-good | publish-status-nms |
+      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml   | NOT_AUTHORIZED      | GRANTED_QOS_1         | 16                 |
 
     @mqtt5 @paho-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
-      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   | NOT_AUTHORIZED      | GRANTED_QOS_1         | 16                 |
+      | mqtt-v | name        | agent                                     | recipe                    | subscribe-status-na | subscribe-status-good | publish-status-nms |
+      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml     | NOT_AUTHORIZED      | GRANTED_QOS_1         | 16                 |
 
     @mqtt5 @paho-python @SkipOnWindows
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
       | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | NOT_AUTHORIZED      | GRANTED_QOS_1         | 0                  |
+
 
   @GGMQ-1-T14
   Scenario Outline: GGMQ-1-T14-<mqtt-v>-<name>: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic
@@ -886,18 +884,18 @@ Feature: GGMQ-1
 
     @mqtt3 @sdk-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient    | client_java_sdk.yaml    |
 
     @mqtt3 @mosquitto-c @SkipOnWindows
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml |
 
     @mqtt3 @paho-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
     @mqtt3 @paho-python @SkipOnWindows
     Examples:
@@ -906,18 +904,18 @@ Feature: GGMQ-1
 
     @mqtt5 @sdk-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient    | client_java_sdk.yaml    |
 
     @mqtt5 @mosquitto-c @SkipOnWindows
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml |
 
     @mqtt5 @paho-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
     @mqtt5 @paho-python @SkipOnWindows
     Examples:
@@ -1032,22 +1030,20 @@ Feature: GGMQ-1
     Then message "Hello world" received on "subscriber" from "pubsub/topic/to/publish/on" topic within 10 seconds
     Then message "Hello world" received on "subscriber" from "prefix/pubsub/topic/to/publish/on" topic within 10 seconds
 
-    And I disconnect device "subscriber" with reason code 0
-
     @mqtt3 @sdk-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient    | client_java_sdk.yaml    |
 
     @mqtt3 @mosquitto-c @SkipOnWindows
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml |
 
     @mqtt3 @paho-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
     @mqtt3 @paho-python @SkipOnWindows
     Examples:
@@ -1056,18 +1052,18 @@ Feature: GGMQ-1
 
     @mqtt5 @sdk-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient    | client_java_sdk.yaml    |
 
     @mqtt5 @mosquitto-c @SkipOnWindows
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml |
 
     @mqtt5 @paho-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
     @mqtt5 @paho-python @SkipOnWindows
     Examples:
@@ -1145,28 +1141,26 @@ Feature: GGMQ-1
     When I subscribe "subscriber" to "iot_data_1" with qos 0
     And message "Hello world1" is not received on "subscriber" from "iot_data_1" topic within 5 seconds
 
-    And I disconnect device "subscriber" with reason code 0
-    And I disconnect device "publisher" with reason code 0
-
     @mqtt3 @sdk-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient    | client_java_sdk.yaml    |
 
     @mqtt3 @mosquitto-c @SkipOnWindows
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml |
 
     @mqtt3 @paho-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
     @mqtt3 @paho-python @SkipOnWindows
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
+
 
   @GGMQ-1-T102
   Scenario Outline: GGMQ-1-T102-<mqtt-v>-<name>: As a customer, I can use publish retain flag,subscribe retain handling, content type using MQTT V5.0
@@ -1227,7 +1221,7 @@ Feature: GGMQ-1
     And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
     And I connect device "subscriber" on <agent> to "localMqttBroker2" using mqtt "<mqtt-v>"
 
-    # publish 'retain' and subscribe 'retain control' tests
+    # A.B. publish 'retain' and subscribe 'retain control' tests
 
     # 1. test case when publishing two messages with retain flag set and subscribe retain handling is 'send at subsription'
     #  and only last message is received
@@ -1324,7 +1318,7 @@ Feature: GGMQ-1
     When I subscribe "subscriber" to "t102_case8" with qos 0
     And message "Single not retained message in case8" is not received on "subscriber" from "t102_case8" topic within 5 seconds
 
-    # 'retain as published' tests
+    # C. 'retain as published' tests
     And I clear message storage
 
     # 9. test case when subscribe 'retain as published' is false.
@@ -1361,7 +1355,7 @@ Feature: GGMQ-1
     When I publish from "publisher" to "iot_data_1" with qos 0 and message "Hello world4"
     And message "Hello world4" received on "subscriber" from "iot_data_1" topic within 5 seconds
 
-    # 'user properties' tests
+    # D. 'user properties' tests
     # 11. test case when publish 'user properties' are not empty.
     #  In that case 'user properties' on receive should be equal to 'user properties' value on publish.
 
@@ -1406,7 +1400,7 @@ Feature: GGMQ-1
     When I publish from "publisher" to "iot_data_4" with qos 0 and message "Without userProperties"
     And message "Without userProperties" received on "subscriber" from "iot_data_4" topic within 5 seconds
 
-    # 'payload format indicator' tests
+    # E. 'payload format indicator' tests
     And I clear message storage
 
     # 15. test case when both tx/rx payload format indicators are set to 0
@@ -1464,6 +1458,7 @@ Feature: GGMQ-1
 
     And I clear message storage
 
+    # F. subscribe 'no local' tests
     # 21. test case when subscribe 'no local' set to true
     And I set MQTT subscribe 'no local' flag to true
     When I subscribe "subscriber" to "no_local_test" with qos 0
@@ -1481,6 +1476,8 @@ Feature: GGMQ-1
     Then message "First message no local false test" received on "subscriber" from "no_local_false" topic within 5 seconds
 
     And I clear message storage
+
+    # G. publish/subscribe 'content type' tests
 
     # 23. test case when tx content type set the same value as rx
     And I set MQTT publish 'content type' to "text/plain; charset=utf-8"
@@ -1515,9 +1512,6 @@ Feature: GGMQ-1
     When I subscribe "subscriber" to "content_type_not_null_null" with qos 0
     When I publish from "publisher" to "content_type_not_null_null" with qos 0 and message "Content types not null/null"
     And message "Content types not null/null" received on "subscriber" from "content_type_not_null_null" topic within 5 seconds
-
-    And I disconnect device "subscriber" with reason code 0
-    And I disconnect device "publisher" with reason code 0
 
     @mqtt5 @sdk-java
     Examples:


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-181
Implement request/response

**Description of changes:**
- Extend protocol by adding Response Topic, Correlation data, Request Response Information
- Update mosquitto client to handle PUBLISH Response Topic in Tx and Rx directions
- Update mosquitto client to handle PUBLISH Correlation Data in Tx and Rx directions
- Update mosquitto client to handle CONNECT Request Response Information
- Update Control application by sending CONNECT Request Response Information, PUBLISH Response Topic, Correlation Data and log it on receive
- Fix mem leak bugs related to property reading
- Fix bug in sdk client when disconnect sent on dead executor service
- Tune mosquitto client and control logging


**Why is this change necessary:**
Capable to test 4 request/response features on MQTT v5.0

**How was this change tested:**
Manually by running client with control application.

**Test results:**
Control:
```
[INFO ] 2023-07-04 21:43:10.339 [com.aws.greengrass.testing.mqtt.client.control.ExampleControl.main()] ExampleControl - Control: port 47619, with TLS, MQTT v5
[INFO ] 2023-07-04 21:43:10.576 [com.aws.greengrass.testing.mqtt.client.control.ExampleControl.main()] EngineControlImpl - MQTT client control gRPC server started, listening on 47619
[INFO ] 2023-07-04 21:43:15.590 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId mosquitto-agent
[INFO ] 2023-07-04 21:43:15.607 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId mosquitto-agent address 127.0.0.1 port 36267
[INFO ] 2023-07-04 21:43:15.610 [grpc-default-executor-0] EngineControlImpl - Created new agent control for mosquitto-agent on 127.0.0.1:36267
[INFO ] 2023-07-04 21:43:15.659 [grpc-default-executor-0] ExampleControl - Agent mosquitto-agent is connected
[INFO ] 2023-07-04 21:43:15.662 [pool-2-thread-1] AgentTestScenario - Playing test scenario for agent id mosquitto-agent
[INFO ] 2023-07-04 21:43:18.683 [pool-2-thread-1] AgentTestScenario - Set Connect user property: region, US
[INFO ] 2023-07-04 21:43:18.684 [pool-2-thread-1] AgentTestScenario - Set Connect user property: type, JSON
[INFO ] 2023-07-04 21:43:18.686 [pool-2-thread-1] AgentTestScenario - Set CONNECT request response information  true
[INFO ] 2023-07-04 21:43:19.181 [pool-2-thread-1] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
reasonCode: 0
receiveMaximum: 100
maximumQoS: 1
retainAvailable: true
maximumPacketSize: 149504
wildcardSubscriptionsAvailable: true
subscriptionIdentifiersAvailable: false
sharedSubscriptionsAvailable: true
serverKeepAlive: 60
topicAliasMaximum: 8
'
[INFO ] 2023-07-04 21:43:19.181 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-07-04 21:43:19.181 [pool-2-thread-1] AgentTestScenario - MQTT connection with id 1 is established
[INFO ] 2023-07-04 21:43:24.187 [pool-2-thread-1] AgentTestScenario - Set Subscribe user property: region, US
[INFO ] 2023-07-04 21:43:24.188 [pool-2-thread-1] AgentTestScenario - Set Subscribe user property: type, JSON
[INFO ] 2023-07-04 21:43:24.195 [pool-2-thread-1] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-07-04 21:43:24.270 [pool-2-thread-1] AgentTestScenario - Subscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-07-04 21:43:34.277 [pool-2-thread-1] AgentTestScenario - Set PUBLISH payload format indicator true
[INFO ] 2023-07-04 21:43:34.277 [pool-2-thread-1] AgentTestScenario - Set PUBLISH message expiry interval 3600
[INFO ] 2023-07-04 21:43:34.278 [pool-2-thread-1] AgentTestScenario - Set PUBLISH response topic /thing1/response/topic
[INFO ] 2023-07-04 21:43:34.280 [pool-2-thread-1] AgentTestScenario - Set PUBLISH correlation data <ByteString@1f05153 size=16 contents="correlation_data">
[INFO ] 2023-07-04 21:43:34.281 [pool-2-thread-1] AgentTestScenario - Set Publish user property: region, US
[INFO ] 2023-07-04 21:43:34.281 [pool-2-thread-1] AgentTestScenario - Set Publish user property: type, JSON
[INFO ] 2023-07-04 21:43:34.282 [pool-2-thread-1] AgentTestScenario - Set PUBLISH content type text/plain; charset=utf-8
[INFO ] 2023-07-04 21:43:34.288 [pool-2-thread-1] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic test/topic
[INFO ] 2023-07-04 21:43:34.334 [pool-2-thread-1] AgentTestScenario - Published connectionId 1 reason code 0 reason string ''
[INFO ] 2023-07-04 21:43:34.334 [grpc-default-executor-0] GRPCDiscoveryServer - OnReceiveMessage: agentId mosquitto-agent connectionId 1 topic test/topic QoS 0
[INFO ] 2023-07-04 21:43:34.335 [grpc-default-executor-0] AgentTestScenario - Message received on agentId mosquitto-agent connectionId 1 topic test/topic QoS 0 content <ByteString@2d96c133 size=12 contents="Hello World!">
[INFO ] 2023-07-04 21:43:34.335 [grpc-default-executor-0] AgentTestScenario - Message has payload format indicator true
[INFO ] 2023-07-04 21:43:34.335 [grpc-default-executor-0] AgentTestScenario - Message has message expiry interval 3599
[INFO ] 2023-07-04 21:43:34.335 [grpc-default-executor-0] AgentTestScenario - Message has response topic /thing1/response/topic
[INFO ] 2023-07-04 21:43:34.336 [grpc-default-executor-0] AgentTestScenario - Message has correlation data <ByteString@449d6909 size=16 contents="correlation_data">
[INFO ] 2023-07-04 21:43:34.336 [grpc-default-executor-0] AgentTestScenario - Message has user property key region value US
[INFO ] 2023-07-04 21:43:34.336 [grpc-default-executor-0] AgentTestScenario - Message has user property key type value JSON
[INFO ] 2023-07-04 21:43:34.336 [grpc-default-executor-0] AgentTestScenario - Message has content type 'text/plain; charset=utf-8'
[INFO ] 2023-07-04 21:43:39.335 [pool-2-thread-1] AgentTestScenario - Set Unsubscribe user property: region, US
[INFO ] 2023-07-04 21:43:39.335 [pool-2-thread-1] AgentTestScenario - Set Unsubscribe user property: type, JSON
[INFO ] 2023-07-04 21:43:39.342 [pool-2-thread-1] AgentControlImpl - UnsubscribeMqtt: unsubscribe on connectionId 1
[INFO ] 2023-07-04 21:43:39.398 [pool-2-thread-1] AgentTestScenario - Unsubscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-07-04 21:43:49.398 [pool-2-thread-1] AgentTestScenario - Set Disconnect user property: region, US
[INFO ] 2023-07-04 21:43:49.399 [pool-2-thread-1] AgentTestScenario - Set Disconnect user property: type, JSON
[INFO ] 2023-07-04 21:43:49.428 [grpc-default-executor-0] GRPCDiscoveryServer - OnMqttDisconnect: agentId mosquitto-agent connectionId 1 disconnect 'reasonCode: 0
' error ''
[INFO ] 2023-07-04 21:43:49.429 [grpc-default-executor-0] AgentTestScenario - MQTT disconnected on agentId mosquitto-agent connectionId 1 disconnect 'reasonCode: 0
' error ''
[INFO ] 2023-07-04 21:43:49.437 [pool-2-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 1 closed
[INFO ] 2023-07-04 21:43:49.446 [pool-2-thread-1] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-07-04 21:43:49.452 [grpc-default-executor-0] GRPCDiscoveryServer - UnregisterAgent: agentId mosquitto-agent reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-07-04 21:43:49.454 [grpc-default-executor-0] ExampleControl - Agent mosquitto-agent is disconnected
```

Mosquitto client:
```
$ build/src/mosquitto-test-client mosquitto-agent 
[DEBUG]: Initialize gRPC library
[DEBUG]: Making gPRC link with 127.0.0.1:47619 as agent_id 'mosquitto-agent'
[DEBUG]: Sending RegisterAgent request with agent_id mosquitto-agent
[ERROR]: gRPC request failed: 14: 'failed to connect to all addresses; last error: UNKNOWN: ipv4:127.0.0.1:47619: Failed to connect to remote host: Connection refused': ''
[DEBUG]: Shutdown gRPC library
[ERROR]: bg@LPT00168:~/src/uat/custom-components/client-mosquitto-c$ build/src/mosquitto-test-client mosquitto-agent 
[DEBUG]: Initialize gRPC library
[DEBUG]: Making gPRC link with 127.0.0.1:47619 as agent_id 'mosquitto-agent'
[DEBUG]: Sending RegisterAgent request with agent_id mosquitto-agent
[DEBUG]: Local address is 127.0.0.1
[DEBUG]: GRPCControlServer created and listed on 127.0.0.1:36267
[DEBUG]: Sending DiscoveryAgent request agent_id 'mosquitto-agent' host:port 127.0.0.1:36267
[DEBUG]: gPRC link established with 127.0.0.1:47619 as agent_id 'mosquitto-agent'
[DEBUG]: Initialize Mosquitto MQTT library
[DEBUG]: Mosquitto library version 2.0.15
[DEBUG]: Handle gRPC requests
[DEBUG]: CreateMqttConnection client_id 'GGMQ-test-device2' broker a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[DEBUG]: Creating Mosquitto MQTT v5 connection for a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[DEBUG]: Copied TX user property region:US
[DEBUG]: Copied TX user property type:JSON
[DEBUG]: Establishing Mosquitto MQTT v5 connection to a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883 in 10 seconds
[DEBUG]: Copied TX request response information 1
[DEBUG]: Use provided TLS credentials
[DEBUG]: mosquitto: Client GGMQ-test-device2 sending CONNECT
[DEBUG]: mosquitto: Client GGMQ-test-device2 received CONNACK (0)
[DEBUG]: onConnect rc 0 flags 0 props 0x7f3d98010780
[DEBUG]: Copied RX receive maximum 100
[DEBUG]: Copied RX maximum QoS 1
[DEBUG]: Copied RX retain available 1
[DEBUG]: Copied RX maximum packet size 149504
[DEBUG]: Copied RX topic alias maximum 8
[DEBUG]: Copied RX wildcard subscription available 1
[DEBUG]: Copied RX subscription identifiers available 0
[DEBUG]: Copied RX shared subscription available 1
[DEBUG]: Copied RX server keep alive 60
[DEBUG]: Establishing MQTT connection to a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883 completed with reason code 0
[DEBUG]: Connection registered with id 1
[DEBUG]: Subscription: filter test/topic QoS 0 noLocal 0 retainAsPublished 0 retainHandling 2
[DEBUG]: SubscribeMqtt connection_id 1
[DEBUG]: Copied TX user property region:US
[DEBUG]: Copied TX user property type:JSON
[DEBUG]: mosquitto: Client GGMQ-test-device2 sending SUBSCRIBE (Mid: 1, Topic: test/topic, QoS: 0, Options: 0x20)
[DEBUG]: mosquitto: Client GGMQ-test-device2 received SUBACK
[DEBUG]: onSubscribe mid 1 qos_count 1 granted_qos 0x7f3d98014040 props (nil)
[DEBUG]: Subscribed on filters 'test/topic,' QoS 0 no local 0 retain as published 0 retain handing 2 with message id 1
[DEBUG]: Copied RX reason code 0
[DEBUG]: PublishMqtt connection_id 1 topic test/topic retain 0
[DEBUG]: Copied TX payload format indicator 1
[DEBUG]: Copied TX message expiry interval 3600
[DEBUG]: Copied TX response topic "/thing1/response/topic"
[DEBUG]: Copied TX correlation data "correlation_data"
[DEBUG]: Copied TX user property region:US
[DEBUG]: Copied TX user property type:JSON
[DEBUG]: Copied TX content type "text/plain; charset=utf-8"
[DEBUG]: mosquitto: Client GGMQ-test-device2 sending PUBLISH (d0, q1, r0, m2, 'test/topic', ... (12 bytes))
[DEBUG]: mosquitto: Client GGMQ-test-device2 received PUBACK (Mid: 2, RC:0)
[DEBUG]: onPublish mid 2 rc 0 props (nil)
[DEBUG]: mosquitto: Client GGMQ-test-device2 received PUBLISH (d0, q0, r0, m0, 'test/topic', ... (12 bytes))
[DEBUG]: onMessage message 0x7f3d98015908 props 0x7f3d98011f00
[DEBUG]: Copied RX payload format indicator 1
[DEBUG]: Copied RX message expiry interval 3599
[DEBUG]: Copied RX response topic "/thing1/response/topic"
[DEBUG]: Copied RX correlation data "correlation_data"
[DEBUG]: Copied RX content type "text/plain; charset=utf-8"
[DEBUG]: Copied RX user property region:US
[DEBUG]: Copied RX user property type:JSON
[DEBUG]: Sending OnReceiveMessage request agent_id 'mosquitto-agent' connection_id 1
[DEBUG]: Published on topic 'test/topic' QoS 1 retain 0 with rc 0 message id 2
[DEBUG]: UnsubscribeMqtt connection_id 1
[DEBUG]: Copied TX user property region:US
[DEBUG]: Copied TX user property type:JSON
[DEBUG]: mosquitto: Client GGMQ-test-device2 sending UNSUBSCRIBE (Mid: 3, Topic: test/topic)
[DEBUG]: mosquitto: Client GGMQ-test-device2 received UNSUBACK
[DEBUG]: onUnsubscribe mid 3 props (nil)
[DEBUG]: Unsubscribed from filters 'test/topic,' with message id 3
[DEBUG]: Copied RX reason code 0
[DEBUG]: CloseMqttConnection connection_id 1 reason 4
[DEBUG]: Disconnect Mosquitto MQTT connection with reason code 4
[DEBUG]: Copied TX user property region:US
[DEBUG]: Copied TX user property type:JSON
[DEBUG]: mosquitto: Client GGMQ-test-device2 sending DISCONNECT
[DEBUG]: onDisconnect rc 0 props (nil)
[DEBUG]: Sending OnMqttDisconnect request agent_id 'mosquitto-agent' connection_id 1 error '(null)'
[DEBUG]: Destroy Mosquitto MQTT connection
[DEBUG]: ShutdownAgent with reason 'That's it.'
[DEBUG]: Shutdown gPRC link
[DEBUG]: Sending UnregisterAgent request agent_id 'mosquitto-agent' reason 'Agent shutdown by OTF request 'That's it.''
[DEBUG]: Shutdown MQTT library
[DEBUG]: Shutdown gRPC library
[DEBUG]: Execution done
```


**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
