### PR TITLE
feat(uat): implement handling user properties for python paho client

### DIFF
--- a/uat/custom-components/client-python-paho/src/main.py
+++ b/uat/custom-components/client-python-paho/src/main.py
@@ -4,7 +4,6 @@
 #
 
 """Paho Python client entry point."""
-# from concurrent import futures
 import logging
 import asyncio
 import sys

--- a/uat/custom-components/client-python-paho/src/mqtt_lib/mqtt_connection.py
+++ b/uat/custom-components/client-python-paho/src/mqtt_lib/mqtt_connection.py
@@ -810,7 +810,7 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
         message - MQTTMessage object
         Returns Mqtt5Message object
         """
-        props = message.properties
+        props = getattr(message, "properties", None)
         mqtt_properties = self.__convert_to_mqtt5_properties(getattr(props, "UserProperty", None), "PUBLISH")
         mqtt_message = Mqtt5Message(
             topic=message.topic,

--- a/uat/custom-components/client-python-paho/src/mqtt_lib/mqtt_connection.py
+++ b/uat/custom-components/client-python-paho/src/mqtt_lib/mqtt_connection.py
@@ -11,7 +11,7 @@ import socket
 import time
 
 from dataclasses import dataclass
-from typing import List
+from typing import List, Tuple
 
 import paho.mqtt.client as mqtt
 
@@ -29,6 +29,7 @@ from grpc_client_server.grpc_generated.mqtt_client_control_pb2 import (
     MqttPublishReply,
     MqttSubscribeReply,
     Mqtt5Message,
+    Mqtt5Properties,
 )
 from grpc_client_server.grpc_discovery_client import GRPCDiscoveryClient
 
@@ -75,8 +76,10 @@ class ConnectionParams:  # pylint: disable=too-many-instance-attributes
     cert: str = None
     # Content of MQTT client's private key, can be None.
     key: str = None
+    # MQTT5 user proprties list
+    mqtt_properties: List[Mqtt5Properties] = None
 
-    # TODO Add user properties
+    # TODO Add all fields
 
 
 @dataclass
@@ -97,8 +100,9 @@ class MqttPubMessage:
     retain: bool
     topic: str
     payload: bytes
+    mqtt_properties: List[Mqtt5Properties] = None
 
-    # TODO add user properties and other fields
+    # TODO add other fields
 
 
 @dataclass
@@ -221,13 +225,12 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
         """
         self.__connection_id = connection_id
 
-    async def __connect_helper(self, host, port, keep_alive, clean_start):
+    async def __connect_helper(
+        self, host, port, keep_alive, clean_start, properties
+    ):  # pylint: disable=too-many-arguments
         """MQTT Connect async wrapper."""
         self.__client.connect(
-            host=host,
-            port=port,
-            keepalive=keep_alive,
-            clean_start=clean_start,
+            host=host, port=port, keepalive=keep_alive, clean_start=clean_start, properties=properties
         )
 
     async def start(self, timeout: int) -> ConnectResult:
