### PR TITLE
fix(uat): add messageExpiryInterval for GRPCDiscoveryClient

### DIFF
--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCDiscoveryClient.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCDiscoveryClient.java
@@ -126,6 +126,16 @@ class GRPCDiscoveryClient implements GRPCClient {
             msgBuilder.setPayloadFormatIndicator(payloadFormatIndicator);
         }
 
+        final Integer messageExpiryInterval = message.getMessageExpiryInterval();
+        if (messageExpiryInterval != null) {
+            msgBuilder.setMessageExpiryInterval(messageExpiryInterval);
+        }
+
+        final String contentType = message.getContentType();
+        if (contentType != null) {
+            msgBuilder.setContentType(contentType);
+        }
+
         final String responseTopic = message.getResponseTopic();
         if (responseTopic != null) {
             msgBuilder.setResponseTopic(responseTopic);
@@ -138,16 +148,6 @@ class GRPCDiscoveryClient implements GRPCClient {
 
         if (message.getUserProperties() != null) {
             msgBuilder.addAllProperties(message.getUserProperties());
-        }
-
-        final String contentType = message.getContentType();
-        if (contentType != null) {
-            msgBuilder.setContentType(contentType);
-        }
-
-        final Integer messageExpiryInterval = message.getMessageExpiryInterval();
-        if (messageExpiryInterval != null) {
-            msgBuilder.setMessageExpiryInterval(messageExpiryInterval);
         }
 
         OnReceiveMessageRequest request = OnReceiveMessageRequest.newBuilder()

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCDiscoveryClient.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCDiscoveryClient.java
@@ -145,6 +145,11 @@ class GRPCDiscoveryClient implements GRPCClient {
             msgBuilder.setContentType(contentType);
         }
 
+        final Integer messageExpiryInterval = message.getMessageExpiryInterval();
+        if (messageExpiryInterval != null) {
+            msgBuilder.setMessageExpiryInterval(messageExpiryInterval);
+        }
+
         OnReceiveMessageRequest request = OnReceiveMessageRequest.newBuilder()
                         .setAgentId(agentId)
                         .setConnectionId(MqttConnectionId.newBuilder().setConnectionId(connectionId).build())

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
@@ -418,13 +418,15 @@ public class MqttConnectionImpl implements MqttConnection {
 
             String contentType = null;
             Boolean payloadFormatIndicator = null;
-            Long messageExpiryInterval = null;
+            Integer messageExpiryInterval = null;
             String responseTopic = null;
             byte[] correlationData = null;
             if (receivedProperties != null) {
                 contentType = receivedProperties.getContentType();
                 payloadFormatIndicator = receivedProperties.getPayloadFormat();
-                messageExpiryInterval = receivedProperties.getMessageExpiryInterval();
+                if (receivedProperties.getMessageExpiryInterval() != null) {
+                    messageExpiryInterval = receivedProperties.getMessageExpiryInterval().intValue();
+                }
                 responseTopic = receivedProperties.getResponseTopic();
                 correlationData = receivedProperties.getCorrelationData();
             }
@@ -437,7 +439,7 @@ public class MqttConnectionImpl implements MqttConnection {
                 GRPCClient.MqttReceivedMessage message = new GRPCClient.MqttReceivedMessage(
                         mqttMessage.getQos(), mqttMessage.isRetained(), topic,
                         mqttMessage.getPayload(), userProps, contentType, payloadFormatIndicator,
-                        messageExpiryInterval.intValue(), responseTopic, correlationData);
+                        messageExpiryInterval, responseTopic, correlationData);
                 executorService.submit(() -> {
                     grpcClient.onReceiveMqttMessage(connectionId, message);
                     logger.atInfo().log("Received MQTT message: connectionId {} topic {} QoS {} retain {}",


### PR DESCRIPTION
**Issue #, if available:**
add messageExpiryInterval for GRPCDiscoveryClient for Java-Paho-client
https://klika-tech.atlassian.net/browse/GGMQ-135

**Description of changes:**
- add messageExpiryInterval for GRPCDiscoveryClient
- fix bug on receive message for Java-Paho-client

**Why is this change necessary:**
to implement Mqtt 5.0 features

**How was this change tested:**
Scenarios run manually and on CI

**Client's log:**
```
[INFO ] 2023-07-11 21:28:13.604 [main] GRPCLinkImpl - Making gPRC client connection with 127.0.0.1:47619 as best-thing-akezhan...
[INFO ] 2023-07-11 21:28:14.060 [main] GRPCLinkImpl - Client connection with Control is established, local address is 127.0.0.1
[INFO ] 2023-07-11 21:28:14.093 [main] GRPCControlServer - GRPCControlServer created and listed on 127.0.0.1:43557
[INFO ] 2023-07-11 21:28:14.159 [main] GRPCLinkImpl - Handle gRPC requests
[INFO ] 2023-07-11 21:28:14.159 [main] GRPCControlServer - Server awaitTermination
[INFO ] 2023-07-11 21:28:17.238 [grpc-default-executor-0] GRPCControlServer - createMqttConnection: clientId best-thing-akezhan broker a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[INFO ] 2023-07-11 21:28:17.487 [grpc-default-executor-0] MqttConnectionImpl - CONNECT Tx user property 'region':'US'
[INFO ] 2023-07-11 21:28:17.487 [grpc-default-executor-0] MqttConnectionImpl - CONNECT Tx user property 'type':'JSON'
[INFO ] 2023-07-11 21:28:17.487 [grpc-default-executor-0] MqttConnectionImpl - CONNECT Tx request response information: true
[INFO ] 2023-07-11 21:28:23.591 [grpc-default-executor-0] GRPCControlServer - Subscription: filter test/topic QoS 0 noLocal false retainAsPublished false retainHandling 2
[INFO ] 2023-07-11 21:28:23.591 [grpc-default-executor-0] GRPCControlServer - Subscribe: connectionId 1 for 1 filters
[INFO ] 2023-07-11 21:28:23.593 [grpc-default-executor-0] MqttConnectionImpl - Subscribe MQTT userProperties: region, US
[INFO ] 2023-07-11 21:28:23.594 [grpc-default-executor-0] MqttConnectionImpl - Subscribe MQTT userProperties: type, JSON
[INFO ] 2023-07-11 21:28:23.738 [grpc-default-executor-0] GRPCControlServer - Subscribe response: connectionId 1 reason codes [0] reason string 
[INFO ] 2023-07-11 21:28:33.774 [grpc-default-executor-0] GRPCControlServer - Publish: connectionId 1 topic test/topic QoS 1 retain false
[INFO ] 2023-07-11 21:28:33.776 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx payload format indicator 'true'
[INFO ] 2023-07-11 21:28:33.776 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx expiry message interval '3600'
[INFO ] 2023-07-11 21:28:33.776 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx response topic: /thing1/response/topic
[INFO ] 2023-07-11 21:28:33.776 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx correlation data: [99, 111, 114, 114, 101, 108, 97, 116, 105, 111, 110, 95, 100, 97, 116, 97]
[INFO ] 2023-07-11 21:28:33.777 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx user property 'region':'US'
[INFO ] 2023-07-11 21:28:33.777 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx user property 'type':'JSON'
[INFO ] 2023-07-11 21:28:33.777 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx payload content type 'text/plain; charset=utf-8'
[INFO ] 2023-07-11 21:28:33.892 [grpc-default-executor-0] GRPCControlServer - Publish response: connectionId 1 reason code 0 reason string 
[INFO ] 2023-07-11 21:28:33.901 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT userProperties: region, US
[INFO ] 2023-07-11 21:28:33.901 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT userProperties: type, JSON
[INFO ] 2023-07-11 21:28:33.901 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT message has content type 'text/plain; charset=utf-8'
[INFO ] 2023-07-11 21:28:33.902 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT message has payload format indicator 'true'
[INFO ] 2023-07-11 21:28:33.902 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT message has message expiry interval 3599
[INFO ] 2023-07-11 21:28:33.902 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT message has response topic: /thing1/response/topic
[INFO ] 2023-07-11 21:28:33.902 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT message has correlation data: [99, 111, 114, 114, 101, 108, 97, 116, 105, 111, 110, 95, 100, 97, 116, 97]
[INFO ] 2023-07-11 21:28:33.923 [pool-3-thread-1] MqttConnectionImpl - Received MQTT message: connectionId 1 topic test/topic QoS 0 retain false
[INFO ] 2023-07-11 21:28:38.915 [grpc-default-executor-0] GRPCControlServer - Unsubscribe: connectionId 1 for [test/topic] filters
[INFO ] 2023-07-11 21:28:38.916 [grpc-default-executor-0] MqttConnectionImpl - Unsubscribe MQTT userProperties: region, US
[INFO ] 2023-07-11 21:28:38.916 [grpc-default-executor-0] MqttConnectionImpl - Unsubscribe MQTT userProperties: type, JSON
[INFO ] 2023-07-11 21:28:39.035 [grpc-default-executor-0] GRPCControlServer - Unsubscribe response: connectionId 1 reason codes [0] reason string 
[INFO ] 2023-07-11 21:28:49.056 [grpc-default-executor-0] GRPCControlServer - closeMqttConnection: connectionId 1 reason 4
[INFO ] 2023-07-11 21:28:49.057 [grpc-default-executor-0] MqttConnectionImpl - Disconnect MQTT userProperties: region, US
[INFO ] 2023-07-11 21:28:49.057 [grpc-default-executor-0] MqttConnectionImpl - Disconnect MQTT userProperties: type, JSON
[INFO ] 2023-07-11 21:28:49.186 [grpc-default-executor-0] GRPCControlServer - shutdownAgent: reason That's it.
[INFO ] 2023-07-11 21:28:49.199 [main] GRPCControlServer - Server awaitTermination done
[INFO ] 2023-07-11 21:28:49.199 [main] GRPCLinkImpl - Shutdown gPRC link
[INFO ] 2023-07-11 21:28:49.211 [main] Main - Execution done successfully
```

**Control's log:**
```
[INFO ] 2023-07-11 21:28:07.023 [com.aws.greengrass.testing.mqtt.client.control.ExampleControl.main()] ExampleControl - Control: port 47619, with TLS, MQTT v5
[INFO ] 2023-07-11 21:28:07.314 [com.aws.greengrass.testing.mqtt.client.control.ExampleControl.main()] EngineControlImpl - MQTT client control gRPC server started, listening on 47619
[INFO ] 2023-07-11 21:28:14.027 [grpc-default-executor-1] GRPCDiscoveryServer - RegisterAgent: agentId best-thing-akezhan
[INFO ] 2023-07-11 21:28:14.097 [grpc-default-executor-1] GRPCDiscoveryServer - DiscoveryClient: agentId best-thing-akezhan address 127.0.0.1 port 43557
[INFO ] 2023-07-11 21:28:14.100 [grpc-default-executor-1] EngineControlImpl - Created new agent control for best-thing-akezhan on 127.0.0.1:43557
[INFO ] 2023-07-11 21:28:14.122 [grpc-default-executor-1] ExampleControl - Agent best-thing-akezhan is connected
[INFO ] 2023-07-11 21:28:14.127 [pool-2-thread-1] AgentTestScenario - Playing test scenario for agent id best-thing-akezhan
[INFO ] 2023-07-11 21:28:17.146 [pool-2-thread-1] AgentTestScenario - Set CONNECT user property: region, US
[INFO ] 2023-07-11 21:28:17.146 [pool-2-thread-1] AgentTestScenario - Set CONNECT user property: type, JSON
[INFO ] 2023-07-11 21:28:17.147 [pool-2-thread-1] AgentTestScenario - Set CONNECT request response information true
[INFO ] 2023-07-11 21:28:18.564 [pool-2-thread-1] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
receiveMaximum: 100
maximumQoS: 1
retainAvailable: true
maximumPacketSize: 149504
serverKeepAlive: 60
'
[INFO ] 2023-07-11 21:28:18.564 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-07-11 21:28:18.564 [pool-2-thread-1] AgentTestScenario - MQTT connection with id 1 is established
[INFO ] 2023-07-11 21:28:23.573 [pool-2-thread-1] AgentTestScenario - Set SUBSCRIBE user property: region, US
[INFO ] 2023-07-11 21:28:23.573 [pool-2-thread-1] AgentTestScenario - Set SUBSCRIBE user property: type, JSON
[INFO ] 2023-07-11 21:28:23.580 [pool-2-thread-1] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-07-11 21:28:23.745 [pool-2-thread-1] AgentTestScenario - Subscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-07-11 21:28:33.751 [pool-2-thread-1] AgentTestScenario - Set PUBLISH payload format indicator true
[INFO ] 2023-07-11 21:28:33.751 [pool-2-thread-1] AgentTestScenario - Set PUBLISH message expiry interval 3600
[INFO ] 2023-07-11 21:28:33.751 [pool-2-thread-1] AgentTestScenario - Set PUBLISH response topic /thing1/response/topic
[INFO ] 2023-07-11 21:28:33.752 [pool-2-thread-1] AgentTestScenario - Set PUBLISH correlation data <ByteString@121f3916 size=16 contents="correlation_data">
[INFO ] 2023-07-11 21:28:33.752 [pool-2-thread-1] AgentTestScenario - Set PUBLISH user property: region, US
[INFO ] 2023-07-11 21:28:33.752 [pool-2-thread-1] AgentTestScenario - Set PUBLISH user property: type, JSON
[INFO ] 2023-07-11 21:28:33.753 [pool-2-thread-1] AgentTestScenario - Set PUBLISH content type text/plain; charset=utf-8
[INFO ] 2023-07-11 21:28:33.758 [pool-2-thread-1] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic test/topic
[INFO ] 2023-07-11 21:28:33.899 [pool-2-thread-1] AgentTestScenario - Published connectionId 1 reason code 0 reason string ''
[INFO ] 2023-07-11 21:28:33.916 [grpc-default-executor-1] GRPCDiscoveryServer - OnReceiveMessage: agentId best-thing-akezhan connectionId 1 topic test/topic QoS 0
[INFO ] 2023-07-11 21:28:33.917 [grpc-default-executor-1] AgentTestScenario - Message received on agentId best-thing-akezhan connectionId 1 topic test/topic QoS 0 content <ByteString@40fdb551 size=12 contents="Hello World!">
[INFO ] 2023-07-11 21:28:33.917 [grpc-default-executor-1] AgentTestScenario - Message has payload format indicator true
[INFO ] 2023-07-11 21:28:33.917 [grpc-default-executor-1] AgentTestScenario - Message has message expiry interval 3599
[INFO ] 2023-07-11 21:28:33.917 [grpc-default-executor-1] AgentTestScenario - Message has response topic /thing1/response/topic
[INFO ] 2023-07-11 21:28:33.917 [grpc-default-executor-1] AgentTestScenario - Message has correlation data <ByteString@1d39d42a size=16 contents="correlation_data">
[INFO ] 2023-07-11 21:28:33.918 [grpc-default-executor-1] AgentTestScenario - Message has user property key region value US
[INFO ] 2023-07-11 21:28:33.918 [grpc-default-executor-1] AgentTestScenario - Message has user property key type value JSON
[INFO ] 2023-07-11 21:28:33.918 [grpc-default-executor-1] AgentTestScenario - Message has content type 'text/plain; charset=utf-8'
[INFO ] 2023-07-11 21:28:38.900 [pool-2-thread-1] AgentTestScenario - Set UNSUBSCRIBE user property: region, US
[INFO ] 2023-07-11 21:28:38.900 [pool-2-thread-1] AgentTestScenario - Set UNSUBSCRIBE user property: type, JSON
[INFO ] 2023-07-11 21:28:38.908 [pool-2-thread-1] AgentControlImpl - UnsubscribeMqtt: unsubscribe on connectionId 1
[INFO ] 2023-07-11 21:28:39.039 [pool-2-thread-1] AgentTestScenario - Unsubscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-07-11 21:28:49.040 [pool-2-thread-1] AgentTestScenario - Set DISCONNECT user property: region, US
[INFO ] 2023-07-11 21:28:49.040 [pool-2-thread-1] AgentTestScenario - Set DISCONNECT user property: type, JSON
[INFO ] 2023-07-11 21:28:49.179 [pool-2-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 1 closed
[INFO ] 2023-07-11 21:28:49.189 [pool-2-thread-1] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-07-11 21:28:49.206 [grpc-default-executor-1] GRPCDiscoveryServer - UnregisterAgent: agentId best-thing-akezhan reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-07-11 21:28:49.207 [grpc-default-executor-1] ExampleControl - Agent best-thing-akezhan is disconnected

```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

