### PR TITLE
fix(uat): resolve clients uncontrolled reconnect issue

### DIFF
--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
@@ -31,7 +31,7 @@ public interface MqttLib extends AutoCloseable {
         private String host;
 
         /** Port of MQTT broker. */
-        private int port;
+        private int port;                               // FIXME: WHY IS NOT USED ?
 
         /** Connection keep alive interval in seconds. */
         private int keepalive;

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
@@ -313,19 +313,19 @@ public class MqttConnectionImpl implements MqttConnection {
         String contentType = message.getContentType();
         if (contentType != null && !contentType.isEmpty()) {
             properties.setContentType(contentType);
-            logger.atInfo().log("Publish Tx payload content type '{}'", contentType);
+            logger.atInfo().log("PUBLISH Tx payload content type '{}'", contentType);
         }
 
         Boolean payloadFormatIndicator = message.getPayloadFormatIndicator();
         if (payloadFormatIndicator != null) {
             properties.setPayloadFormat(payloadFormatIndicator);
-            logger.atInfo().log("Publish Tx payload format indicator '{}'", payloadFormatIndicator);
+            logger.atInfo().log("PUBLISH Tx payload format indicator '{}'", payloadFormatIndicator);
         }
 
         Integer messageExpiryInterval = message.getMessageExpiryInterval();
         if (messageExpiryInterval != null) {
             properties.setMessageExpiryInterval(Long.valueOf(messageExpiryInterval));
-            logger.atInfo().log("Publish Tx expiry message interval '{}'", messageExpiryInterval);
+            logger.atInfo().log("PUBLISH Tx expiry message interval '{}'", messageExpiryInterval);
         }
 
         return properties;

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt311/client/sdkmqtt/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt311/client/sdkmqtt/Mqtt311ConnectionImpl.java
@@ -47,7 +47,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
     private static final String EXCEPTION_WHEN_PUBLISHING = "Exception occurred during publish";
     private static final String EXCEPTION_WHEN_SUBSCRIBING = "Exception occurred during subscribe";
     private static final String EXCEPTION_WHEN_UNSUBSCRIBING = "Exception occurred during unsubscribe";
-    private static final long RECONNECT_TIMEOUT_SEC = 86400; // one day
+    private static final long RECONNECT_TIMEOUT_SEC = 86_400; // one day
 
     static final int REASON_CODE_SUCCESS = 0;
 

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttConnectionImpl.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttConnectionImpl.java
@@ -54,6 +54,7 @@ import java.util.stream.Collectors;
  */
 public class MqttConnectionImpl implements MqttConnection {
     private static final Logger logger = LogManager.getLogger(MqttConnectionImpl.class);
+    private static final long RECONNECT_DELAY_MS = 86_400_000; // one day
 
     private final AtomicBoolean isClosing = new AtomicBoolean();
     private final AtomicBoolean isConnected = new AtomicBoolean();
@@ -250,11 +251,12 @@ public class MqttConnectionImpl implements MqttConnection {
     @Override
     public ConnectResult start(long timeout, int connectionId) throws MqttException {
         this.connectionId = connectionId;
+        boolean success = false;
         client.start();
         try {
             OnConnectionDoneInfo onConnectionDoneInfo = lifecycleEvents.connectedFuture.get(timeout, TimeUnit.SECONDS);
             // translate onConnectionInfo to intermediate object and return
-            final boolean success = onConnectionDoneInfo.onConnectionSuccessReturn != null;
+            success = onConnectionDoneInfo.onConnectionSuccessReturn != null;
             ConnAckPacket packet = null;
             if (success) {
                 packet = onConnectionDoneInfo.onConnectionSuccessReturn.getConnAckPacket();
@@ -267,6 +269,11 @@ public class MqttConnectionImpl implements MqttConnection {
         } catch (Exception ex) {
             logger.atError().withThrowable(ex).log("Exception occurred during connect");
             throw new MqttException("Exception occurred during connect", ex);
+        } finally {
+            if (!success) {
+                client.stop(null);
+                client.close();
+            }
         }
     }
 
@@ -467,15 +474,14 @@ public class MqttConnectionImpl implements MqttConnection {
                 .withSessionBehavior(clientSessionBehavior)
                 .withPort(Long.valueOf(connectionParams.getPort()))
                 .withLifeCycleEvents(lifecycleEvents)
-                .withPublishEvents(publishEvents);
+                .withPublishEvents(publishEvents)
+                .withMaxReconnectDelayMs(RECONNECT_DELAY_MS)
+                .withMinReconnectDelayMs(RECONNECT_DELAY_MS);
 
             /* TODO: other options:
                 withAckTimeoutSeconds()
                 withConnackTimeoutMs()
                 withExtendedValidationAndFlowControlOptions()
-                withMaxReconnectDelayMs()
-                withMaxReconnectDelayMs()
-                withMinReconnectDelayMs()
                 withOfflineQueueBehavior()
                 withPingTimeoutMs()
                 withRetryJitterMode()

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttConnectionImpl.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttConnectionImpl.java
@@ -281,7 +281,7 @@ public class MqttConnectionImpl implements MqttConnection {
     @Override
     public void disconnect(long timeout, int reasonCode, List<Mqtt5Properties> userProperties) throws MqttException {
 
-        if (!isClosing.getAndSet(true)) {
+        if (isClosing.compareAndSet(false, true)) {
             final DisconnectPacket.DisconnectReasonCode disconnectReason
                     = DisconnectPacket.DisconnectReasonCode.getEnumValueFromInteger(reasonCode);
             DisconnectPacket.DisconnectPacketBuilder builder = new DisconnectPacket.DisconnectPacketBuilder()

--- a/uat/custom-components/client-mosquitto-c/src/MqttConnection.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/MqttConnection.cpp
@@ -181,9 +181,10 @@ ClientControl::Mqtt5ConnAck * MqttConnection::start(unsigned timeout) {
         mosquitto_subscribe_v5_callback_set(m_mosq, on_subscribe);
         mosquitto_unsubscribe_v5_callback_set(m_mosq, on_unsubscribe);
 
+
         mosquitto_log_callback_set(m_mosq, on_log);
 
-        // TODO: mosquitto_reconnect_delay_set(m_mosq, ...)
+        mosquitto_reconnect_delay_set(m_mosq, RECONNECT_DELAY_SEC, RECONNECT_DELAY_SEC, true);
 
         if (!m_ca.empty() && !m_cert.empty() && !m_key.empty()) {
             logd("Use provided TLS credentials\n");

--- a/uat/custom-components/client-mosquitto-c/src/MqttConnection.h
+++ b/uat/custom-components/client-mosquitto-c/src/MqttConnection.h
@@ -184,6 +184,8 @@ private:
     void stateCheck();
 
 
+    const int RECONNECT_DELAY_SEC = 86400; //one day
+
     std::mutex m_mutex;
     GRPCDiscoveryClient & m_grpc_client;
     std::string m_client_id;


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-259
Clients retry MQTT connection even when first attempt failed and control lost it

**Description of changes:**
- Set long reconnect timeout (1 day) in SDK java and mosquitto C clients
- Disable reconnect feature in paho java client
- Add closing of library client when connection was not successful
- Resolve usage of terminated ExecutorService issue in paho and sdk clients
- Use keep alive and clean session in paho java client
- Add FIXME tags for future changes

**Why is this change necessary:**
Connections doubled and have a race

**How was this change tested:**
Only manually when local broker is terminated.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