@@ -238,14 +241,20 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
         timeout - connect operation timeout in seconds
         Returns connection result
         """
-        # TODO add properties
         self.__asyncio_helper = AsyncioHelper(self.__loop, self.__client)  # pylint: disable=unused-private-member
 
         clean_start = self.__connection_params.clean_session
 
-        # Clean Start is used only for the MQTT 5
+        properties = Properties(PacketTypes.CONNECT)
+
+        user_properties = self.__convert_to_user_properties(self.__connection_params.mqtt_properties, "CONNECT")
+
+        # Clean Start and Properties are used only for the MQTT 5
         if self.__protocol == mqtt.MQTTv311:
             clean_start = mqtt.MQTT_CLEAN_START_FIRST_ONLY
+            properties = None
+        else:
+            properties.UserProperty = user_properties
 
         self.__logger.info("MQTT connection ID %i connecting...", self.__connection_id)
 
@@ -258,6 +267,7 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
                 port=self.__connection_params.port,
                 keep_alive=self.__connection_params.keep_alive,
                 clean_start=clean_start,
+                properties=properties,
             )
 
             await asyncio.wait_for(connect_awaitable, timeout)
@@ -266,7 +276,7 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
             remaining_timeout = max(timeout - passed_time, 0)
 
             result = await asyncio.wait_for(self.__on_connect_future, remaining_timeout)
-            conn_ack_info = MqttConnection.convert_to_conn_ack(result)
+            conn_ack_info = self.__convert_to_conn_ack(result)
 
             connected = True
             if result.reason_code == mqtt.MQTT_ERR_SUCCESS:
@@ -318,21 +328,25 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
         except asyncio.InvalidStateError:
             pass
 
-    async def disconnect(self, timeout: int, reason: int):
+    async def disconnect(self, timeout: int, reason: int, mqtt_properties: List[Mqtt5Properties]):
         """
         Closes MQTT connection.
         Parameters
         ----------
         timeout - disconnect operation timeout in seconds
+        mqtt_properties - list of Mqtt5Properties
         reason - disconnect reason code
         """
         self.__logger.info("Disconnect MQTT connection with reason code %i", reason)
         self.__on_disconnect_future = self.__loop.create_future()
 
         try:
+            user_properties = self.__convert_to_user_properties(mqtt_properties, "DISCONNECT")
             if self.__protocol == mqtt.MQTTv5:
                 reason_code_obj = ReasonCodes(PacketTypes.DISCONNECT, identifier=reason)
-                self.__client.disconnect(reasoncode=reason_code_obj)
+                properties = Properties(PacketTypes.DISCONNECT)
+                properties.UserProperty = user_properties
+                self.__client.disconnect(reasoncode=reason_code_obj, properties=properties)
             else:
                 self.__client.disconnect()
 
@@ -356,7 +370,7 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
 
         mqtt_result = MqttResult(reason_code=mqtt_reason_code, properties=properties)
 
-        disconnect_info = MqttConnection.convert_to_disconnect(mqtt_result=mqtt_result)
+        disconnect_info = self.__convert_to_disconnect(mqtt_result=mqtt_result)
         self.__grpc_client.on_mqtt_disconnect(self.__connection_id, disconnect_info, None)
 
         try:
@@ -374,13 +388,25 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
         message - Mqtt message info and payload
         Returns MqttPublishReply object
         """
-        # TODO add set property
         self.state_check()
         self.__on_publish_future = self.__loop.create_future()
 
+        properties = Properties(PacketTypes.PUBLISH)
+        user_properties = self.__convert_to_user_properties(message.mqtt_properties, "PUBLISH")
+
+        # Properties are used only for the MQTT 5
+        if self.__protocol == mqtt.MQTTv311:
+            properties = None
+        else:
+            properties.UserProperty = user_properties
+
         try:
             publish_info = self.__client.publish(
-                topic=message.topic, payload=message.payload, qos=message.qos, retain=message.retain
+                topic=message.topic,
+                payload=message.payload,
+                qos=message.qos,
+                retain=message.retain,
+                properties=properties,
             )
 
             result = await asyncio.wait_for(self.__on_publish_future, timeout)
@@ -400,7 +426,7 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
                 result.mid,
             )
 
-            return MqttConnection.convert_to_pub_reply(publish_info)
+            return self.__convert_to_pub_reply(publish_info)
         except asyncio.TimeoutError as error:
             raise MQTTException("Couldn't publish") from error
         finally:
@@ -418,18 +444,18 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
         except asyncio.InvalidStateError:
             pass
 
-    async def subscribe(
-        self, timeout: int, subscriptions: List[Subscribtion]
-    ) -> MqttSubscribeReply:  # TODO Add user properties
+    async def subscribe(  # pylint: disable=too-many-locals
+        self, timeout: int, subscriptions: List[Subscribtion], mqtt_properties: List[Mqtt5Properties]
+    ) -> MqttSubscribeReply:
         """
         Subscribe on MQTT topics.
         Parameters
         ----------
         timeout - subscribe operation timeout in seconds
         subscriptions - Subscriptions information
+        mqtt_properties - list of Mqtt5Properties
         Returns MqttSubscribeReply object
         """
