### PR TITLE
feat(uat): add responseTopic, correlationData and fix connection port

### DIFF
--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
@@ -176,7 +176,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
      */
     private IMqttAsyncClient createAsyncClient(MqttLib.ConnectionParams connectionParams)
             throws org.eclipse.paho.client.mqttv3.MqttException {
-        String uri = createUri(connectionParams.getHost(), connectionParams.getPort(), connectionParams.getKey());
+        String uri = createUri(connectionParams.getHost(), connectionParams.getPort(), connectionParams.isHasTls());
         return new MqttAsyncClient(uri, connectionParams.getClientId());
     }
 
@@ -188,7 +188,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
             logger.atWarn().log("MQTT v3.1.1 does not support request response information");
         }
 
-        String uri = createUri(connectionParams.getHost(), connectionParams.getPort(), connectionParams.getKey());
+        String uri = createUri(connectionParams.getHost(), connectionParams.getPort(), connectionParams.isHasTls());
         connectionOptions.setServerURIs(new String[]{uri});
 
         if (connectionParams.getKey() != null) {

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
@@ -176,9 +176,8 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
      */
     private IMqttAsyncClient createAsyncClient(MqttLib.ConnectionParams connectionParams)
             throws org.eclipse.paho.client.mqttv3.MqttException {
-        // FIXME: use port
-        // FIMXE: URI depends on optional TLS settings
-        return new MqttAsyncClient(connectionParams.getUri(), connectionParams.getClientId());
+        String uri = createUri(connectionParams.getHost(), connectionParams.getPort(), connectionParams.getKey());
+        return new MqttAsyncClient(uri, connectionParams.getClientId());
     }
 
     private MqttConnectOptions convertParams(MqttLib.ConnectionParams connectionParams)
@@ -188,7 +187,9 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
         if (connectionParams.getRequestResponseInformation() != null) {
             logger.atWarn().log("MQTT v3.1.1 does not support request response information");
         }
-        connectionOptions.setServerURIs(new String[]{connectionParams.getUri()});
+
+        String uri = createUri(connectionParams.getHost(), connectionParams.getPort(), connectionParams.getKey());
+        connectionOptions.setServerURIs(new String[]{uri});
 
         if (connectionParams.getKey() != null) {
             SSLSocketFactory sslSocketFactory = SslUtil.getSocketFactory(connectionParams);

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
@@ -176,7 +176,8 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
      */
     private IMqttAsyncClient createAsyncClient(MqttLib.ConnectionParams connectionParams)
             throws org.eclipse.paho.client.mqttv3.MqttException {
-        String uri = createUri(connectionParams.getHost(), connectionParams.getPort(), connectionParams.isHasTls());
+        String uri = createUri(connectionParams.getHost(), connectionParams.getPort(),
+                connectionParams.getCert() != null);
         return new MqttAsyncClient(uri, connectionParams.getClientId());
     }
 
@@ -188,7 +189,8 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
             logger.atWarn().log("MQTT v3.1.1 does not support request response information");
         }
 
-        String uri = createUri(connectionParams.getHost(), connectionParams.getPort(), connectionParams.isHasTls());
+        String uri = createUri(connectionParams.getHost(), connectionParams.getPort(),
+                connectionParams.getCert() != null);
         connectionOptions.setServerURIs(new String[]{uri});
 
         if (connectionParams.getKey() != null) {

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/GRPCClient.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/GRPCClient.java
@@ -41,6 +41,15 @@ public interface GRPCClient {
 
         /** Optional payload format indicator. */
         private Boolean payloadFormatIndicator;
+
+        /** Optional message expiry interval. */
+        private Long messageExpiryInterval;
+
+        /** Optional response topic. */
+        private String responseTopic;
+
+        /** Optional correlation data. */
+        private byte[] correlationData;
     }
 
 

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/GRPCClient.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/GRPCClient.java
@@ -43,7 +43,7 @@ public interface GRPCClient {
         private Boolean payloadFormatIndicator;
 
         /** Optional message expiry interval. */
-        private Long messageExpiryInterval;
+        private Integer messageExpiryInterval;
 
         /** Optional response topic. */
         private String responseTopic;

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
@@ -184,4 +184,17 @@ public interface MqttConnection {
     MqttSubscribeReply unsubscribe(long timeout, @NonNull List<String> filters,
                                    List<Mqtt5Properties> userProperties);
 
+
+    /**
+     * Create URI.
+     *
+     * @param host connection IP address
+     * @param port connection port
+     * @param key TLS key
+     * @return URI of connection
+     */
+    default String createUri(String host, int port, String key) {
+        return (key != null ? "ssl" : "tcp")
+                + "://" + host + ":" + port;
+    }
 }

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
@@ -112,6 +112,12 @@ public interface MqttConnection {
         /** Payload of message. */
         private byte[] payload;
 
+        /** Optional response topic. */
+        private String responseTopic;
+
+        /** Optional correlation data. */
+        private byte[] correlationData;
+
         /** Optional user properties. */
         private List<Mqtt5Properties>  userProperties;
 

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
@@ -190,11 +190,11 @@ public interface MqttConnection {
      *
      * @param host connection IP address
      * @param port connection port
-     * @param key TLS key
+     * @param hasTls has TLS
      * @return URI of connection
      */
-    default String createUri(String host, int port, String key) {
-        return (key != null ? "ssl" : "tcp")
+    default String createUri(String host, int port, Boolean hasTls) {
+        return (hasTls ? "ssl" : "tcp")
                 + "://" + host + ":" + port;
     }
 }

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
@@ -51,9 +51,6 @@ public interface MqttLib extends AutoCloseable {
         /** The true MQTT v5.0 connection is requested. */
         private boolean mqtt50;
 
-        /** The connection has TLS. */
-        private boolean hasTls;
-
         /** Connection timeout in seconds. */
         private int connectionTimeout;
 

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
@@ -27,8 +27,11 @@ public interface MqttLib extends AutoCloseable {
         /** MQTT client id. */
         private String clientId;
 
-        /** URI of protocol, IP address, port of MQTT broker. */
-        private String uri;
+        /** Host name of IP address of MQTT broker. */
+        private String host;
+
+        /** Port of MQTT broker. */
+        private int port;
 
         /** Connection keep alive interval in seconds. */
         private int keepalive;

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
@@ -27,11 +27,8 @@ public interface MqttLib extends AutoCloseable {
         /** MQTT client id. */
         private String clientId;
 
-        /** Host name of IP address of MQTT broker. */
-        private String host;
-
-        /** Port of MQTT broker. */
-        private int port;                               // FIXME: WHY IS NOT USED ?
+        /** URI of protocol, IP address, port of MQTT broker. */
+        private String uri;
 
         /** Connection keep alive interval in seconds. */
         private int keepalive;
@@ -56,6 +53,9 @@ public interface MqttLib extends AutoCloseable {
 
         /** User properties. */
         private List<Mqtt5Properties> userProperties;
+
+        /** Optional request response information. */
+        private Boolean requestResponseInformation;
     }
 
     /**

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
@@ -51,6 +51,9 @@ public interface MqttLib extends AutoCloseable {
         /** The true MQTT v5.0 connection is requested. */
         private boolean mqtt50;
 
+        /** The connection has TLS. */
+        private boolean hasTls;
+
         /** Connection timeout in seconds. */
         private int connectionTimeout;
 

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
@@ -168,7 +168,8 @@ class GRPCControlServer {
             MqttLib.ConnectionParams.ConnectionParamsBuilder connectionParamsBuilder
                     = MqttLib.ConnectionParams.builder()
                     .clientId(clientId)
-                    .uri(createUri(host, port, request.hasTls()))
+                    .host(host)
+                    .port(port)
                     .keepalive(keepalive)
                     .cleanSession(request.getCleanSession())
                     .mqtt50(version == MqttProtoVersion.MQTT_PROTOCOL_V_50)
@@ -702,15 +703,5 @@ class GRPCControlServer {
             return false;
         }
         return true;
-    }
-
-    private String createUri(String host, int port, Boolean hasTls) {
-        String protocol = hasTls ? "ssl" : "tcp";
-
-        return protocol
-                .concat("://")
-                .concat(host)
-                .concat(":")
-                .concat(String.valueOf(port));
     }
 }

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
@@ -183,6 +183,7 @@ class GRPCControlServer {
                 connectionParamsBuilder.requestResponseInformation(request.getRequestResponseInformation());
             }
 
+            connectionParamsBuilder.hasTls(request.hasTls());
             // check TLS optional settings
             if (request.hasTls()) {
                 TLSSettings tls = request.getTls();

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
@@ -183,7 +183,6 @@ class GRPCControlServer {
                 connectionParamsBuilder.requestResponseInformation(request.getRequestResponseInformation());
             }
 
-            connectionParamsBuilder.hasTls(request.hasTls());
             // check TLS optional settings
             if (request.hasTls()) {
                 TLSSettings tls = request.getTls();

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCDiscoveryClient.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCDiscoveryClient.java
@@ -121,6 +121,21 @@ class GRPCDiscoveryClient implements GRPCClient {
                                         .setPayload(ByteString.copyFrom(message.getPayload()))
                                         .setQos(MqttQoS.forNumber(message.getQos()))
                                         .setRetain(message.isRetain());
+        final Boolean payloadFormatIndicator = message.getPayloadFormatIndicator();
+        if (payloadFormatIndicator != null) {
+            msgBuilder.setPayloadFormatIndicator(payloadFormatIndicator);
+        }
+
+        final String responseTopic = message.getResponseTopic();
+        if (responseTopic != null) {
+            msgBuilder.setResponseTopic(responseTopic);
+        }
+
+        final byte[] correlationData = message.getCorrelationData();
+        if (correlationData != null) {
+            msgBuilder.setCorrelationData(ByteString.copyFrom(correlationData));
+        }
+
         if (message.getUserProperties() != null) {
             msgBuilder.addAllProperties(message.getUserProperties());
         }
@@ -128,11 +143,6 @@ class GRPCDiscoveryClient implements GRPCClient {
         final String contentType = message.getContentType();
         if (contentType != null) {
             msgBuilder.setContentType(contentType);
-        }
-
-        final Boolean payloadFormatIndicator = message.getPayloadFormatIndicator();
-        if (payloadFormatIndicator != null) {
-            msgBuilder.setPayloadFormatIndicator(payloadFormatIndicator);
         }
 
         OnReceiveMessageRequest request = OnReceiveMessageRequest.newBuilder()

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
@@ -253,7 +253,8 @@ public class MqttConnectionImpl implements MqttConnection {
      */
     private IMqttAsyncClient createAsyncClient(MqttLib.ConnectionParams connectionParams)
             throws org.eclipse.paho.mqttv5.common.MqttException {
-        String uri = createUri(connectionParams.getHost(), connectionParams.getPort(), connectionParams.isHasTls());
+        String uri = createUri(connectionParams.getHost(), connectionParams.getPort(),
+                connectionParams.getCert() != null);
         return new MqttAsyncClient(uri, connectionParams.getClientId());
     }
 
@@ -278,7 +279,8 @@ public class MqttConnectionImpl implements MqttConnection {
 
         MqttConnectionOptions connectionOptions = new MqttConnectionOptions();
 
-        String uri = createUri(connectionParams.getHost(), connectionParams.getPort(), connectionParams.isHasTls());
+        String uri = createUri(connectionParams.getHost(), connectionParams.getPort(),
+                connectionParams.getCert() != null);
 
         connectionOptions.setServerURIs(new String[]{uri});
         connectionOptions.setConnectionTimeout(connectionParams.getConnectionTimeout());

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
@@ -253,9 +253,7 @@ public class MqttConnectionImpl implements MqttConnection {
      */
     private IMqttAsyncClient createAsyncClient(MqttLib.ConnectionParams connectionParams)
             throws org.eclipse.paho.mqttv5.common.MqttException {
-        // FIXME: use port
-        // FIXME: provide URI with different schema depends on credentials specified.
-        return new MqttAsyncClient(connectionParams.getHost(), connectionParams.getClientId());
+        return new MqttAsyncClient(connectionParams.getUri(), connectionParams.getClientId());
     }
 
     private void disconnectAndClose(long timeout, int reasonCode, List<Mqtt5Properties> userProperties)
@@ -278,13 +276,14 @@ public class MqttConnectionImpl implements MqttConnection {
 
 
         MqttConnectionOptions connectionOptions = new MqttConnectionOptions();
-        // FIXME: use port
-        connectionOptions.setServerURIs(new String[]{connectionParams.getHost()});
+        connectionOptions.setServerURIs(new String[]{connectionParams.getUri()});
         connectionOptions.setConnectionTimeout(connectionParams.getConnectionTimeout());
 
-        // FIXME: ca/cert/key are optional !
-        SSLSocketFactory sslSocketFactory = SslUtil.getSocketFactory(connectionParams);
-        connectionOptions.setSocketFactory(sslSocketFactory);
+        if (connectionParams.getKey() != null) {
+            SSLSocketFactory sslSocketFactory = SslUtil.getSocketFactory(connectionParams);
+            connectionOptions.setSocketFactory(sslSocketFactory);
+        }
+
         connectionOptions.setKeepAliveInterval(connectionParams.getKeepalive());
         connectionOptions.setCleanStart(connectionParams.isCleanSession());
         connectionOptions.setAutomaticReconnect(false);
@@ -296,13 +295,42 @@ public class MqttConnectionImpl implements MqttConnection {
                     .log("CONNECT Tx user property '{}':'{}'", p.getKey(), p.getValue()));
         }
 
+        final Boolean requestResponseInformation = connectionParams.getRequestResponseInformation();
+        if (requestResponseInformation != null) {
+            connectionOptions.setRequestResponseInfo(requestResponseInformation);
+            logger.atInfo().log("CONNECT Tx request response information: {}", requestResponseInformation);
+        }
+
         return connectionOptions;
     }
 
     private MqttProperties createPublishProperties(Message message) {
         MqttProperties properties = new MqttProperties();
 
-        // TODO: order these properties in the same order as in 3.3.2.3 PUBLISH Properties of MQTT v5.0 spec
+        final Boolean payloadFormatIndicator = message.getPayloadFormatIndicator();
+        if (payloadFormatIndicator != null) {
+            properties.setPayloadFormat(payloadFormatIndicator);
+            logger.atInfo().log("PUBLISH Tx payload format indicator '{}'", payloadFormatIndicator);
+        }
+
+        final Integer messageExpiryInterval = message.getMessageExpiryInterval();
+        if (messageExpiryInterval != null) {
+            properties.setMessageExpiryInterval(Long.valueOf(messageExpiryInterval));
+            logger.atInfo().log("PUBLISH Tx expiry message interval '{}'", messageExpiryInterval);
+        }
+
+        final String responseTopic = message.getResponseTopic();
+        if (responseTopic != null) {
+            properties.setResponseTopic(responseTopic);
+            logger.atInfo().log("PUBLISH Tx response topic: {}", responseTopic);
+        }
+
+        final byte[] correlationData = message.getCorrelationData();
+        if (correlationData != null) {
+            properties.setCorrelationData(correlationData);
+            logger.atInfo().log("PUBLISH Tx correlation data: {}", correlationData);
+        }
+
         if (message.getUserProperties() != null && !message.getUserProperties().isEmpty()) {
             List<UserProperty> userProperties = convertToUserProperties(message.getUserProperties());
             properties.setUserProperties(userProperties);
@@ -310,22 +338,10 @@ public class MqttConnectionImpl implements MqttConnection {
                     .log("PUBLISH Tx user property '{}':'{}'", p.getKey(), p.getValue()));
         }
 
-        String contentType = message.getContentType();
+        final String contentType = message.getContentType();
         if (contentType != null && !contentType.isEmpty()) {
             properties.setContentType(contentType);
             logger.atInfo().log("PUBLISH Tx payload content type '{}'", contentType);
-        }
-
-        Boolean payloadFormatIndicator = message.getPayloadFormatIndicator();
-        if (payloadFormatIndicator != null) {
-            properties.setPayloadFormat(payloadFormatIndicator);
-            logger.atInfo().log("PUBLISH Tx payload format indicator '{}'", payloadFormatIndicator);
-        }
-
-        Integer messageExpiryInterval = message.getMessageExpiryInterval();
-        if (messageExpiryInterval != null) {
-            properties.setMessageExpiryInterval(Long.valueOf(messageExpiryInterval));
-            logger.atInfo().log("PUBLISH Tx expiry message interval '{}'", messageExpiryInterval);
         }
 
         return properties;
@@ -358,6 +374,11 @@ public class MqttConnectionImpl implements MqttConnection {
         List<Mqtt5Properties> ackUserProperties =
                 getAckUserProperties(token.getResponseProperties().getUserProperties(), "ConAck");
 
+        String responseInformation = token.getResponseProperties().getResponseInfo();
+        if (responseInformation != null) {
+            logger.atInfo().log("CONNACK Rx response information: '{}'", responseInformation);
+        }
+
         return new ConnAckInfo(token.getSessionPresent(),
                 reasonCode,
                 sessionExpiryInterval,
@@ -371,7 +392,7 @@ public class MqttConnectionImpl implements MqttConnection {
                 subscriptionIdentifiersAvailable,
                 sharedSubscriptionAvailable,
                 token.getResponseProperties().getServerKeepAlive(),
-                token.getResponseProperties().getResponseInfo(),
+                responseInformation,
                 token.getResponseProperties().getServerReference(),
                 ackUserProperties
         );
@@ -392,10 +413,14 @@ public class MqttConnectionImpl implements MqttConnection {
             String contentType = null;
             Boolean payloadFormatIndicator = null;
             Long messageExpiryInterval = null;
+            String responseTopic = null;
+            byte[] correlationData = null;
             if (receivedProperties != null) {
                 contentType = receivedProperties.getContentType();
                 payloadFormatIndicator = receivedProperties.getPayloadFormat();
                 messageExpiryInterval = receivedProperties.getMessageExpiryInterval();
+                responseTopic = receivedProperties.getResponseTopic();
+                correlationData = receivedProperties.getCorrelationData();
             }
 
             List<Mqtt5Properties> userProps = convertToMqtt5Properties(receivedProperties);
@@ -405,7 +430,8 @@ public class MqttConnectionImpl implements MqttConnection {
             } else {
                 GRPCClient.MqttReceivedMessage message = new GRPCClient.MqttReceivedMessage(
                         mqttMessage.getQos(), mqttMessage.isRetained(), topic,
-                        mqttMessage.getPayload(), userProps, contentType, payloadFormatIndicator);
+                        mqttMessage.getPayload(), userProps, contentType, payloadFormatIndicator, messageExpiryInterval,
+                        responseTopic, correlationData);
                 executorService.submit(() -> {
                     grpcClient.onReceiveMqttMessage(connectionId, message);
                     logger.atInfo().log("Received MQTT message: connectionId {} topic {} QoS {} retain {}",
@@ -425,6 +451,12 @@ public class MqttConnectionImpl implements MqttConnection {
             }
             if (messageExpiryInterval != null) {
                 logger.atInfo().log("Received MQTT message has message expiry interval {}", messageExpiryInterval);
+            }
+            if (responseTopic != null) {
+                logger.atInfo().log("Received MQTT message has response topic: {}", responseTopic);
+            }
+            if (correlationData != null) {
+                logger.atInfo().log("Received MQTT message has correlation data: {}", correlationData);
             }
         }
     }

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
@@ -253,7 +253,7 @@ public class MqttConnectionImpl implements MqttConnection {
      */
     private IMqttAsyncClient createAsyncClient(MqttLib.ConnectionParams connectionParams)
             throws org.eclipse.paho.mqttv5.common.MqttException {
-        String uri = createUri(connectionParams.getHost(), connectionParams.getPort(), connectionParams.getKey());
+        String uri = createUri(connectionParams.getHost(), connectionParams.getPort(), connectionParams.isHasTls());
         return new MqttAsyncClient(uri, connectionParams.getClientId());
     }
 
@@ -278,7 +278,7 @@ public class MqttConnectionImpl implements MqttConnection {
 
         MqttConnectionOptions connectionOptions = new MqttConnectionOptions();
 
-        String uri = createUri(connectionParams.getHost(), connectionParams.getPort(), connectionParams.getKey());
+        String uri = createUri(connectionParams.getHost(), connectionParams.getPort(), connectionParams.isHasTls());
 
         connectionOptions.setServerURIs(new String[]{uri});
         connectionOptions.setConnectionTimeout(connectionParams.getConnectionTimeout());


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-134
https://klika-tech.atlassian.net/browse/GGMQ-263
add responseTopic, correlationData and fix connection port for Java-Paho-client

**Description of changes:**
- add responseTopic and correlationData for Java-Paho-client
- fix setting connection port and schema for Java-Paho-client

**Why is this change necessary:**
to implement Mqtt 5.0 features

**How was this change tested:**
Scenarios run manually and on CI

**Client's log:**
```
[INFO ] 2023-07-10 18:38:39.707 [main] GRPCLinkImpl - Making gPRC client connection with 127.0.0.1:47619 as best-thing-akezhan...
[INFO ] 2023-07-10 18:38:40.390 [main] GRPCLinkImpl - Client connection with Control is established, local address is 127.0.0.1
[INFO ] 2023-07-10 18:38:40.420 [main] GRPCControlServer - GRPCControlServer created and listed on 127.0.0.1:41799
[INFO ] 2023-07-10 18:38:40.486 [main] GRPCLinkImpl - Handle gRPC requests
[INFO ] 2023-07-10 18:38:40.486 [main] GRPCControlServer - Server awaitTermination
[INFO ] 2023-07-10 18:38:43.551 [grpc-default-executor-0] GRPCControlServer - createMqttConnection: clientId best-thing-akezhan broker a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[INFO ] 2023-07-10 18:38:43.747 [grpc-default-executor-0] MqttConnectionImpl - CONNECT Tx user property 'region':'US'
[INFO ] 2023-07-10 18:38:43.747 [grpc-default-executor-0] MqttConnectionImpl - CONNECT Tx user property 'type':'JSON'
[INFO ] 2023-07-10 18:38:43.747 [grpc-default-executor-0] MqttConnectionImpl - CONNECT Tx request response information: true
[INFO ] 2023-07-10 18:38:50.124 [grpc-default-executor-0] GRPCControlServer - Subscription: filter test/topic QoS 0 noLocal false retainAsPublished false retainHandling 2
[INFO ] 2023-07-10 18:38:50.124 [grpc-default-executor-0] GRPCControlServer - Subscribe: connectionId 1 for 1 filters
[INFO ] 2023-07-10 18:38:50.125 [grpc-default-executor-0] MqttConnectionImpl - Subscribe MQTT userProperties: region, US
[INFO ] 2023-07-10 18:38:50.125 [grpc-default-executor-0] MqttConnectionImpl - Subscribe MQTT userProperties: type, JSON
[INFO ] 2023-07-10 18:38:50.272 [grpc-default-executor-0] GRPCControlServer - Subscribe response: connectionId 1 reason codes [0] reason string 
[INFO ] 2023-07-10 18:39:00.299 [grpc-default-executor-0] GRPCControlServer - Publish: connectionId 1 topic test/topic QoS 1 retain false
[INFO ] 2023-07-10 18:39:00.299 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx payload format indicator 'true'
[INFO ] 2023-07-10 18:39:00.299 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx expiry message interval '3600'
[INFO ] 2023-07-10 18:39:00.299 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx response topic: /thing1/response/topic
[INFO ] 2023-07-10 18:39:00.299 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx correlation data: [99, 111, 114, 114, 101, 108, 97, 116, 105, 111, 110, 95, 100, 97, 116, 97]
[INFO ] 2023-07-10 18:39:00.300 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx user property 'region':'US'
[INFO ] 2023-07-10 18:39:00.300 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx user property 'type':'JSON'
[INFO ] 2023-07-10 18:39:00.300 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx payload content type 'text/plain; charset=utf-8'
[INFO ] 2023-07-10 18:39:00.413 [grpc-default-executor-0] GRPCControlServer - Publish response: connectionId 1 reason code 0 reason string 
[INFO ] 2023-07-10 18:39:00.421 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT userProperties: region, US
[INFO ] 2023-07-10 18:39:00.422 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT userProperties: type, JSON
[INFO ] 2023-07-10 18:39:00.422 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT message has content type 'text/plain; charset=utf-8'
[INFO ] 2023-07-10 18:39:00.422 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT message has payload format indicator 'true'
[INFO ] 2023-07-10 18:39:00.422 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT message has message expiry interval 3599
[INFO ] 2023-07-10 18:39:00.422 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT message has response topic: /thing1/response/topic
[INFO ] 2023-07-10 18:39:00.422 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT message has correlation data: [99, 111, 114, 114, 101, 108, 97, 116, 105, 111, 110, 95, 100, 97, 116, 97]
[INFO ] 2023-07-10 18:39:00.439 [pool-3-thread-1] MqttConnectionImpl - Received MQTT message: connectionId 1 topic test/topic QoS 0 retain false
[INFO ] 2023-07-10 18:39:05.426 [grpc-default-executor-0] GRPCControlServer - Unsubscribe: connectionId 1 for [test/topic] filters
[INFO ] 2023-07-10 18:39:05.427 [grpc-default-executor-0] MqttConnectionImpl - Unsubscribe MQTT userProperties: region, US
[INFO ] 2023-07-10 18:39:05.427 [grpc-default-executor-0] MqttConnectionImpl - Unsubscribe MQTT userProperties: type, JSON
[INFO ] 2023-07-10 18:39:05.642 [grpc-default-executor-0] GRPCControlServer - Unsubscribe response: connectionId 1 reason codes [0] reason string 
[INFO ] 2023-07-10 18:39:15.658 [grpc-default-executor-0] GRPCControlServer - closeMqttConnection: connectionId 1 reason 4
[INFO ] 2023-07-10 18:39:15.659 [grpc-default-executor-0] MqttConnectionImpl - Disconnect MQTT userProperties: region, US
[INFO ] 2023-07-10 18:39:15.659 [grpc-default-executor-0] MqttConnectionImpl - Disconnect MQTT userProperties: type, JSON
[INFO ] 2023-07-10 18:39:15.790 [grpc-default-executor-0] GRPCControlServer - shutdownAgent: reason That's it.
[INFO ] 2023-07-10 18:39:15.804 [main] GRPCControlServer - Server awaitTermination done
[INFO ] 2023-07-10 18:39:15.804 [main] GRPCLinkImpl - Shutdown gPRC link
[INFO ] 2023-07-10 18:39:15.817 [main] Main - Execution done successfully
```

**Control's log:**
```
[INFO ] 2023-07-10 18:38:31.990 [com.aws.greengrass.testing.mqtt.client.control.ExampleControl.main()] ExampleControl - Control: port 47619, with TLS, MQTT v5
[INFO ] 2023-07-10 18:38:32.105 [com.aws.greengrass.testing.mqtt.client.control.ExampleControl.main()] EngineControlImpl - MQTT client control gRPC server started, listening on 47619
[INFO ] 2023-07-10 18:38:40.345 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId best-thing-akezhan
[INFO ] 2023-07-10 18:38:40.425 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId best-thing-akezhan address 127.0.0.1 port 41799
[INFO ] 2023-07-10 18:38:40.427 [grpc-default-executor-0] EngineControlImpl - Created new agent control for best-thing-akezhan on 127.0.0.1:41799
[INFO ] 2023-07-10 18:38:40.450 [grpc-default-executor-0] ExampleControl - Agent best-thing-akezhan is connected
[INFO ] 2023-07-10 18:38:40.454 [pool-2-thread-1] AgentTestScenario - Playing test scenario for agent id best-thing-akezhan
[INFO ] 2023-07-10 18:38:43.463 [pool-2-thread-1] AgentTestScenario - Set CONNECT user property: region, US
[INFO ] 2023-07-10 18:38:43.463 [pool-2-thread-1] AgentTestScenario - Set CONNECT user property: type, JSON
[INFO ] 2023-07-10 18:38:43.464 [pool-2-thread-1] AgentTestScenario - Set CONNECT request response information true
[INFO ] 2023-07-10 18:38:45.105 [pool-2-thread-1] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
receiveMaximum: 100
maximumQoS: 1
retainAvailable: true
maximumPacketSize: 149504
serverKeepAlive: 60
'
[INFO ] 2023-07-10 18:38:45.105 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-07-10 18:38:45.105 [pool-2-thread-1] AgentTestScenario - MQTT connection with id 1 is established
[INFO ] 2023-07-10 18:38:50.110 [pool-2-thread-1] AgentTestScenario - Set SUBSCRIBE user property: region, US
[INFO ] 2023-07-10 18:38:50.110 [pool-2-thread-1] AgentTestScenario - Set SUBSCRIBE user property: type, JSON
[INFO ] 2023-07-10 18:38:50.113 [pool-2-thread-1] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-07-10 18:38:50.278 [pool-2-thread-1] AgentTestScenario - Subscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-07-10 18:39:00.283 [pool-2-thread-1] AgentTestScenario - Set PUBLISH payload format indicator true
[INFO ] 2023-07-10 18:39:00.283 [pool-2-thread-1] AgentTestScenario - Set PUBLISH message expiry interval 3600
[INFO ] 2023-07-10 18:39:00.283 [pool-2-thread-1] AgentTestScenario - Set PUBLISH response topic /thing1/response/topic
[INFO ] 2023-07-10 18:39:00.285 [pool-2-thread-1] AgentTestScenario - Set PUBLISH correlation data <ByteString@338410c size=16 contents="correlation_data">
[INFO ] 2023-07-10 18:39:00.285 [pool-2-thread-1] AgentTestScenario - Set PUBLISH user property: region, US
[INFO ] 2023-07-10 18:39:00.285 [pool-2-thread-1] AgentTestScenario - Set PUBLISH user property: type, JSON
[INFO ] 2023-07-10 18:39:00.285 [pool-2-thread-1] AgentTestScenario - Set PUBLISH content type text/plain; charset=utf-8
[INFO ] 2023-07-10 18:39:00.287 [pool-2-thread-1] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic test/topic
[INFO ] 2023-07-10 18:39:00.419 [pool-2-thread-1] AgentTestScenario - Published connectionId 1 reason code 0 reason string ''
[INFO ] 2023-07-10 18:39:00.432 [grpc-default-executor-0] GRPCDiscoveryServer - OnReceiveMessage: agentId best-thing-akezhan connectionId 1 topic test/topic QoS 0
[INFO ] 2023-07-10 18:39:00.433 [grpc-default-executor-0] AgentTestScenario - Message received on agentId best-thing-akezhan connectionId 1 topic test/topic QoS 0 content <ByteString@77cb79b2 size=12 contents="Hello World!">
[[INFO ] 2023-07-11 18:34:27.307 [grpc-default-executor-3] AgentTestScenario - Message has payload format indicator true
[INFO ] 2023-07-11 18:34:27.307 [grpc-default-executor-3] AgentTestScenario - Message has response topic /thing1/response/topic
[INFO ] 2023-07-11 18:34:27.307 [grpc-default-executor-3] AgentTestScenario - Message has correlation data <ByteString@647f3d9f size=16 contents="correlation_data">
[INFO ] 2023-07-10 18:39:00.433 [grpc-default-executor-0] AgentTestScenario - Message has user property key region value US
[INFO ] 2023-07-10 18:39:00.433 [grpc-default-executor-0] AgentTestScenario - Message has user property key type value JSON
[INFO ] 2023-07-10 18:39:00.434 [grpc-default-executor-0] AgentTestScenario - Message has content type 'text/plain; charset=utf-8'
[INFO ] 2023-07-10 18:39:05.420 [pool-2-thread-1] AgentTestScenario - Set UNSUBSCRIBE user property: region, US
[INFO ] 2023-07-10 18:39:05.420 [pool-2-thread-1] AgentTestScenario - Set UNSUBSCRIBE user property: type, JSON
[INFO ] 2023-07-10 18:39:05.422 [pool-2-thread-1] AgentControlImpl - UnsubscribeMqtt: unsubscribe on connectionId 1
[INFO ] 2023-07-10 18:39:05.644 [pool-2-thread-1] AgentTestScenario - Unsubscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-07-10 18:39:15.645 [pool-2-thread-1] AgentTestScenario - Set DISCONNECT user property: region, US
[INFO ] 2023-07-10 18:39:15.646 [pool-2-thread-1] AgentTestScenario - Set DISCONNECT user property: type, JSON
[INFO ] 2023-07-10 18:39:15.781 [pool-2-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 1 closed
[INFO ] 2023-07-10 18:39:15.795 [pool-2-thread-1] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-07-10 18:39:15.812 [grpc-default-executor-0] GRPCDiscoveryServer - UnregisterAgent: agentId best-thing-akezhan reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-07-10 18:39:15.814 [grpc-default-executor-0] ExampleControl - Agent best-thing-akezhan is disconnected
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

