### PR TITLE
feat(uat): add test cases for message expiry interval

### DIFF
--- a/uat/README.md
+++ b/uat/README.md
@@ -114,7 +114,7 @@ sudo -E java -Dggc.archive=greengrass-nucleus-latest.zip -Dtest.log.path=logs -D
 ### Run scenarios on Windows
 On Windows due to mosquitto-based client is not yet build on Windows use a little modified command.
 ```
-java -Dggc.archive=greengrass-nucleus-latest.zip -Dtest.log.path=logs -Dtags="@GGMQ and not @mosquitto-c" -jar testing-features/target/client-devices-auth-testing-features.jar
+java -Dggc.archive=greengrass-nucleus-latest.zip -Dtest.log.path=logs -Dtags="@GGMQ and not @SkipOnWindows" -jar testing-features/target/client-devices-auth-testing-features.jar
 ```
 
 Command arguments:
@@ -123,7 +123,7 @@ Dggc.archive - path to the nucleus zip that was downloaded.
 Dtest.log.path - path where you would like the test results to be stored.  
 
 
-Dtags can be extended, if you would like to test exact scenario, you can do as follows:
+-Dtags can be extended, if you would like to test exact scenario, you can do as follows:
 
 ```bash
 java -Dggc.archive=greengrass-nucleus-latest.zip -Dtest.log.path=logs -Dtags="@GGMQ-1-T1 and @sdk-java and @mqtt3" -jar testing-features/target/client-devices-auth-testing-features.jar

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/addon/EventFilter.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/addon/EventFilter.java
@@ -32,6 +32,7 @@ public final class EventFilter {
     private final Boolean retain;
     private final List<Mqtt5Properties> userProperties;
     private final Boolean payloadFormatIndicator;
+    private final Integer messageExpiryInterval;
 
     EventFilter(Builder builder) {
         super();
@@ -49,6 +50,7 @@ public final class EventFilter {
         this.retain = builder.retain;
         this.userProperties = builder.userProperties;
         this.payloadFormatIndicator = builder.payloadFormatIndicator;
+        this.messageExpiryInterval = builder.messageExpiryInterval;
     }
 
     /**
@@ -69,6 +71,7 @@ public final class EventFilter {
         private Boolean retain;
         private List<Mqtt5Properties> userProperties;
         private Boolean payloadFormatIndicator;
+        private Integer messageExpiryInterval;
 
         /**
          * Sets type of event.
@@ -238,6 +241,17 @@ public final class EventFilter {
          */
         public Builder withPayloadFormatIndicator(Boolean payloadFormatIndicator) {
             this.payloadFormatIndicator = payloadFormatIndicator;
+            return this;
+        }
+
+        /**
+         * Sets message expiry interval.
+         * Applicable only for MQTT message events
+         *
+         * @param messageExpiryInterval the message expiry interval of the message or null
+         */
+        public Builder withMessageExpiryInterval(Integer messageExpiryInterval) {
+            this.messageExpiryInterval = messageExpiryInterval;
             return this;
         }
 

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/addon/MqttMessageEvent.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/addon/MqttMessageEvent.java
@@ -92,6 +92,11 @@ public class MqttMessageEvent extends EventImpl {
             return false;
         }
 
+        matched = isMessageExpiryIntervalMatched(filter.getMessageExpiryInterval());
+        if (!matched) {
+            return false;
+        }
+
         // TODO: check QoS ?
 
         // check content
@@ -147,7 +152,12 @@ public class MqttMessageEvent extends EventImpl {
         return payloadFormatIndicator == null || payloadFormatIndicator == message.getPayloadFormatIndicator();
     }
 
+    private boolean isMessageExpiryIntervalMatched(Integer messageExpiryInterval) {
+        return messageExpiryInterval == null || messageExpiryInterval == message.getMessageExpiryInterval();
+    }
+
     private static boolean isTopicMatched(@NonNull String topic, @NonNull String topicFilter) {
         return MqttTopic.topicIsSupersetOf(topicFilter, topic);
     }
+
 }

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -103,9 +103,14 @@ public class MqttControlSteps {
     private static final int IOT_CORE_MQTT_PORT = 8883;
 
     // publish default properties
+
+    // please keep order the same as in 3.3.1 PUBLISH Fixed Header of MQTT v5.0 spec
     private static final boolean DEFAULT_PUBLISH_RETAIN = false;
-    private static final String DEFAULT_CONTENT_TYPE = null;
+
+    // please keep order the same as in 3.3.2.3 PUBLISH Properties of MQTT v5.0 spec
     private static final Boolean DEFAULT_PUBLISH_PAYLOAD_FORMAT_INDICATOR = null;
+    private static final Integer DEFAULT_MESSAGE_EXPIRY_INTERVAL = null;
+    private static final String DEFAULT_CONTENT_TYPE = null;
 
     // subscribe efault properties
     private static final Integer DEFAULT_SUBSCRIPTION_ID = null;        // NOTE: do not set for IoT Core broker !!!
@@ -143,28 +148,40 @@ public class MqttControlSteps {
     /** Actual value of subscribe retain handling option. */
     private Mqtt5RetainHandling subscribeRetainHandling = DEFAULT_SUBSCRIBE_RETAIN_HANDLING;
 
+
     /** Actual value of publish retain option. */
-    private boolean publishRetain = DEFAULT_PUBLISH_RETAIN;
-
-    /** Actual value of publish payload format indicator. */
-    private Boolean publishPayloadFormatIndicator = DEFAULT_PUBLISH_PAYLOAD_FORMAT_INDICATOR;
-
-    /** Actual value of content type to transmit. */
-    private String txContentType = DEFAULT_CONTENT_TYPE;
-
-    /** Actual value of content type to receive. */
-    private String rxContentType = DEFAULT_CONTENT_TYPE;
+    private boolean txRetain = DEFAULT_PUBLISH_RETAIN;
 
     /** Actual expected value of retain flag in received messages. */
-    private Boolean receivedRetain = DEFAULT_RECEIVED_RETAIN;
+    private Boolean rxRetain = DEFAULT_RECEIVED_RETAIN;
 
-    private Boolean receivedPayloadFormatIndicator = DEFAULT_RECEIVED_PAYLOAD_FORMAT_INDICATOR;
+    // please keep order the same as in 3.3.2.3 PUBLISH Properties of MQTT v5.0 spec
+    /** Actual value of payload format indicator to publish. */
+    private Boolean txPayloadFormatIndicator = DEFAULT_PUBLISH_PAYLOAD_FORMAT_INDICATOR;
+
+    /** Actual expected value of payload format indicator in received messages. */
+    private Boolean rxPayloadFormatIndicator = DEFAULT_RECEIVED_PAYLOAD_FORMAT_INDICATOR;
+
+    /** Actual value of message expiry interval. */
+    private Integer txMessageExpiryInterval = DEFAULT_MESSAGE_EXPIRY_INTERVAL;
+
+    /** Actual expected value of message expiry interval in received messages. */
+    private Integer rxMessageExpiryInterval = DEFAULT_MESSAGE_EXPIRY_INTERVAL;
+
 
     /** Actual list of user properties to transmit. */
     private static List<Mqtt5Properties> txUserProperties = null;
 
-    /** Actual list of user properties to receive. */
+    /** Actual expected list of user properties in received messages. */
     private static List<Mqtt5Properties> rxUserProperties = null;
+
+
+    /** Actual value of content type to transmit. */
+    private String txContentType = DEFAULT_CONTENT_TYPE;
+
+    /** Actual value of content type to receive in received messages. */
+    private String rxContentType = DEFAULT_CONTENT_TYPE;
+
 
     private final Map<String, List<MqttBrokerConnectionInfo>> brokers = new HashMap<>();
     private final Map<String, MqttProtoVersion> mqttVersions = new HashMap<>();
@@ -475,7 +492,7 @@ public class MqttControlSteps {
      */
     @And("I set MQTT publish 'retain' flag to {booleanValue}")
     public void setPublishRetain(Boolean retain) {
-        this.publishRetain = retain;
+        this.txRetain = retain;
         log.info("Publish 'retain' flag set to {}", retain);
     }
 
@@ -485,10 +502,56 @@ public class MqttControlSteps {
      * @param payloadFormatIndicator the new boolean value of publish 'payload format indicator' flag or null to reset
      */
     @And("I set MQTT publish 'payload format indicator' flag to {booleanOrNullValue}")
-    public void setPublishPayloadFormatIndicator(Boolean payloadFormatIndicator) {
-        this.publishPayloadFormatIndicator = payloadFormatIndicator;
-        log.info("Publish 'payload format indicator' flag set to {}", payloadFormatIndicator);
+    public void setTxPayloadFormatIndicator(Boolean payloadFormatIndicator) {
+        this.txPayloadFormatIndicator = payloadFormatIndicator;
+        log.info("Publish 'payload format indicator' flag set to {}", txPayloadFormatIndicator);
     }
+
+    /**
+     * Sets MQTT 'message expiry interval' value for publishing.
+     *
+     * @param messageExpiryInterval the new value of message expiry interval for publishing
+     */
+    @And("I set MQTT publish 'message expiry interval' to {int}")
+    public void setTxMessageExpiryInterval(Integer messageExpiryInterval) {
+        this.txMessageExpiryInterval = messageExpiryInterval;
+        log.info("Publish 'message expiry interval' set to {}", this.txMessageExpiryInterval);
+    }
+
+    /**
+     * Reset MQTT 'message expiry interval' value for publishing.
+     *
+     */
+    @SuppressWarnings("PMD.NullAssignment")
+    @And("I reset MQTT publish 'message expiry interval'")
+    public void resetTxMessageExpiryInterval() {
+        this.txMessageExpiryInterval = null;
+        log.info("Publish 'message expiry interval' is reset");
+    }
+
+
+    /**
+     * Sets value of expected MQTT 'message expiry interval' in received messages.
+     *
+     * @param messageExpiryInterval the new expected value of 'message expiry interval' in received messages
+     */
+    @And("I set the 'message expiry interval' in expected received messages to {int}")
+    public void setRxMessageExpiryInterval(Integer messageExpiryInterval) {
+        this.rxMessageExpiryInterval = messageExpiryInterval;
+        log.info("Expected 'message expiry interval' in received messages set to {}", messageExpiryInterval);
+    }
+
+    /**
+     * Reset expected value 'message expiry interval' in received messages.
+     *
+     */
+    @SuppressWarnings("PMD.NullAssignment")
+    @And("I reset expected 'message expiry interval'")
+    public void resetRxMessageExpiryInterval() {
+        this.rxMessageExpiryInterval = null;
+        log.info("Expected 'message expiry interval' is reset");
+    }
+
 
     /**
      * Sets MQTT receive 'retain' flag.
@@ -496,10 +559,11 @@ public class MqttControlSteps {
      * @param retain the boolean new value of receive 'retain' flag or null
      */
     @And("I set the 'retain' flag in expected received messages to {booleanOrNullValue}")
-    public void setReceivedRetain(Boolean retain) {
-        this.receivedRetain = retain;
+    public void setRxRetain(Boolean retain) {
+        this.rxRetain = retain;
         log.info("Expected 'retain' flag in received messages set to {}", retain);
     }
+
 
     /**
      * Sets MQTT receive 'payload format indicator' flag.
@@ -507,8 +571,8 @@ public class MqttControlSteps {
      * @param payloadFormatIndicator the new boolean value of receive 'payload format indicator' flag or null
      */
     @And("I set the 'payload format indicator' flag in expected received messages to {booleanOrNullValue}")
-    public void setReceivedPayloadFormatIndicator(Boolean payloadFormatIndicator) {
-        this.receivedPayloadFormatIndicator = payloadFormatIndicator;
+    public void setRxPayloadFormatIndicator(Boolean payloadFormatIndicator) {
+        this.rxPayloadFormatIndicator = payloadFormatIndicator;
         log.info("Expected 'payload format indicator' flag in received messages set to {}", payloadFormatIndicator);
     }
 
@@ -642,10 +706,10 @@ public class MqttControlSteps {
         final String topic = scenarioContext.applyInline(topicString);
 
         // do publishing
-        log.info("Publishing MQTT message '{}' as Thing {} to topic {} with QoS {} retain {} payloadFormatIndicator {}",
-                    message, clientDeviceThingName, topic, qos, publishRetain, publishPayloadFormatIndicator);
-        Mqtt5Message mqtt5Message = buildMqtt5Message(qos, publishRetain, topic, message,
-                                                        publishPayloadFormatIndicator);
+        log.info("Publishing MQTT message '{}' as Thing {} to topic {} with QoS {} retain {}"
+                        + " payload format indicator {} message expire interval {}", message, clientDeviceThingName,
+                    topic, qos, txRetain, txPayloadFormatIndicator, txMessageExpiryInterval);
+        Mqtt5Message mqtt5Message = buildMqtt5Message(qos, topic, message);
         MqttPublishReply mqttPublishReply = connectionControl.publishMqtt(mqtt5Message);
         if (mqttPublishReply == null) {
             throw new RuntimeException("Do not receive reply to MQTT publish request");
@@ -727,17 +791,18 @@ public class MqttControlSteps {
                                         .withTopic(topic)
                                         .withContentType(rxContentType)
                                         .withContent(message)
-                                        .withRetain(receivedRetain)
+                                        .withRetain(rxRetain)
                                         .withUserProperties(rxUserProperties)
-                                        .withPayloadFormatIndicator(receivedPayloadFormatIndicator)
+                                        .withPayloadFormatIndicator(rxPayloadFormatIndicator)
+                                        .withMessageExpiryInterval(rxMessageExpiryInterval)
                                         .build();
         // convert time units
         TimeUnit timeUnit = TimeUnit.valueOf(unit.toUpperCase());
 
         // awaiting for message
-        log.info("Awaiting for MQTT message '{}' with retain {} payload format indicator {} on topic '{}' on Thing '{}'"
-                    + " for {} {}", message, receivedRetain, receivedPayloadFormatIndicator, topic,
-                                    clientDeviceThingName, value, unit);
+        log.info("Awaiting for MQTT message '{}' with retain {} payload format indicator {} message expiry interval {} "
+                    + "on topic '{}' on Thing '{}' for {} {}", message, rxRetain, rxPayloadFormatIndicator,
+                    rxMessageExpiryInterval, topic, clientDeviceThingName, value, unit);
         List<Event> events = new ArrayList<>();
         try {
             events = eventStorage.awaitEvents(eventFilter, value, timeUnit);
@@ -1080,21 +1145,25 @@ public class MqttControlSteps {
                     .build();
     }
 
-    private Mqtt5Message buildMqtt5Message(int qos, boolean retain, @NonNull String topic, @NonNull String content,
-                                            Boolean payloadFormatIndicator) {
+    private Mqtt5Message buildMqtt5Message(int qos, @NonNull String topic, @NonNull String content) {
         MqttQoS mqttQoS = getMqttQoS(qos);
         Mqtt5Message.Builder builder = Mqtt5Message.newBuilder()
                             .setTopic(topic)
                             .setPayload(ByteString.copyFromUtf8(content))
                             .setQos(mqttQoS)
-                            .setRetain(retain);
+                            .setRetain(txRetain);
+
+        // please order the same as in 3.3.2.3 PUBLISH Properties of MQTT v5.0 spec
+        if (txPayloadFormatIndicator != null) {
+            builder.setPayloadFormatIndicator(txPayloadFormatIndicator);
+        }
 
         if (txUserProperties != null) {
              builder.addAllProperties(txUserProperties);
         }
 
-        if (payloadFormatIndicator != null) {
-            builder.setPayloadFormatIndicator(payloadFormatIndicator);
+        if (txMessageExpiryInterval != null) {
+            builder.setMessageExpiryInterval(txMessageExpiryInterval);
         }
 
         if (txContentType != null) {

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -140,13 +140,15 @@ public class MqttControlSteps {
     /** Actual value of timeout in seconds used in all MQTT opetations. */
     private int mqttTimeoutSec = DEFAULT_MQTT_TIMEOUT_SEC;
 
+    // please keep order the same as in 3.8.3.1 Subscription Options of MQTT v5.0
     /** Actual value of subscribe no local option. */
     private boolean subscribeNoLocal = DEFAULT_SUBSCRIBE_NO_LOCAL;
 
-    private boolean subscribeRetainAsPublished = DEFAULT_SUBSCRIBE_RETAIN_AS_PUBLISHED;
-
     /** Actual value of subscribe retain handling option. */
     private Mqtt5RetainHandling subscribeRetainHandling = DEFAULT_SUBSCRIBE_RETAIN_HANDLING;
+
+    /** Actual value of subscribe retain handling option. */
+    private boolean subscribeRetainAsPublished = DEFAULT_SUBSCRIBE_RETAIN_AS_PUBLISHED;
 
 
     /** Actual value of publish retain option. */
@@ -155,12 +157,14 @@ public class MqttControlSteps {
     /** Actual expected value of retain flag in received messages. */
     private Boolean rxRetain = DEFAULT_RECEIVED_RETAIN;
 
+
     // please keep order the same as in 3.3.2.3 PUBLISH Properties of MQTT v5.0 spec
     /** Actual value of payload format indicator to publish. */
     private Boolean txPayloadFormatIndicator = DEFAULT_PUBLISH_PAYLOAD_FORMAT_INDICATOR;
 
     /** Actual expected value of payload format indicator in received messages. */
     private Boolean rxPayloadFormatIndicator = DEFAULT_RECEIVED_PAYLOAD_FORMAT_INDICATOR;
+
 
     /** Actual value of message expiry interval. */
     private Integer txMessageExpiryInterval = DEFAULT_MESSAGE_EXPIRY_INTERVAL;
@@ -250,6 +254,263 @@ public class MqttControlSteps {
         initMqttVersions();
         startMqttControl();
     }
+
+    /**
+     * Convert boolean string to value.
+     *
+     * @param value the string value of boolean
+     */
+    @SuppressWarnings("PMD.UnnecessaryAnnotationValueElement")
+    @ParameterType(value = "true|True|TRUE|false|False|FALSE")
+    public Boolean booleanValue(String value) {
+        return Boolean.valueOf(value);
+    }
+
+    /**
+     * Convert boolean or null string to nullable value.
+     *
+     * @param value the string value of boolean or null
+     */
+    @SuppressWarnings("PMD.UnnecessaryAnnotationValueElement")
+    @ParameterType(value = "true|True|TRUE|false|False|FALSE|null|NULL")
+    public Boolean booleanOrNullValue(String value) {
+        if ("null".equals(value) || "NULL".equals(value)) {
+            return null;
+        }
+
+        return Boolean.valueOf(value);
+    }
+
+    /**
+     * Sets MQTT operations timeout value.
+     *
+     * @param mqttTimeoutSec MQTT operations timeout in seconds
+     */
+    @And("I set MQTT timeout to {int} second(s)")
+    public void setMqttTimeoutSec(int mqttTimeoutSec) {
+        this.mqttTimeoutSec = mqttTimeoutSec;
+        log.info("MQTT timeout set to {} second(s)", mqttTimeoutSec);
+    }
+
+
+    /**
+     * Sets MQTT subscribe 'no local' flag.
+     *
+     * @param subscribeNoLocal the new values of 'no local' flag.
+     */
+    @And("I set MQTT subscribe 'no local' flag to {booleanValue}")
+    public void setSubscribeNoLocal(Boolean subscribeNoLocal) {
+        this.subscribeNoLocal = subscribeNoLocal;
+        log.info("Subscribe 'no local' flag set to {}", subscribeNoLocal);
+    }
+
+    /**
+     * Sets MQTT subscribe 'retain handling' property.
+     *
+     * @param subscribeRetainHandling the new values of 'retain handling' property.
+     */
+    @And("I set MQTT subscribe 'retain handling' property to {string}")
+    public void setSubscribeRetainHandling(String subscribeRetainHandling) {
+        this.subscribeRetainHandling = Mqtt5RetainHandling.valueOf(subscribeRetainHandling);
+        log.info("Subscribe 'retain handling' property set to {}", subscribeRetainHandling);
+    }
+
+    /**
+     * Sets MQTT subscribe 'retain as published' flag.
+     *
+     * @param subscribeRetainAsPublished the new values of 'retain as published' flag.
+     */
+    @And("I set MQTT subscribe 'retain as published' flag to {booleanValue}")
+    public void setSubscribeRetainAsPublished(Boolean subscribeRetainAsPublished) {
+        this.subscribeRetainAsPublished = subscribeRetainAsPublished;
+        log.info("Subscribe 'retain as published' flag set to {}", subscribeRetainAsPublished);
+    }
+
+
+    /**
+     * Sets MQTT publish 'retain' flag.
+     *
+     * @param retain the new value of publish 'retain' flag
+     */
+    @And("I set MQTT publish 'retain' flag to {booleanValue}")
+    public void setTxRetain(Boolean retain) {
+        this.txRetain = retain;
+        log.info("Publish 'retain' flag set to {}", retain);
+    }
+
+    /**
+     * Sets MQTT receive 'retain' flag.
+     *
+     * @param retain the boolean new value of receive 'retain' flag or null
+     */
+    @And("I set the 'retain' flag in expected received messages to {booleanOrNullValue}")
+    public void setRxRetain(Boolean retain) {
+        this.rxRetain = retain;
+        log.info("Expected 'retain' flag in received messages set to {}", retain);
+    }
+
+    /**
+     * Sets MQTT publish 'payload format indicator' flag.
+     *
+     * @param payloadFormatIndicator the new boolean value of publish 'payload format indicator' flag or null to reset
+     */
+    @And("I set MQTT publish 'payload format indicator' flag to {booleanOrNullValue}")
+    public void setTxPayloadFormatIndicator(Boolean payloadFormatIndicator) {
+        this.txPayloadFormatIndicator = payloadFormatIndicator;
+        log.info("Publish 'payload format indicator' flag set to {}", txPayloadFormatIndicator);
+    }
+
+    /**
+     * Sets MQTT receive 'payload format indicator' flag.
+     *
+     * @param payloadFormatIndicator the new boolean value of receive 'payload format indicator' flag or null
+     */
+    @And("I set the 'payload format indicator' flag in expected received messages to {booleanOrNullValue}")
+    public void setRxPayloadFormatIndicator(Boolean payloadFormatIndicator) {
+        this.rxPayloadFormatIndicator = payloadFormatIndicator;
+        log.info("Expected 'payload format indicator' flag in received messages set to {}", payloadFormatIndicator);
+    }
+
+    /**
+     * Sets MQTT 'message expiry interval' value for publishing.
+     *
+     * @param messageExpiryInterval the new value of message expiry interval for publishing
+     */
+    @And("I set MQTT publish 'message expiry interval' to {int}")
+    public void setTxMessageExpiryInterval(Integer messageExpiryInterval) {
+        this.txMessageExpiryInterval = messageExpiryInterval;
+        log.info("Publish 'message expiry interval' set to {}", this.txMessageExpiryInterval);
+    }
+
+    /**
+     * Reset MQTT 'message expiry interval' value for publishing.
+     *
+     */
+    @SuppressWarnings("PMD.NullAssignment")
+    @And("I reset MQTT publish 'message expiry interval'")
+    public void resetTxMessageExpiryInterval() {
+        this.txMessageExpiryInterval = null;
+        log.info("Publish 'message expiry interval' is reset");
+    }
+
+    /**
+     * Sets value of expected MQTT 'message expiry interval' in received messages.
+     *
+     * @param messageExpiryInterval the new expected value of 'message expiry interval' in received messages
+     */
+    @And("I set the 'message expiry interval' in expected received messages to {int}")
+    public void setRxMessageExpiryInterval(Integer messageExpiryInterval) {
+        this.rxMessageExpiryInterval = messageExpiryInterval;
+        log.info("Expected 'message expiry interval' in received messages set to {}", messageExpiryInterval);
+    }
+
+    /**
+     * Reset expected value 'message expiry interval' in received messages.
+     *
+     */
+    @SuppressWarnings("PMD.NullAssignment")
+    @And("I reset expected 'message expiry interval'")
+    public void resetRxMessageExpiryInterval() {
+        this.rxMessageExpiryInterval = null;
+        log.info("Expected 'message expiry interval' is reset");
+    }
+
+    /**
+     * Sets MQTT user Properties to transmit.
+     *
+     * @param key the key of userProperties property.
+     * @param value the value of userProperties property.
+     */
+    @And("I add MQTT 'user property' with key {string} and value {string} to transmit")
+    public void addTxUserProperty(String key, String value) {
+        if (txUserProperties == null) {
+            txUserProperties = new ArrayList<>();
+        }
+        Mqtt5Properties userProperty = Mqtt5Properties.newBuilder()
+                .setKey(key)
+                .setValue(value)
+                .build();
+        txUserProperties.add(userProperty);
+    }
+
+    /**
+     * Clear MQTT user properties to transmit.
+     *
+     */
+    @And("I clear MQTT 'user properties' to transmit")
+    @SuppressWarnings("PMD.NullAssignment")
+    public void clearTxUserProperties() {
+        txUserProperties = null;
+    }
+
+    /**
+     * Sets MQTT user Properties to receive.
+     *
+     * @param key the key of userProperties property.
+     * @param value the value of userProperties property.
+     */
+    @And("I add MQTT 'user property' with key {string} and value {string} to receive")
+    public void addRxUserProperty(String key, String value) {
+        if (rxUserProperties == null) {
+            rxUserProperties = new ArrayList<>();
+        }
+        Mqtt5Properties userProperty = Mqtt5Properties.newBuilder()
+                .setKey(key)
+                .setValue(value)
+                .build();
+        rxUserProperties.add(userProperty);
+    }
+
+    /**
+     * Clear MQTT user properties to receive.
+     *
+     */
+    @And("I clear MQTT 'user properties' to receive")
+    @SuppressWarnings("PMD.NullAssignment")
+    public void clearRxUserProperties() {
+        rxUserProperties = null;
+    }
+
+    /**
+     * Sets MQTT content type to transmit.
+     *
+     * @param contentType MQTT content type to transmit
+     */
+    @And("I set MQTT publish 'content type' to {string}")
+    public void setMqttTxContentType(String contentType) {
+        this.txContentType = contentType;
+        log.info("MQTT content type set to {} to transmit", contentType);
+    }
+
+    /**
+     * Sets MQTT content type to receive.
+     *
+     * @param contentType MQTT content type to receive
+     */
+    @And("I set MQTT 'content type' in expected received messages to {string}")
+    public void setMqttRxContentType(String contentType) {
+        this.rxContentType = contentType;
+        log.info("MQTT content type set to {} to receive", contentType);
+    }
+
+    /**
+     * Reset MQTT content type to transmit.
+     */
+    @And("I reset MQTT publish 'content type'")
+    public void resetMqttTxContentType() {
+        this.txContentType = DEFAULT_CONTENT_TYPE;
+        log.info("MQTT content type reset to transmit");
+    }
+
+    /**
+     * Reset MQTT content type to receive.
+     */
+    @And("I reset MQTT 'content type' in expected received messages")
+    public void resetMqttRxContentType() {
+        this.rxContentType = DEFAULT_CONTENT_TYPE;
+        log.info("MQTT content type reset to receive");
+    }
+
 
     /**
      * Associate client device with a core device .
@@ -372,208 +633,6 @@ public class MqttControlSteps {
         // do disconnect
         connectionControl.closeMqttConnection(reasonCode, txUserProperties);
         log.info("Thing {} was disconnected with reason code {}", clientDeviceId, reasonCode);
-    }
-
-    /**
-     * Convert boolean string to value.
-     *
-     * @param value the string value of boolean
-     */
-    @SuppressWarnings("PMD.UnnecessaryAnnotationValueElement")
-    @ParameterType(value = "true|True|TRUE|false|False|FALSE")
-    public Boolean booleanValue(String value) {
-        return Boolean.valueOf(value);
-    }
-
-    /**
-     * Convert boolean or null string to nullable value.
-     *
-     * @param value the string value of boolean or null
-     */
-    @SuppressWarnings("PMD.UnnecessaryAnnotationValueElement")
-    @ParameterType(value = "true|True|TRUE|false|False|FALSE|null|NULL")
-    public Boolean booleanOrNullValue(String value) {
-        if ("null".equals(value) || "NULL".equals(value)) {
-            return null;
-        }
-
-        return Boolean.valueOf(value);
-    }
-
-    /**
-     * Sets MQTT operations timeout value.
-     *
-     * @param mqttTimeoutSec MQTT operations timeout in seconds
-     */
-    @And("I set MQTT timeout to {int} second(s)")
-    public void setMqttTimeoutSec(int mqttTimeoutSec) {
-        this.mqttTimeoutSec = mqttTimeoutSec;
-        log.info("MQTT timeout set to {} second(s)", mqttTimeoutSec);
-    }
-
-    /**
-     * Sets MQTT content type to transmit.
-     *
-     * @param contentType MQTT content type to transmit
-     */
-    @And("I set MQTT publish 'content type' to {string}")
-    public void setMqttTxContentType(String contentType) {
-        this.txContentType = contentType;
-        log.info("MQTT content type set to {} to transmit", contentType);
-    }
-
-    /**
-     * Sets MQTT content type to receive.
-     *
-     * @param contentType MQTT content type to receive
-     */
-    @And("I set MQTT 'content type' in expected received messages to {string}")
-    public void setMqttRxContentType(String contentType) {
-        this.rxContentType = contentType;
-        log.info("MQTT content type set to {} to receive", contentType);
-    }
-
-    /**
-     * Reset MQTT content type to transmit.
-     */
-    @And("I reset MQTT publish 'content type'")
-    public void resetMqttTxContentType() {
-        this.txContentType = DEFAULT_CONTENT_TYPE;
-        log.info("MQTT content type reset to transmit");
-    }
-
-    /**
-     * Reset MQTT content type to receive.
-     */
-    @And("I reset MQTT 'content type' in expected received messages")
-    public void resetMqttRxContentType() {
-        this.rxContentType = DEFAULT_CONTENT_TYPE;
-        log.info("MQTT content type reset to receive");
-    }
-
-    /**
-     * Sets MQTT subscribe 'no local' flag.
-     *
-     * @param subscribeNoLocal the new values of 'no local' flag.
-     */
-    @And("I set MQTT subscribe 'no local' flag to {booleanValue}")
-    public void setSubscribeNoLocal(Boolean subscribeNoLocal) {
-        this.subscribeNoLocal = subscribeNoLocal;
-        log.info("Subscribe 'no local' flag set to {}", subscribeNoLocal);
-    }
-
-    /**
-     * Sets MQTT subscribe 'retain as published' flag.
-     *
-     * @param subscribeRetainAsPublished the new values of 'retain as published' flag.
-     */
-    @And("I set MQTT subscribe 'retain as published' flag to {booleanValue}")
-    public void setSubscribeRetainAsPublished(Boolean subscribeRetainAsPublished) {
-        this.subscribeRetainAsPublished = subscribeRetainAsPublished;
-        log.info("Subscribe 'retain as published' flag set to {}", subscribeRetainAsPublished);
-    }
-
-
-    /**
-     * Sets MQTT subscribe 'retain handling' property.
-     *
-     * @param subscribeRetainHandling the new values of 'retain handling' property.
-     */
-    @And("I set MQTT subscribe 'retain handling' property to {string}")
-    public void setSubscribeRetainHandling(String subscribeRetainHandling) {
-        this.subscribeRetainHandling = Mqtt5RetainHandling.valueOf(subscribeRetainHandling);
-        log.info("Subscribe 'retain handling' property set to {}", subscribeRetainHandling);
-    }
-
-    /**
-     * Sets MQTT publish 'retain' flag.
-     *
-     * @param retain the new value of publish 'retain' flag
-     */
-    @And("I set MQTT publish 'retain' flag to {booleanValue}")
-    public void setPublishRetain(Boolean retain) {
-        this.txRetain = retain;
-        log.info("Publish 'retain' flag set to {}", retain);
-    }
-
-    /**
-     * Sets MQTT publish 'payload format indicator' flag.
-     *
-     * @param payloadFormatIndicator the new boolean value of publish 'payload format indicator' flag or null to reset
-     */
-    @And("I set MQTT publish 'payload format indicator' flag to {booleanOrNullValue}")
-    public void setTxPayloadFormatIndicator(Boolean payloadFormatIndicator) {
-        this.txPayloadFormatIndicator = payloadFormatIndicator;
-        log.info("Publish 'payload format indicator' flag set to {}", txPayloadFormatIndicator);
-    }
-
-    /**
-     * Sets MQTT 'message expiry interval' value for publishing.
-     *
-     * @param messageExpiryInterval the new value of message expiry interval for publishing
-     */
-    @And("I set MQTT publish 'message expiry interval' to {int}")
-    public void setTxMessageExpiryInterval(Integer messageExpiryInterval) {
-        this.txMessageExpiryInterval = messageExpiryInterval;
-        log.info("Publish 'message expiry interval' set to {}", this.txMessageExpiryInterval);
-    }
-
-    /**
-     * Reset MQTT 'message expiry interval' value for publishing.
-     *
-     */
-    @SuppressWarnings("PMD.NullAssignment")
-    @And("I reset MQTT publish 'message expiry interval'")
-    public void resetTxMessageExpiryInterval() {
-        this.txMessageExpiryInterval = null;
-        log.info("Publish 'message expiry interval' is reset");
-    }
-
-
-    /**
-     * Sets value of expected MQTT 'message expiry interval' in received messages.
-     *
-     * @param messageExpiryInterval the new expected value of 'message expiry interval' in received messages
-     */
-    @And("I set the 'message expiry interval' in expected received messages to {int}")
-    public void setRxMessageExpiryInterval(Integer messageExpiryInterval) {
-        this.rxMessageExpiryInterval = messageExpiryInterval;
-        log.info("Expected 'message expiry interval' in received messages set to {}", messageExpiryInterval);
-    }
-
-    /**
-     * Reset expected value 'message expiry interval' in received messages.
-     *
-     */
-    @SuppressWarnings("PMD.NullAssignment")
-    @And("I reset expected 'message expiry interval'")
-    public void resetRxMessageExpiryInterval() {
-        this.rxMessageExpiryInterval = null;
-        log.info("Expected 'message expiry interval' is reset");
-    }
-
-
-    /**
-     * Sets MQTT receive 'retain' flag.
-     *
-     * @param retain the boolean new value of receive 'retain' flag or null
-     */
-    @And("I set the 'retain' flag in expected received messages to {booleanOrNullValue}")
-    public void setRxRetain(Boolean retain) {
-        this.rxRetain = retain;
-        log.info("Expected 'retain' flag in received messages set to {}", retain);
-    }
-
-
-    /**
-     * Sets MQTT receive 'payload format indicator' flag.
-     *
-     * @param payloadFormatIndicator the new boolean value of receive 'payload format indicator' flag or null
-     */
-    @And("I set the 'payload format indicator' flag in expected received messages to {booleanOrNullValue}")
-    public void setRxPayloadFormatIndicator(Boolean payloadFormatIndicator) {
-        this.rxPayloadFormatIndicator = payloadFormatIndicator;
-        log.info("Expected 'payload format indicator' flag in received messages set to {}", payloadFormatIndicator);
     }
 
     /**
@@ -720,7 +779,7 @@ public class MqttControlSteps {
             throw new RuntimeException("MQTT publish completed with negative reason code " + reasonCode);
         }
 
-        log.info("MQTT message {} has been succesfully published", message);
+        log.info("MQTT message '{}' has been succesfully published", message);
     }
 
     /**
@@ -828,61 +887,33 @@ public class MqttControlSteps {
     }
 
     /**
-     * Sets MQTT user Properties to transmit.
-     *
-     * @param key the key of userProperties property.
-     * @param value the value of userProperties property.
-     */
-    @And("I add MQTT 'user property' with key {string} and value {string} to transmit")
-    public void addTxUserProperty(String key, String value) {
-        if (txUserProperties == null) {
-            txUserProperties = new ArrayList<>();
-        }
-        Mqtt5Properties userProperty = Mqtt5Properties.newBuilder()
-                .setKey(key)
-                .setValue(value)
-                .build();
-        txUserProperties.add(userProperty);
-    }
-
-    /**
-     * Clear MQTT user properties to transmit.
+     * Clear message storage.
      *
      */
-    @And("I clear MQTT 'user properties' to transmit")
-    @SuppressWarnings("PMD.NullAssignment")
-    public void clearTxUserProperties() {
-        txUserProperties = null;
-    }
+    @And("I clear message storage and reset all MQTT settings to default")
+    public void clearAnything() {
+        clearStorage();
+        setMqttTimeoutSec(DEFAULT_MQTT_TIMEOUT_SEC);
 
-    /**
-     * Sets MQTT user Properties to receive.
-     *
-     * @param key the key of userProperties property.
-     * @param value the value of userProperties property.
-     */
-    @And("I add MQTT 'user property' with key {string} and value {string} to receive")
-    public void addRxUserProperty(String key, String value) {
-        if (rxUserProperties == null) {
-            rxUserProperties = new ArrayList<>();
-        }
-        Mqtt5Properties userProperty = Mqtt5Properties.newBuilder()
-                .setKey(key)
-                .setValue(value)
-                .build();
-        rxUserProperties.add(userProperty);
-    }
+        setTxRetain(DEFAULT_PUBLISH_RETAIN);
+        setRxRetain(DEFAULT_RECEIVED_RETAIN);
 
-    /**
-     * Clear MQTT user properties to receive.
-     *
-     */
-    @And("I clear MQTT 'user properties' to receive")
-    @SuppressWarnings("PMD.NullAssignment")
-    public void clearRxUserProperties() {
-        rxUserProperties = null;
-    }
+        setTxPayloadFormatIndicator(DEFAULT_PUBLISH_PAYLOAD_FORMAT_INDICATOR);
+        setRxPayloadFormatIndicator(DEFAULT_RECEIVED_PAYLOAD_FORMAT_INDICATOR);
 
+        setTxMessageExpiryInterval(DEFAULT_MESSAGE_EXPIRY_INTERVAL);
+        setRxMessageExpiryInterval(DEFAULT_MESSAGE_EXPIRY_INTERVAL);
+
+        clearTxUserProperties();
+        clearRxUserProperties();
+
+        setMqttTxContentType(DEFAULT_CONTENT_TYPE);
+        setMqttRxContentType(DEFAULT_CONTENT_TYPE);
+
+        setSubscribeNoLocal(DEFAULT_SUBSCRIBE_NO_LOCAL);
+        setSubscribeRetainHandling(DEFAULT_SUBSCRIBE_RETAIN_HANDLING.name());
+        setSubscribeRetainAsPublished(DEFAULT_SUBSCRIBE_RETAIN_AS_PUBLISHED);
+    }
 
     /**
      * Discover IoT core device broker directly in OTF.

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1513,6 +1513,26 @@ Feature: GGMQ-1
     When I publish from "publisher" to "content_type_not_null_null" with qos 0 and message "Content types not null/null"
     And message "Content types not null/null" received on "subscriber" from "content_type_not_null_null" topic within 5 seconds
 
+    And I clear message storage
+
+    # H. publish/subscribe 'message expiry interval' tests
+
+    # 27. test case when send message expiry interval 100 and receive 100
+    And I set MQTT publish 'message expiry interval' to 100
+    And I set the 'message expiry interval' in expected received messages to 100
+    When I subscribe "subscriber" to "message_expire_interval_100" with qos 0
+    When I publish from "publisher" to "message_expire_interval_100" with qos 0 and message "Message expiry interval was 100"
+    And message "Message expiry interval was 100" received on "subscriber" from "message_expire_interval_100" topic within 5 seconds
+
+    And I clear message storage
+
+    # 28. test case when send message expiry interval 1 and message do not forward by broker
+    And I set MQTT publish 'message expiry interval' to 100
+    And I reset expected 'message expiry interval'
+    When I subscribe "subscriber" to "message_expire_interval_1" with qos 0
+    When I publish from "publisher" to "message_expire_interval_1" with qos 0 and message "Message expiry interval was 1"
+    And message "Message expiry interval was 1" is not received on "subscriber" from "message_expire_interval_1" topic within 10 seconds
+
     @mqtt5 @sdk-java
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  | publish-status-nms |

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1221,7 +1221,7 @@ Feature: GGMQ-1
     And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
     And I connect device "subscriber" on <agent> to "localMqttBroker2" using mqtt "<mqtt-v>"
 
-    # A.B. publish 'retain' and subscribe 'retain control' tests
+    # A.B. PUBLISH 'retain' and SUBSCRIBE 'retain control' tests
 
     # 1. test case when publishing two messages with retain flag set and subscribe retain handling is 'send at subsription'
     #  and only last message is received
@@ -1307,7 +1307,6 @@ Feature: GGMQ-1
     When I subscribe "subscriber" to "t102_case7" with qos 0
     And message "Single not retained message in case7" is not received on "subscriber" from "t102_case7" topic within 5 seconds
 
-
     And I clear message storage
 
     # 8. test case when no retaine messages and subscribed with 'do not send at subscription'
@@ -1318,8 +1317,9 @@ Feature: GGMQ-1
     When I subscribe "subscriber" to "t102_case8" with qos 0
     And message "Single not retained message in case8" is not received on "subscriber" from "t102_case8" topic within 5 seconds
 
-    # C. 'retain as published' tests
-    And I clear message storage
+    And I clear message storage and reset all MQTT settings to default
+
+    # C. SUBSCRIBE 'retain as published' tests
 
     # 9. test case when subscribe 'retain as published' is false.
     #  In that case 'retain' flag on receive should be false regardless 'retain' value on publish.
@@ -1355,7 +1355,10 @@ Feature: GGMQ-1
     When I publish from "publisher" to "iot_data_1" with qos 0 and message "Hello world4"
     And message "Hello world4" received on "subscriber" from "iot_data_1" topic within 5 seconds
 
-    # D. 'user properties' tests
+    And I clear message storage and reset all MQTT settings to default
+
+    # D. PUBLISH 'user properties' tests
+
     # 11. test case when publish 'user properties' are not empty.
     #  In that case 'user properties' on receive should be equal to 'user properties' value on publish.
 
@@ -1367,10 +1370,11 @@ Feature: GGMQ-1
     When I publish from "publisher" to "iot_data_2" with qos 0 and message "Expected userProperties are received"
     And message "Expected userProperties are received" received on "subscriber" from "iot_data_2" topic within 5 seconds
 
+    And I clear message storage
+
     # 12. test case when publish 'user properties' are empty.
     #  In that case 'user properties' on receive should not be equal to 'user properties' value on publish.
 
-    And I clear message storage
     And I clear MQTT 'user properties' to transmit
     And I clear MQTT 'user properties' to receive
     And I add MQTT 'user property' with key "agent-control" and value "control" to receive
@@ -1379,9 +1383,10 @@ Feature: GGMQ-1
     When I publish from "publisher" to "iot_data_2" with qos 0 and message "Expected userProperties are not received"
     And message "Expected userProperties are not received" is not received on "subscriber" from "iot_data_2" topic within 5 seconds
 
+    And I clear message storage
+
     # 13. test case when publish 'user properties' are empty.
     #  In that case 'user properties' on receive should ignore 'user properties' value on publish.
-    And I clear message storage
     And I clear MQTT 'user properties' to transmit
     And I clear MQTT 'user properties' to receive
     And I add MQTT 'user property' with key "agent-control" and value "control" to transmit
@@ -1390,21 +1395,22 @@ Feature: GGMQ-1
     When I publish from "publisher" to "iot_data_3" with qos 0 and message "Ignore userProperties"
     And message "Ignore userProperties" received on "subscriber" from "iot_data_3" topic within 5 seconds
 
+    And I clear message storage
+
     # 14. test case when publish 'user properties' are empty.
     #  In that case 'user properties' on receive should be equal to 'user properties' value on publish.
 
-    And I clear message storage
     And I clear MQTT 'user properties' to transmit
     And I clear MQTT 'user properties' to receive
     When I subscribe "subscriber" to "iot_data_4" with qos 0
     When I publish from "publisher" to "iot_data_4" with qos 0 and message "Without userProperties"
     And message "Without userProperties" received on "subscriber" from "iot_data_4" topic within 5 seconds
 
+    And I clear message storage and reset all MQTT settings to default
+
     # E. 'payload format indicator' tests
-    And I clear message storage
 
     # 15. test case when both tx/rx payload format indicators are set to 0
-    And I clear message storage
     And I set MQTT publish 'payload format indicator' flag to false
     And I set the 'payload format indicator' flag in expected received messages to false
     When I subscribe "subscriber" to "payload_format_indicator_false_false" with qos 0
@@ -1456,9 +1462,10 @@ Feature: GGMQ-1
     When I publish from "publisher" to "payload_format_indicator_false_null" with qos 0 and message "Payload format indicators false/null"
     And message "Payload format indicators false/null" received on "subscriber" from "payload_format_indicator_false_null" topic within 5 seconds
 
-    And I clear message storage
+    And I clear message storage and reset all MQTT settings to default
 
     # F. subscribe 'no local' tests
+
     # 21. test case when subscribe 'no local' set to true
     And I set MQTT subscribe 'no local' flag to true
     When I subscribe "subscriber" to "no_local_test" with qos 0
@@ -1475,7 +1482,7 @@ Feature: GGMQ-1
     When I publish from "subscriber" to "no_local_false" with qos 0 and message "First message no local false test"
     Then message "First message no local false test" received on "subscriber" from "no_local_false" topic within 5 seconds
 
-    And I clear message storage
+    And I clear message storage and reset all MQTT settings to default
 
     # G. publish/subscribe 'content type' tests
 
@@ -1513,24 +1520,38 @@ Feature: GGMQ-1
     When I publish from "publisher" to "content_type_not_null_null" with qos 0 and message "Content types not null/null"
     And message "Content types not null/null" received on "subscriber" from "content_type_not_null_null" topic within 5 seconds
 
+    And I clear message storage and reset all MQTT settings to default
+
+    # H. test 'message expiry interval' feature
+
+    # 27. test case when send message expiry interval 50 and receive 50 without delay
+    And I set MQTT publish 'retain' flag to false
+    And I set MQTT publish 'message expiry interval' to 50
+    And I set the 'message expiry interval' in expected received messages to 50
+    When I subscribe "subscriber" to "message_expire_interval_50" with qos 0
+    When I publish from "publisher" to "message_expire_interval_50" with qos 0 and message "Message expiry interval was 50"
+    And message "Message expiry interval was 50" received on "subscriber" from "message_expire_interval_50" topic within 5 seconds
+
     And I clear message storage
 
-    # H. publish/subscribe 'message expiry interval' tests
-
-    # 27. test case when send message expiry interval 100 and receive 100
+    # 28. test case when send message expiry interval 100 make 5 seconds pause and receive 95
+    And I set MQTT publish 'retain' flag to true
     And I set MQTT publish 'message expiry interval' to 100
-    And I set the 'message expiry interval' in expected received messages to 100
-    When I subscribe "subscriber" to "message_expire_interval_100" with qos 0
+    And I set the 'message expiry interval' in expected received messages to 95
     When I publish from "publisher" to "message_expire_interval_100" with qos 0 and message "Message expiry interval was 100"
+    And I wait 5 seconds
+    When I subscribe "subscriber" to "message_expire_interval_100" with qos 0
     And message "Message expiry interval was 100" received on "subscriber" from "message_expire_interval_100" topic within 5 seconds
 
     And I clear message storage
 
-    # 28. test case when send message expiry interval 1 and message do not forward by broker
-    And I set MQTT publish 'message expiry interval' to 100
+    # 29. test case when send message expiry interval 1 make 5 seconds pause and message do not forward by broker
+    And I set MQTT publish 'retain' flag to true
+    And I set MQTT publish 'message expiry interval' to 1
     And I reset expected 'message expiry interval'
-    When I subscribe "subscriber" to "message_expire_interval_1" with qos 0
     When I publish from "publisher" to "message_expire_interval_1" with qos 0 and message "Message expiry interval was 1"
+    And I wait 5 seconds
+    When I subscribe "subscriber" to "message_expire_interval_1" with qos 0
     And message "Message expiry interval was 1" is not received on "subscriber" from "message_expire_interval_1" topic within 10 seconds
 
     @mqtt5 @sdk-java


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-172
Add test cases to T102 for 'message expiry interval' feature

**Description of changes:**
- Add steps to set and reset 'message expiry interval' in transmitted and expected received message
- Add step to reset event storage and all MQTT v5.0 settings
- Add test cases to test 'message expiry interval' feature of EMQX
- Add messageExpiryInterval to EventFilter and implementation
- Reoder steps code to be in the same order as in MQTT v5.0 spec to avoid mess
- Update uat/README.md to use @SkipOnWindows


**Why is this change necessary:**
These test cases testing 'message expiry interval' MQTT v5.0 feature

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