-        # TODO add set property
         self.state_check()
 
         mqtt_subscriptions = []
@@ -458,10 +484,19 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
             filters.append(sub.filter)
             qos.append(str(sub.qos))
 
+        properties = Properties(PacketTypes.SUBSCRIBE)
+        user_properties = self.__convert_to_user_properties(mqtt_properties, "SUBSCRIBE")
+
+        # Properties are used only for the MQTT 5
+        if self.__protocol == mqtt.MQTTv311:
+            properties = None
+        else:
+            properties.UserProperty = user_properties
+
         self.__on_subscribe_future = self.__loop.create_future()
 
         try:
-            (resp_code, message_id) = self.__client.subscribe(mqtt_subscriptions, properties=None)
+            (resp_code, message_id) = self.__client.subscribe(mqtt_subscriptions, properties=properties)
 
             result = await asyncio.wait_for(self.__on_subscribe_future, timeout)
 
@@ -480,7 +515,7 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
                 message_id,
             )
 
-            return MqttConnection.convert_to_sub_reply(result)
+            return self.__convert_to_sub_reply(result)
         except asyncio.TimeoutError as error:
             raise MQTTException("Couldn't subscribe") from error
         finally:
@@ -511,25 +546,36 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
         Paho MQTT receive message callback
         """
         self.__logger.debug("onMessage message %s from topic '%s'", message.payload, message.topic)
-        mqtt_message = MqttConnection.convert_to_mqtt_message(message=message)
+        mqtt_message = self.__convert_to_mqtt_message(message=message)
         self.__grpc_client.on_receive_mqtt_message(self.__connection_id, mqtt_message)
 
-    async def unsubscribe(self, timeout: int, filters: List[str]) -> MqttSubscribeReply:  # TODO Add user properties
+    async def unsubscribe(
+        self, timeout: int, filters: List[str], mqtt_properties: List[Mqtt5Properties]
+    ) -> MqttSubscribeReply:
         """
         Unsubscribe from MQTT topics.
         Parameters
         ----------
         timeout - subscribe operation timeout in seconds
         filters - Topics to unsubscribe
+        mqtt_properties - list of Mqtt5Properties
         Returns MqttSubscribeReply object
         """
-        # TODO add set property
         self.state_check()
+
+        properties = Properties(PacketTypes.UNSUBSCRIBE)
+        user_properties = self.__convert_to_user_properties(mqtt_properties, "UNSUBSCRIBE")
+
+        # Properties are used only for the MQTT 5
+        if self.__protocol == mqtt.MQTTv311:
+            properties = None
+        else:
+            properties.UserProperty = user_properties
 
         self.__on_unsubscribe_future = self.__loop.create_future()
 
         try:
-            (resp_code, message_id) = self.__client.unsubscribe(filters, properties=None)
+            (resp_code, message_id) = self.__client.unsubscribe(filters, properties=properties)
 
             result = await asyncio.wait_for(self.__on_unsubscribe_future, timeout)
 
@@ -549,7 +595,7 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
                 for _ in filters:
                     result.reason_codes.append(mqtt.MQTT_ERR_SUCCESS)
 
-            return MqttConnection.convert_to_sub_reply(result)
+            return self.__convert_to_sub_reply(result)
         except asyncio.TimeoutError as error:
             raise MQTTException("Couldn't unsubscribe") from error
         finally:
@@ -628,16 +674,64 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
         if (self.__client is None) or not self.__client.is_connected():
             raise MQTTException("MQTT client is not in connected state")
 
-    @staticmethod
-    def convert_to_conn_ack(mqtt_result: MqttResult) -> Mqtt5ConnAck:
+    def __convert_to_user_properties(
+        self, mqtt_properties: List[Mqtt5Properties], message_type: str
+    ) -> List[Tuple[str, str]]:
         """
