### PR TITLE
fix(uat): resolve stop agent and channel leak issues

### DIFF
--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt311/client/sdkmqtt/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt311/client/sdkmqtt/Mqtt311ConnectionImpl.java
@@ -385,7 +385,6 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
                 withPingTimeoutMs()
                 withProtocolOperationTimeoutMs()
                 withTimeoutMs()
-                withReconnectTimeoutSecs()
                 withSocketOptions()
                 withUsername()
                 withPassword()

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
@@ -197,12 +197,16 @@ class AgentTestScenario implements Runnable {
                                                         status.getCode(), status.getDescription());
         } finally {
             if (connectionControl != null) {
-                // close MQTT connection
-                List<Mqtt5Properties> userProperties = null;
-                if (mqtt50) {
-                    userProperties = createMqtt5Properties("DISCONNECT");
+                try {
+                    // close MQTT connection
+                    List<Mqtt5Properties> userProperties = null;
+                    if (mqtt50) {
+                        userProperties = createMqtt5Properties("DISCONNECT");
+                    }
+                    connectionControl.closeMqttConnection(DISCONNECT_REASON, userProperties);
+                } catch (StatusRuntimeException ex) {
+                    logger.atWarn().withThrowable(ex).log("Exception during close MQTT connection");
                 }
-                connectionControl.closeMqttConnection(DISCONNECT_REASON, userProperties);
             }
             agentControl.shutdownAgent("That's it.");
         }

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/ExampleControl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/ExampleControl.java
@@ -76,7 +76,7 @@ public class ExampleControl {
             public void run() {
                 // Use stderr here since the logger may have been reset by its JVM shutdown hook.
                 logger.atInfo().log("*** shutting down gRPC server since JVM is shutting down");
-                engineControl.stopEngine();
+                engineControl.stopEngine(true);
                 shutdownExecutorService();
                 logger.atInfo().log("*** server shut down");
             }

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/EngineControl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/EngineControl.java
@@ -100,6 +100,7 @@ public interface EngineControl {
     /**
      * Stops engine instance.
      *
+     * @param shutdownAgents when set control will send shutdown request to active agents
      */
-    void stopEngine();
+    void stopEngine(boolean shutdownAgents);
 }

--- a/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImplTest.java
+++ b/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImplTest.java
@@ -52,7 +52,7 @@ class EngineControlImplTest {
 
     @AfterEach
     void teardown() throws InterruptedException {
-        engineControl.stopEngine();
+        engineControl.stopEngine(true);
         engineControl.awaitTermination();
     }
 
@@ -218,7 +218,7 @@ class EngineControlImplTest {
         engineControl.startEngine(port, engineEvents);
 
         // WHEN
-        engineControl.stopEngine();
+        engineControl.stopEngine(true);
 
         // THEN
         assertFalse(engineControl.isEngineRunning());

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -1421,7 +1421,7 @@ public class MqttControlSteps {
             engineControl.stopEngine(false);
             engineControl.awaitTermination();
         } catch (StatusRuntimeException ex) {
-            log.warn("Exception during stop clients control", ex);
+            log.warn("Exception during stopping control engine", ex);
         }
     }
 

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -1418,10 +1418,10 @@ public class MqttControlSteps {
     @After
     public void stopMqttControlEngine() throws InterruptedException {
         try {
-            engineControl.stopEngine();
+            engineControl.stopEngine(false);
             engineControl.awaitTermination();
-        } catch (StatusRuntimeException e) {
-            log.warn(e);
+        } catch (StatusRuntimeException ex) {
+            log.warn("Exception during stop clients control", ex);
         }
     }
 

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1610,7 +1610,7 @@ Feature: GGMQ-1
 
     # 35. test case when publish message with correlation data but without expected correlation data
     And I set MQTT publish 'correlation data' to "correlation_data_2"
-    And "I reset expected 'correlation data'"
+    And I reset expected 'correlation data'
 
     When I subscribe "subscriber" to "correlation_data_test_case_2" with qos 0
     When I publish from "publisher" to "correlation_data_test_case_2" with qos 0 and message "Message with correlation data 2"


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-255
Test scenarios finish with warning "MqttControlSteps - io.grpc.StatusRuntimeException: UNAVAILABLE: io exception"

https://klika-tech.atlassian.net/browse/GGMQ-249
gRPC channels are leaked in control

**Description of changes:**
- Make sending  shutdown and close MQTT connections optional
- Resolve issue when send requests to dead agent and closing resources is bypassed
- Resolve channel leak issue when agent is restarted
- Fix mistype in T102
- Add logging about closing resources


**Why is this change necessary:**
Should fix issues related to closing control's resources

**How was this change tested:**
Automatically on CodeBuild
Manually on dev host

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
