### PR TITLE
feat(uat): implement request response features in sdk-java client

### DIFF
--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt311/client/sdkmqtt/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt311/client/sdkmqtt/Mqtt311ConnectionImpl.java
@@ -294,7 +294,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
         checkUserProperties(userProperties);
 
         if (subscriptionId != null) {
-            throw new IllegalArgumentException("MQTT v3.1.1 doesn't support subscription id");
+            throw new IllegalArgumentException("Iot device SDK MQTT v3.1.1 client does not support subscription id");
         }
 
         if (subscriptions.size() != 1) {
@@ -361,6 +361,9 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
      */
     private MqttClientConnection createConnection(MqttLib.ConnectionParams connectionParams) throws MqttException {
         checkUserProperties(connectionParams.getUserProperties());
+        if (connectionParams.getRequestResponseInformation() != null) {
+            logger.atWarn().log("MQTT v3.1.1 does not support request response information");
+        }
 
         try (AwsIotMqttConnectionBuilder builder = getConnectionBuilder(connectionParams)) {
             builder.withEndpoint(connectionParams.getHost())

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/GRPCClient.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/GRPCClient.java
@@ -43,7 +43,13 @@ public interface GRPCClient {
         private Boolean payloadFormatIndicator;
 
         /** Optional message expiry interval. */
-        private Long messageExpiryInterval;
+        private Integer messageExpiryInterval;
+
+        /** Optional response topic. */
+        private String responseTopic;
+
+        /** Optional correlation data. */
+        private byte[] correlationData;
 
         // TODO: add other properties
     }

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
@@ -45,8 +45,9 @@ public interface MqttConnection {
         private String responseInformation;
         private String serverReference;
         private List<Mqtt5Properties> userProperties;
+        private Integer topicAliasMaximum;          // miss for AWS IoT device SDK MQTT5 client ?
 
-        // TODO: int topicAliasMaximum;          // miss for AWS IoT device SDK MQTT5 client ?
+
         // TODO: Authentication Method
         // TODO: Authentication Data
 

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
@@ -136,6 +136,12 @@ public interface MqttConnection {
 
         /** Optional message expiry interval. */
         private Integer messageExpiryInterval;
+
+        /** Optional response topic. */
+        private String responseTopic;
+
+        /** Optional correlation data. */
+        private byte[] correlationData;
     }
 
     /**

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
@@ -53,6 +53,9 @@ public interface MqttLib extends AutoCloseable {
 
         /** User properties. */
         private List<Mqtt5Properties> userProperties;
+
+        /** Optional request response information. */
+        private Boolean requestResponseInformation;
     }
 
     /**

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCDiscoveryClient.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCDiscoveryClient.java
@@ -126,6 +126,29 @@ class GRPCDiscoveryClient implements GRPCClient {
                                         .setQos(MqttQoS.forNumber(message.getQos()))
                                         .setRetain(message.isRetain());
 
+        // please use the same order as in 3.3.2 PUBLISH Variable Header of MQTT v5.0 specification
+        final Boolean payloadFormatIndicator = message.getPayloadFormatIndicator();
+        if (payloadFormatIndicator != null) {
+            builder.setPayloadFormatIndicator(payloadFormatIndicator);
+        }
+
+
+        final Integer messageExpiryInterval = message.getMessageExpiryInterval();
+        if (messageExpiryInterval != null) {
+            builder.setMessageExpiryInterval(messageExpiryInterval);
+        }
+
+
+        final String responseTopic = message.getResponseTopic();
+        if (responseTopic != null) {
+            builder.setResponseTopic(responseTopic);
+        }
+
+        final byte[] correlationData = message.getCorrelationData();
+        if (correlationData != null) {
+            builder.setCorrelationData(ByteString.copyFrom(correlationData));
+        }
+
         final List<Mqtt5Properties> userProperties = message.getUserProperties();
         if (userProperties != null && !userProperties.isEmpty()) {
             builder.addAllProperties(userProperties);
@@ -134,11 +157,6 @@ class GRPCDiscoveryClient implements GRPCClient {
         final String contentType = message.getContentType();
         if (contentType != null) {
             builder.setContentType(contentType);
-        }
-
-        final Boolean payloadFormatIndicator = message.getPayloadFormatIndicator();
-        if (payloadFormatIndicator != null) {
-            builder.setPayloadFormatIndicator(payloadFormatIndicator);
         }
 
         OnReceiveMessageRequest request = OnReceiveMessageRequest.newBuilder()

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCDiscoveryClient.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCDiscoveryClient.java
@@ -132,12 +132,10 @@ class GRPCDiscoveryClient implements GRPCClient {
             builder.setPayloadFormatIndicator(payloadFormatIndicator);
         }
 
-
         final Integer messageExpiryInterval = message.getMessageExpiryInterval();
         if (messageExpiryInterval != null) {
             builder.setMessageExpiryInterval(messageExpiryInterval);
         }
-
 
         final String responseTopic = message.getResponseTopic();
         if (responseTopic != null) {

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttConnectionImpl.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttConnectionImpl.java
@@ -454,6 +454,12 @@ public class MqttConnectionImpl implements MqttConnection {
                 connectBuilder.withUserProperties(convertToUserProperties(userProperties, "CONNECT"));
             }
 
+            final Boolean requestResponseInformation = connectionParams.getRequestResponseInformation();
+            if (requestResponseInformation != null) {
+                connectBuilder.withRequestResponseInformation(requestResponseInformation);
+                logger.atInfo().log("CONNECT Tx request response information: {}", requestResponseInformation);
+            }
+
             ClientSessionBehavior clientSessionBehavior = connectionParams.isCleanSession()
                         ? ClientSessionBehavior.CLEAN : ClientSessionBehavior.DEFAULT;
 
@@ -530,6 +536,11 @@ public class MqttConnectionImpl implements MqttConnection {
 
         final List<Mqtt5Properties> userProperties = convertToMqtt5Properties(packet.getUserProperties(), "CONNACK");
 
+        final String responseInformation = packet.getResponseInformation();
+        if (responseInformation != null) {
+            logger.atInfo().log("CONNACK Rx response information: '{}'", responseInformation);
+        }
+
         QOS maximumQOS = packet.getMaximumQOS();
         return new ConnAckInfo(packet.getSessionPresent(),
                                 reasonCode == null ? null : reasonCode.getValue(),
@@ -544,9 +555,10 @@ public class MqttConnectionImpl implements MqttConnection {
                                 packet.getSubscriptionIdentifiersAvailable(),
                                 packet.getSharedSubscriptionsAvailable(),
                                 packet.getServerKeepAlive(),
-                                packet.getResponseInformation(),
+                                responseInformation,
                                 packet.getServerReference(),
-                                userProperties
+                                userProperties,
+                                null
                                 );
     }
 

--- a/uat/custom-components/client-mosquitto-c/README.md
+++ b/uat/custom-components/client-mosquitto-c/README.md
@@ -65,3 +65,6 @@ In result we check all values of QoS and properties in gRPC SubscribeMqtt reques
 
 3. Unsubscription
 In Mosquitto API mosquitto_unsubscribe_v5_callback_set() callback does not provides result code, instead zero code will be returned on success.
+
+4. Windows implementation
+mosquitto library can build on Windows but miss threaded interface and can works only in synchronous mode. That brokes logic of gRPC requests and client control.


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-220
Implement request/response features

**Description of changes:**
- Implement PUBLISH Response Topic feature for both Tx and Rx directions
- Implement PUBLISH Correlation data feature for both Tx and Rx directions
- Implement CONNECT Request Response Information feature for Tx
- Implement CONNACK Response Information feature for Rx
- Extend fix of executorService usage to receive message
- Reorder property handling to be the same order as in MQTT v5.0 spec

**Why is this change necessary:**
We need support request/response MQTT v5.0 features in SDK-java client

**How was this change tested:**
Currently manually by run Control as application.
Later by creating scenario to test these 4 features.

**Test results:**
Control:
```
[INFO ] 2023-07-06 15:41:56.077 [com.aws.greengrass.testing.mqtt.client.control.ExampleControl.main()] ExampleControl - Control: port 47619, with TLS, MQTT v5
[INFO ] 2023-07-06 15:41:56.475 [com.aws.greengrass.testing.mqtt.client.control.ExampleControl.main()] EngineControlImpl - MQTT client control gRPC server started, listening on 47619
[INFO ] 2023-07-06 15:42:22.341 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId sdk-java-agent
[INFO ] 2023-07-06 15:42:22.421 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId sdk-java-agent address 127.0.0.1 port 39465
[INFO ] 2023-07-06 15:42:22.425 [grpc-default-executor-0] EngineControlImpl - Created new agent control for sdk-java-agent on 127.0.0.1:39465
[INFO ] 2023-07-06 15:42:22.480 [grpc-default-executor-0] ExampleControl - Agent sdk-java-agent is connected
[INFO ] 2023-07-06 15:42:22.485 [pool-2-thread-1] AgentTestScenario - Playing test scenario for agent id sdk-java-agent
[INFO ] 2023-07-06 15:42:25.505 [pool-2-thread-1] AgentTestScenario - Set CONNECT user property: region, US
[INFO ] 2023-07-06 15:42:25.505 [pool-2-thread-1] AgentTestScenario - Set CONNECT user property: type, JSON
[INFO ] 2023-07-06 15:42:25.508 [pool-2-thread-1] AgentTestScenario - Set CONNECT request response information true
[INFO ] 2023-07-06 15:42:26.260 [pool-2-thread-1] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
reasonCode: 0
receiveMaximum: 100
maximumQoS: 1
retainAvailable: true
maximumPacketSize: 149504
wildcardSubscriptionsAvailable: true
subscriptionIdentifiersAvailable: false
sharedSubscriptionsAvailable: true
serverKeepAlive: 60
'
[INFO ] 2023-07-06 15:42:26.260 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-07-06 15:42:26.260 [pool-2-thread-1] AgentTestScenario - MQTT connection with id 1 is established
[INFO ] 2023-07-06 15:42:31.267 [pool-2-thread-1] AgentTestScenario - Set SUBSCRIBE user property: region, US
[INFO ] 2023-07-06 15:42:31.267 [pool-2-thread-1] AgentTestScenario - Set SUBSCRIBE user property: type, JSON
[INFO ] 2023-07-06 15:42:31.275 [pool-2-thread-1] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-07-06 15:42:31.382 [pool-2-thread-1] AgentTestScenario - Subscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-07-06 15:42:41.389 [pool-2-thread-1] AgentTestScenario - Set PUBLISH payload format indicator true
[INFO ] 2023-07-06 15:42:41.389 [pool-2-thread-1] AgentTestScenario - Set PUBLISH message expiry interval 3600
[INFO ] 2023-07-06 15:42:41.390 [pool-2-thread-1] AgentTestScenario - Set PUBLISH response topic /thing1/response/topic
[INFO ] 2023-07-06 15:42:41.392 [pool-2-thread-1] AgentTestScenario - Set PUBLISH correlation data <ByteString@1f8c8662 size=16 contents="correlation_data">
[INFO ] 2023-07-06 15:42:41.393 [pool-2-thread-1] AgentTestScenario - Set PUBLISH user property: region, US
[INFO ] 2023-07-06 15:42:41.393 [pool-2-thread-1] AgentTestScenario - Set PUBLISH user property: type, JSON
[INFO ] 2023-07-06 15:42:41.394 [pool-2-thread-1] AgentTestScenario - Set PUBLISH content type text/plain; charset=utf-8
[INFO ] 2023-07-06 15:42:41.400 [pool-2-thread-1] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic test/topic
[INFO ] 2023-07-06 15:42:41.470 [pool-2-thread-1] AgentTestScenario - Published connectionId 1 reason code 0 reason string ''
[INFO ] 2023-07-06 15:42:41.478 [grpc-default-executor-0] GRPCDiscoveryServer - OnReceiveMessage: agentId sdk-java-agent connectionId 1 topic test/topic QoS 0
[INFO ] 2023-07-06 15:42:41.478 [grpc-default-executor-0] AgentTestScenario - Message received on agentId sdk-java-agent connectionId 1 topic test/topic QoS 0 content <ByteString@3775da32 size=12 contents="Hello World!">
[INFO ] 2023-07-06 15:42:41.478 [grpc-default-executor-0] AgentTestScenario - Message has payload format indicator true
[INFO ] 2023-07-06 15:42:41.479 [grpc-default-executor-0] AgentTestScenario - Message has message expiry interval 3599
[INFO ] 2023-07-06 15:42:41.479 [grpc-default-executor-0] AgentTestScenario - Message has response topic /thing1/response/topic
[INFO ] 2023-07-06 15:42:41.479 [grpc-default-executor-0] AgentTestScenario - Message has correlation data <ByteString@dbb0170 size=16 contents="correlation_data">
[INFO ] 2023-07-06 15:42:41.479 [grpc-default-executor-0] AgentTestScenario - Message has user property key region value US
[INFO ] 2023-07-06 15:42:41.479 [grpc-default-executor-0] AgentTestScenario - Message has user property key type value JSON
[INFO ] 2023-07-06 15:42:41.479 [grpc-default-executor-0] AgentTestScenario - Message has content type 'text/plain; charset=utf-8'
[INFO ] 2023-07-06 15:42:46.470 [pool-2-thread-1] AgentTestScenario - Set UNSUBSCRIBE user property: region, US
[INFO ] 2023-07-06 15:42:46.471 [pool-2-thread-1] AgentTestScenario - Set UNSUBSCRIBE user property: type, JSON
[INFO ] 2023-07-06 15:42:46.479 [pool-2-thread-1] AgentControlImpl - UnsubscribeMqtt: unsubscribe on connectionId 1
[INFO ] 2023-07-06 15:42:46.557 [pool-2-thread-1] AgentTestScenario - Unsubscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-07-06 15:42:56.557 [pool-2-thread-1] AgentTestScenario - Set DISCONNECT user property: region, US
[INFO ] 2023-07-06 15:42:56.558 [pool-2-thread-1] AgentTestScenario - Set DISCONNECT user property: type, JSON
[INFO ] 2023-07-06 15:42:56.591 [pool-2-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 1 closed
[INFO ] 2023-07-06 15:42:56.604 [pool-2-thread-1] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-07-06 15:42:56.622 [grpc-default-executor-0] GRPCDiscoveryServer - UnregisterAgent: agentId sdk-java-agent reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-07-06 15:42:56.624 [grpc-default-executor-0] ExampleControl - Agent sdk-java-agent is disconnected

```

SDK-java client
```
[INFO ] 2023-07-06 15:42:21.779 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Making gPRC client connection with 127.0.0.1:47619 as sdk-java-agent...
[INFO ] 2023-07-06 15:42:22.370 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Client connection with Control is established, local address is 127.0.0.1
[INFO ] 2023-07-06 15:42:22.416 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - GRPCControlServer created and listed on 127.0.0.1:39465
[INFO ] 2023-07-06 15:42:22.490 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Handle gRPC requests
[INFO ] 2023-07-06 15:42:22.490 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - Server awaitTermination
[INFO ] 2023-07-06 15:42:25.604 [grpc-default-executor-0] GRPCControlServer - createMqttConnection: clientId GGMQ-test-device2 broker a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[INFO ] 2023-07-06 15:42:25.609 [grpc-default-executor-0] MqttConnectionImpl - Creating Mqtt5Client with TLS
[INFO ] 2023-07-06 15:42:25.849 [grpc-default-executor-0] MqttConnectionImpl - CONNECT Tx user property 'region':'US'
[INFO ] 2023-07-06 15:42:25.849 [grpc-default-executor-0] MqttConnectionImpl - CONNECT Tx user property 'type':'JSON'
[INFO ] 2023-07-06 15:42:25.849 [grpc-default-executor-0] MqttConnectionImpl - CONNECT Tx request response information: true
[INFO ] 2023-07-06 15:42:25.879 [Thread-2] MqttConnectionImpl - MQTT connectionId 1 connecting...
[INFO ] 2023-07-06 15:42:26.151 [Thread-2] MqttConnectionImpl - MQTT connectionId 1 connected, client id GGMQ-test-device2
[INFO ] 2023-07-06 15:42:31.299 [grpc-default-executor-0] GRPCControlServer - Subscription: filter test/topic QoS 0 noLocal false retainAsPublished false retainHandling 2
[INFO ] 2023-07-06 15:42:31.299 [grpc-default-executor-0] GRPCControlServer - Subscribe: connectionId 1 subscriptionId null for 1 filters
[INFO ] 2023-07-06 15:42:31.303 [grpc-default-executor-0] MqttConnectionImpl - SUBSCRIBE Tx user property 'region':'US'
[INFO ] 2023-07-06 15:42:31.303 [grpc-default-executor-0] MqttConnectionImpl - SUBSCRIBE Tx user property 'type':'JSON'
[INFO ] 2023-07-06 15:42:31.366 [grpc-default-executor-0] GRPCControlServer - Subscribe response: connectionId 1 reason codes [0] reason string null
[INFO ] 2023-07-06 15:42:41.432 [grpc-default-executor-0] GRPCControlServer - Publish: connectionId 1 topic test/topic QoS 1 retain false
[INFO ] 2023-07-06 15:42:41.435 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx payload format indicator: true
[INFO ] 2023-07-06 15:42:41.435 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx message expiry interval: 3600
[INFO ] 2023-07-06 15:42:41.435 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx response topic: /thing1/response/topic
[INFO ] 2023-07-06 15:42:41.436 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx correlation data: [99, 111, 114, 114, 101, 108, 97, 116, 105, 111, 110, 95, 100, 97, 116, 97]
[INFO ] 2023-07-06 15:42:41.436 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx user property 'region':'US'
[INFO ] 2023-07-06 15:42:41.436 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx user property 'type':'JSON'
[INFO ] 2023-07-06 15:42:41.436 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx content type: 'text/plain; charset=utf-8'
[INFO ] 2023-07-06 15:42:41.466 [grpc-default-executor-0] GRPCControlServer - Publish response: connectionId 1 reason code 0 reason string null
[INFO ] 2023-07-06 15:42:41.468 [Thread-2] MqttConnectionImpl - PUBLISH Rx payload format indicator: true
[INFO ] 2023-07-06 15:42:41.468 [Thread-2] MqttConnectionImpl - PUBLISH Rx message expiry interval: 3599
[INFO ] 2023-07-06 15:42:41.468 [Thread-2] MqttConnectionImpl - PUBLISH Rx response topic: /thing1/response/topic
[INFO ] 2023-07-06 15:42:41.468 [Thread-2] MqttConnectionImpl - PUBLISH Rx correlation data: [99, 111, 114, 114, 101, 108, 97, 116, 105, 111, 110, 95, 100, 97, 116, 97]
[INFO ] 2023-07-06 15:42:41.469 [Thread-2] MqttConnectionImpl - PUBLISH Rx user property 'region':'US'
[INFO ] 2023-07-06 15:42:41.469 [Thread-2] MqttConnectionImpl - PUBLISH Rx user property 'type':'JSON'
[INFO ] 2023-07-06 15:42:41.469 [Thread-2] MqttConnectionImpl - PUBLISH Rx content type: 'text/plain; charset=utf-8'
[INFO ] 2023-07-06 15:42:41.470 [Thread-2] MqttConnectionImpl - Received MQTT message: connectionId 1 topic test/topic QoS 0 retain false
[INFO ] 2023-07-06 15:42:46.492 [grpc-default-executor-0] GRPCControlServer - Unsubscribe: connectionId 1 for [test/topic] filters
[INFO ] 2023-07-06 15:42:46.494 [grpc-default-executor-0] MqttConnectionImpl - UNSUBSCRIBE Tx user property 'region':'US'
[INFO ] 2023-07-06 15:42:46.494 [grpc-default-executor-0] MqttConnectionImpl - UNSUBSCRIBE Tx user property 'type':'JSON'
[INFO ] 2023-07-06 15:42:46.550 [grpc-default-executor-0] GRPCControlServer - Unsubscribe response: connectionId 1 reason codes [0] reason string null
[INFO ] 2023-07-06 15:42:56.577 [grpc-default-executor-0] GRPCControlServer - closeMqttConnection: connectionId 1 reason 4
[INFO ] 2023-07-06 15:42:56.579 [grpc-default-executor-0] MqttConnectionImpl - DISCONNECT Tx user property 'region':'US'
[INFO ] 2023-07-06 15:42:56.579 [grpc-default-executor-0] MqttConnectionImpl - DISCONNECT Tx user property 'type':'JSON'
[WARN ] 2023-07-06 15:42:56.580 [Thread-2] MqttConnectionImpl - DISCONNECT event ignored due to shutdown initiated
[INFO ] 2023-07-06 15:42:56.581 [Thread-2] MqttConnectionImpl - MQTT connectionId 1 disconnected error 'Mqtt5 client connection interrupted by user request.' disconnectPacket 'null'
[INFO ] 2023-07-06 15:42:56.582 [Thread-2] MqttConnectionImpl - MQTT connectionId 1 stopped
[INFO ] 2023-07-06 15:42:56.600 [grpc-default-executor-0] GRPCControlServer - shutdownAgent: reason That's it.
[INFO ] 2023-07-06 15:42:56.615 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - Server awaitTermination done
[INFO ] 2023-07-06 15:42:56.615 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Shutdown gPRC link
[INFO ] 2023-07-06 15:42:56.629 [com.aws.greengrass.testing.mqtt5.client.Main.main()] Main - Execution done successfully
```


**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