-        Convert MqttResult info to Mqtt5ConnAck
+        Convert Mqtt5Properties into to User properties list
+        Parameters
+        ----------
+        mqtt_properties - mqtt_properties
+        message_type - message type
+        Returns User properties list
+        """
+        user_properties = []
+
+        if mqtt_properties:
+            if self.__protocol == mqtt.MQTTv5:
+                for mqtt_property in mqtt_properties:
+                    key = mqtt_property.key
+                    value = mqtt_property.value
+                    user_properties.append((key, value))
+                    self.__logger.info("%s TX user property '%s', '%s'", message_type, key, value)
+            else:
+                self.__logger.warning("User properties are ignored for MQTT v3.1.1 connection")
+
+        return user_properties
+
+    def __convert_to_mqtt5_properties(
+        self, user_properties: List[Tuple[str, str]], message_type: str
+    ) -> List[Mqtt5Properties]:
+        """
+        Convert User properties list into to Mqtt5Properties
+        Parameters
+        ----------
+        user_properties - User properties list
+        message_type - message type
+        Returns Mqtt5Properties
+        """
+        if user_properties:
+            mqtt_properties = []
+
+            for user_property in user_properties:
+                mqtt_property = Mqtt5Properties(key=user_property[0], value=user_property[1])
+                mqtt_properties.append(mqtt_property)
+                self.__logger.info("%s RX user property '%s', '%s'", message_type, user_property[0], user_property[1])
+
+            return mqtt_properties
+
+        return None
+
+    def __convert_to_conn_ack(self, mqtt_result: MqttResult) -> Mqtt5ConnAck:
+        """
+        Convert MqttResult into to Mqtt5ConnAck
         Parameters
         ----------
         mqtt_result - MqttResult object
         Returns Mqtt5ConnAck object
         """
         props = mqtt_result.properties
+        mqtt_properties = self.__convert_to_mqtt5_properties(getattr(props, "UserProperty", None), "CONNACK")
         conn_ack = Mqtt5ConnAck(
             sessionPresent=mqtt_result.flags["session present"],
             reasonCode=mqtt_result.reason_code,
@@ -655,32 +749,31 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
             responseInformation=getattr(props, "ResponseInformation", None),
             serverReference=getattr(props, "ServerReference", None),
             topicAliasMaximum=getattr(props, "TopicAliasMaximum", None),
+            properties=mqtt_properties,
         )
-        # TODO add user properties
 
         return conn_ack
 
-    @staticmethod
-    def convert_to_disconnect(mqtt_result: MqttResult) -> Mqtt5ConnAck:
+    def __convert_to_disconnect(self, mqtt_result: MqttResult) -> Mqtt5ConnAck:
         """
-        Convert MqttResult info to Mqtt5Disconnect
+        Convert MqttResult into to Mqtt5Disconnect
         Parameters
         ----------
         mqtt_result - MqttResult object
         Returns Mqtt5Disconnect object
         """
         props = mqtt_result.properties
+        mqtt_properties = self.__convert_to_mqtt5_properties(getattr(props, "UserProperty", None), "DISCONNECT")
         disconnect_info = Mqtt5Disconnect(
             reasonCode=mqtt_result.reason_code,
             sessionExpiryInterval=getattr(props, "SessionExpiryInterval", None),
             reasonString=getattr(props, "ReasonString", None),
             serverReference=getattr(props, "ServerReference", None),
+            properties=mqtt_properties,
         )
-        # TODO add user properties
         return disconnect_info
 
-    @staticmethod
-    def convert_to_pub_reply(pub_info: mqtt.MQTTMessageInfo) -> MqttPublishReply:
+    def __convert_to_pub_reply(self, pub_info: mqtt.MQTTMessageInfo) -> MqttPublishReply:
         """
         Build MQTT publish reply
         Parameters
@@ -691,8 +784,7 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
         # Python Paho MQTT does not support recieving any properties for the pusblished messages
         return MqttPublishReply(reasonCode=pub_info.rc)
 
-    @staticmethod
-    def convert_to_sub_reply(mqtt_result: SubscribesResult) -> MqttSubscribeReply:
+    def __convert_to_sub_reply(self, mqtt_result: SubscribesResult) -> MqttSubscribeReply:
         """
         Build MQTT subscribe reply
         Parameters
@@ -700,25 +792,33 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
         mqtt_result - subscribe info
         Returns MqttSubscribeReply object
         """
-        # TODO add user properties handling
+        props = mqtt_result.properties
+        mqtt_properties = self.__convert_to_mqtt5_properties(getattr(props, "UserProperty", None), "SUBACK")
         mqtt_sub_reply = MqttSubscribeReply(
-            reasonCodes=mqtt_result.reason_codes, reasonString=getattr(mqtt_result.properties, "ReasonString", None)
+            reasonCodes=mqtt_result.reason_codes,
+            reasonString=getattr(mqtt_result.properties, "ReasonString", None),
+            properties=mqtt_properties,
         )
 
         return mqtt_sub_reply
 
-    @staticmethod
-    def convert_to_mqtt_message(message: mqtt.MQTTMessage) -> Mqtt5Message:
+    def __convert_to_mqtt_message(self, message: mqtt.MQTTMessage) -> Mqtt5Message:
         """
-        Convert MQTTMessage info to Mqtt5Message
+        Convert MQTTMessage into to Mqtt5Message
         Parameters
         ----------
         message - MQTTMessage object
         Returns Mqtt5Message object
         """
+        props = message.properties
+        mqtt_properties = self.__convert_to_mqtt5_properties(getattr(props, "UserProperty", None), "PUBLISH")
         mqtt_message = Mqtt5Message(
-            topic=message.topic, payload=message.payload, qos=message.qos, retain=message.retain
+            topic=message.topic,
+            payload=message.payload,
+            qos=message.qos,
+            retain=message.retain,
+            properties=mqtt_properties,
         )
 
-        # TODO add user properties, payload format indicator, content type for mqtt5
+        # TODO payload format indicator, content type for mqtt5
         return mqtt_message


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-148

**Description of changes:**
- Implement handling user properties

**Why is this change necessary:**
- Part of Python Paho client implementation

**How was this change tested:**
Manual run of mqtt-client-control and python client.
MQTT connect, subscribe, unsubscribe, publish, delivery of received MQTT message and disconnect are successful. Linking and shutdown steps are successful.

**Test results:**
Python Paho client output
```
client-python-paho.exe python-paho-agent
[DEBUG] 2023-07-05 16:46:45.413 asyncio - Using selector: SelectSelector
[INFO ] 2023-07-05 16:46:45.415 GRPCLib - Initialize gRPC library
[INFO ] 2023-07-05 16:46:45.416 GRPCLink - Making gPRC client connection with 127.0.0.1:47619 as python-paho-agent...
[INFO ] 2023-07-05 16:46:45.593 GRPCLink - Client connection with Control is established, local address is 127.0.0.1
[DEBUG] 2023-07-05 16:46:45.594 grpc._cython.cygrpc - Using AsyncIOEngine.POLLER as I/O engine
[INFO ] 2023-07-05 16:46:45.664 MQTTLib - Initialize Paho MQTT library
[INFO ] 2023-07-05 16:46:45.664 GRPCLink - Handle gRPC requests
[INFO ] 2023-07-05 16:46:45.666 GRPCControlServer - Server awaiting termination
[INFO ] 2023-07-05 16:46:48.720 GRPCControlServer - createMqttConnection: clientId Python_Paho_Client broker a3t8vwpkw3sltg-ats.iot.eu-west-1.amazonaws.com:8883
[INFO ] 2023-07-05 16:46:48.728 MqttConnection - Creating MQTT 5 client with TLS
[INFO ] 2023-07-05 16:46:48.729 MqttConnection - CONNECT TX user property 'region', 'US'
[INFO ] 2023-07-05 16:46:48.729 MqttConnection - CONNECT TX user property 'type', 'JSON'
[INFO ] 2023-07-05 16:46:48.730 MqttConnection - MQTT connection ID 0 connecting...
[DEBUG] 2023-07-05 16:46:49.045 AsyncioHelper - On socket open
[DEBUG] 2023-07-05 16:46:49.045 AsyncioHelper - On socket register write
[DEBUG] 2023-07-05 16:46:49.048 AsyncioHelper - On socket unregister write
[INFO ] 2023-07-05 16:46:49.158 MqttConnection - MQTT connection ID 0 connected, client id Python_Paho_Client
[DEBUG] 2023-07-05 16:46:54.277 GRPCControlServer - Subscription: filter test/topic QoS 0 noLocal 0 retainAsPublished 0 retainHandling 2
[INFO ] 2023-07-05 16:46:54.277 GRPCControlServer - SubscribeMqtt connection_id 0
[INFO ] 2023-07-05 16:46:54.278 MqttConnection - SUBSCRIBE TX user property 'region', 'US'
[INFO ] 2023-07-05 16:46:54.280 MqttConnection - SUBSCRIBE TX user property 'type', 'JSON'
[DEBUG] 2023-07-05 16:46:54.282 AsyncioHelper - On socket register write
[DEBUG] 2023-07-05 16:46:54.283 AsyncioHelper - On socket unregister write
[DEBUG] 2023-07-05 16:46:54.380 MqttConnection - Subscribed on filters 'test/topic' with QoS 0 no local False retain as published False retain handing 2 with message id 1
[INFO ] 2023-07-05 16:47:04.415 GRPCControlServer - PublishMqtt connection_id 0 topic test/topic retain 0
[INFO ] 2023-07-05 16:47:04.415 MqttConnection - PUBLISH TX user property 'region', 'US'
[INFO ] 2023-07-05 16:47:04.416 MqttConnection - PUBLISH TX user property 'type', 'JSON'
[DEBUG] 2023-07-05 16:47:04.416 AsyncioHelper - On socket register write
[DEBUG] 2023-07-05 16:47:04.417 AsyncioHelper - On socket unregister write
[DEBUG] 2023-07-05 16:47:04.495 MqttConnection - Published on topic 'test/topic' QoS 1 retain 0 with rc 0 message id 2
[DEBUG] 2023-07-05 16:47:04.496 MqttConnection - onMessage message b'Hello World!' from topic 'test/topic'
[INFO ] 2023-07-05 16:47:04.497 MqttConnection - PUBLISH RX user property 'region', 'US'
[INFO ] 2023-07-05 16:47:04.499 MqttConnection - PUBLISH RX user property 'type', 'JSON'
[INFO ] 2023-07-05 16:47:04.499 GRPCDiscoveryClient - Sending OnReceiveMessage request agent_id 'python-paho-agent' connection_id 0 message b'Hello World!' on topic 'test/topic'
[DEBUG] 2023-07-05 16:47:09.507 GRPCControlServer - Unsubscription: filter test/topic
[INFO ] 2023-07-05 16:47:09.507 GRPCControlServer - UnsubscribeMqtt connection_id 0
[INFO ] 2023-07-05 16:47:09.510 MqttConnection - UNSUBSCRIBE TX user property 'region', 'US'
[INFO ] 2023-07-05 16:47:09.510 MqttConnection - UNSUBSCRIBE TX user property 'type', 'JSON'
[DEBUG] 2023-07-05 16:47:09.512 AsyncioHelper - On socket register write
[DEBUG] 2023-07-05 16:47:09.512 AsyncioHelper - On socket unregister write
[DEBUG] 2023-07-05 16:47:09.601 MqttConnection - Unsubscribed from filters 'test/topic' with message id 3
[INFO ] 2023-07-05 16:47:19.611 GRPCControlServer - CloseMqttConnection connection_id 0 reason 4
[INFO ] 2023-07-05 16:47:19.611 MqttConnection - Disconnect MQTT connection with reason code 4
[INFO ] 2023-07-05 16:47:19.613 MqttConnection - DISCONNECT TX user property 'region', 'US'
[INFO ] 2023-07-05 16:47:19.613 MqttConnection - DISCONNECT TX user property 'type', 'JSON'
[DEBUG] 2023-07-05 16:47:19.616 AsyncioHelper - On socket register write
[INFO ] 2023-07-05 16:47:19.616 GRPCDiscoveryClient - Sending OnMqttDisconnect request agent_id 'python-paho-agent' connection_id 0 error 'None'
[DEBUG] 2023-07-05 16:47:19.628 AsyncioHelper - On socket unregister write
[DEBUG] 2023-07-05 16:47:19.629 AsyncioHelper - On socket close
[INFO ] 2023-07-05 16:47:19.636 GRPCControlServer - shutdownAgent: reason That's it.
[INFO ] 2023-07-05 16:47:19.638 GRPCControlServer - Server termination done
[INFO ] 2023-07-05 16:47:19.639 GRPCLink - Shutdown gPRC link
[INFO ] 2023-07-05 16:47:19.647 Main - Execution done successfully
```
Mqtt Client Control output
```
java -Dmqtt_client_id=Python_Paho_Client -Dmqtt_broker_addr=a3t8vwpkw3sltg-ats.iot.eu-west-1.amazonaws.com -Dmqtt_client_ca_file=creds_aws/rootCA.pem -Dmqtt_client_cert_file=creds_aws/thingCert.crt -Dmqtt_client_key_file=creds_aws/privKey.key -jar target/aws-greengrass-testing-mqtt-client-control.jar 47619 true true
[INFO ] 2023-07-05 16:46:38.010 [main] ExampleControl - Control: port 47619, with TLS, MQTT v5
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
[INFO ] 2023-07-05 16:46:39.536 [main] EngineControlImpl - MQTT client control gRPC server started, listening on 47619
[INFO ] 2023-07-05 16:46:45.580 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId python-paho-agent
[INFO ] 2023-07-05 16:46:45.602 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId python-paho-agent address 127.0.0.1 port 58480
[INFO ] 2023-07-05 16:46:45.607 [grpc-default-executor-0] EngineControlImpl - Created new agent control for python-paho-agent on 127.0.0.1:58480
[INFO ] 2023-07-05 16:46:45.653 [grpc-default-executor-0] ExampleControl - Agent python-paho-agent is connected
[INFO ] 2023-07-05 16:46:45.661 [pool-2-thread-1] AgentTestScenario - Playing test scenario for agent id python-paho-agent
[INFO ] 2023-07-05 16:46:48.668 [pool-2-thread-1] AgentTestScenario - Connect Set user property: region, US
[INFO ] 2023-07-05 16:46:48.668 [pool-2-thread-1] AgentTestScenario - Connect Set user property: type, JSON
[INFO ] 2023-07-05 16:46:49.256 [pool-2-thread-1] AgentControlImpl - Created connection with id 0 CONNACK 'sessionPresent: false
reasonCode: 0
receiveMaximum: 100
maximumQoS: 1
retainAvailable: true
maximumPacketSize: 149504
wildcardSubscriptionsAvailable: true
subscriptionIdentifiersAvailable: false
sharedSubscriptionsAvailable: true
serverKeepAlive: 60
topicAliasMaximum: 8
'
[INFO ] 2023-07-05 16:46:49.257 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 0 created
[INFO ] 2023-07-05 16:46:49.259 [pool-2-thread-1] AgentTestScenario - MQTT connection with id 0 is established
[INFO ] 2023-07-05 16:46:54.263 [pool-2-thread-1] AgentTestScenario - Subscribe Set user property: region, US
[INFO ] 2023-07-05 16:46:54.263 [pool-2-thread-1] AgentTestScenario - Subscribe Set user property: type, JSON
[INFO ] 2023-07-05 16:46:54.268 [pool-2-thread-1] AgentControlImpl - SubscribeMqtt: subscribe on connection 0
[INFO ] 2023-07-05 16:46:54.398 [pool-2-thread-1] AgentTestScenario - Subscribe response: connectionId 0 reason codes [0] reason string ''
[INFO ] 2023-07-05 16:47:04.402 [pool-2-thread-1] AgentTestScenario - Set property payload format indicator true
[INFO ] 2023-07-05 16:47:04.402 [pool-2-thread-1] AgentTestScenario - Set property message expiry interval 3600
[INFO ] 2023-07-05 16:47:04.404 [pool-2-thread-1] AgentTestScenario - Publish Set user property: region, US
[INFO ] 2023-07-05 16:47:04.406 [pool-2-thread-1] AgentTestScenario - Publish Set user property: type, JSON
[INFO ] 2023-07-05 16:47:04.406 [pool-2-thread-1] AgentTestScenario - Set property content type text/plain; charset=utf-8
[INFO ] 2023-07-05 16:47:04.409 [pool-2-thread-1] AgentControlImpl - PublishMqtt: publishing on connectionId 0 topic test/topic
[INFO ] 2023-07-05 16:47:04.499 [pool-2-thread-1] AgentTestScenario - Published connectionId 0 reason code 0 reason string ''
[INFO ] 2023-07-05 16:47:04.504 [grpc-default-executor-0] GRPCDiscoveryServer - OnReceiveMessage: agentId python-paho-agent connectionId 0 topic test/topic QoS 0
[INFO ] 2023-07-05 16:47:04.506 [grpc-default-executor-0] AgentTestScenario - Message received on agentId python-paho-agent connectionId 0 topic test/topic QoS 0 content <ByteString@7cfcccc8 size=12 contents="Hello World!">
[INFO ] 2023-07-05 16:47:04.507 [grpc-default-executor-0] AgentTestScenario - Message has user property key region value US
[INFO ] 2023-07-05 16:47:04.508 [grpc-default-executor-0] AgentTestScenario - Message has user property key type value JSON
[INFO ] 2023-07-05 16:47:09.500 [pool-2-thread-1] AgentTestScenario - Unsubscribe Set user property: region, US
[INFO ] 2023-07-05 16:47:09.500 [pool-2-thread-1] AgentTestScenario - Unsubscribe Set user property: type, JSON
[INFO ] 2023-07-05 16:47:09.504 [pool-2-thread-1] AgentControlImpl - UnsubscribeMqtt: unsubscribe on connectionId 0
[INFO ] 2023-07-05 16:47:09.604 [pool-2-thread-1] AgentTestScenario - Unsubscribe response: connectionId 0 reason codes [0] reason string ''
[INFO ] 2023-07-05 16:47:19.605 [pool-2-thread-1] AgentTestScenario - Disconnect Set user property: region, US
[INFO ] 2023-07-05 16:47:19.605 [pool-2-thread-1] AgentTestScenario - Disconnect Set user property: type, JSON
[INFO ] 2023-07-05 16:47:19.625 [grpc-default-executor-0] GRPCDiscoveryServer - OnMqttDisconnect: agentId python-paho-agent connectionId 0 disconnect 'reasonCode: 0
' error ''
[INFO ] 2023-07-05 16:47:19.625 [grpc-default-executor-0] AgentTestScenario - MQTT disconnected on agentId python-paho-agent connectionId 0 disconnect 'reasonCode: 0
' error ''
[INFO ] 2023-07-05 16:47:19.630 [pool-2-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 0 closed
[INFO ] 2023-07-05 16:47:19.639 [pool-2-thread-1] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-07-05 16:47:19.642 [grpc-default-executor-0] GRPCDiscoveryServer - UnregisterAgent: agentId python-paho-agent reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-07-05 16:47:19.645 [grpc-default-executor-0] ExampleControl - Agent python-paho-agent is disconnected
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
