### PR TITLE
fix(uat): add callback for disconnect

### DIFF
--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
@@ -228,7 +228,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
 
         @Override
         public void messageArrived(String topic, MqttMessage mqttMessage) {
-            Mqtt311ConnectionImpl.this.messageArrived(topic, mqttMessage);
+            processMessage(topic, mqttMessage);
         }
     }
 
@@ -293,7 +293,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
 
         @Override
         public void messageArrived(String topic, MqttMessage mqttMessage) {
-            Mqtt311ConnectionImpl.this.messageArrived(topic, mqttMessage);
+            processMessage(topic, mqttMessage);
         }
 
         @Override
@@ -303,7 +303,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
     }
 
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
-    private void messageArrived(String topic, MqttMessage mqttMessage) {
+    private void processMessage(String topic, MqttMessage mqttMessage) {
         if (isClosing.get()) {
             logger.atWarn().log("PIBLISH event ignored due to shutdown initiated");
         } else {

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
@@ -21,6 +21,7 @@ import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
 import org.eclipse.paho.client.mqttv3.IMqttMessageListener;
 import org.eclipse.paho.client.mqttv3.IMqttToken;
 import org.eclipse.paho.client.mqttv3.MqttAsyncClient;
+import org.eclipse.paho.client.mqttv3.MqttCallback;
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
 
@@ -70,8 +71,11 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
         this.connectionId = connectionId;
         try {
             MqttConnectOptions connectOptions = convertParams(connectionParams);
+
             IMqttToken token = mqttClient.connect(connectOptions);
+            mqttClient.setCallback(new MqttCallbackImpl());
             token.waitForCompletion(TimeUnit.SECONDS.toMillis(connectionParams.getConnectionTimeout()));
+
             logger.atInfo().log("MQTT 3.1.1 connection {} is establisted", connectionId);
             return buildConnectResult(true, token.isComplete());
         } catch (org.eclipse.paho.client.mqttv3.MqttException e) {
@@ -222,26 +226,9 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
 
     private class MqttMessageListener implements IMqttMessageListener {
 
-        @SuppressWarnings("PMD.AvoidCatchingGenericException")
         @Override
-        public void messageArrived(String topic, MqttMessage mqttMessage) throws Exception {
-            if (isClosing.get()) {
-                logger.atWarn().log("PIBLISH event ignored due to shutdown initiated");
-            } else {
-                GRPCClient.MqttReceivedMessage message = new GRPCClient.MqttReceivedMessage(
-                        mqttMessage.getQos(), mqttMessage.isRetained(), topic, mqttMessage.getPayload(),
-                        null, null, null,null, null, null);
-                executorService.submit(() -> {
-                    try {
-                        grpcClient.onReceiveMqttMessage(connectionId, message);
-                    } catch (Exception ex) {
-                        logger.atError().withThrowable(ex).log("onReceiveMqttMessage failed");
-                    }
-                });
-
-                logger.atInfo().log("Received MQTT message: connectionId {} topic '{}' QoS {} retain {}",
-                                        connectionId, topic, mqttMessage.getQos(), mqttMessage.isRetained());
-            }
+        public void messageArrived(String topic, MqttMessage mqttMessage) {
+            Mqtt311ConnectionImpl.this.messageArrived(topic, mqttMessage);
         }
     }
 
@@ -278,6 +265,61 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
     private void checkCorrelationData(byte[] correlationData) {
         if (correlationData != null) {
             logger.atWarn().log("MQTT v3.1.1 doesn't support correlation data");
+        }
+    }
+
+    class MqttCallbackImpl implements MqttCallback {
+
+        @SuppressWarnings("PMD.AvoidCatchingGenericException")
+        @Override
+        public void connectionLost(Throwable throwable) {
+            // only unsolicited disconnect
+            if (isClosing.get()) {
+                logger.atWarn().log("DISCONNECT event ignored due to shutdown initiated");
+            } else {
+                GRPCClient.DisconnectInfo disconnectInfo = new GRPCClient.DisconnectInfo(null, null, null, null, null);
+                executorService.submit(() -> {
+                    try {
+                        grpcClient.onMqttDisconnect(connectionId, disconnectInfo, throwable.getMessage());
+                    } catch (Exception ex) {
+                        logger.atError().withThrowable(ex).log("onMqttDisconnect failed");
+                    }
+                });
+            }
+
+            logger.atInfo().log("MQTT connection {} interrupted, error code {}", connectionId, throwable.getMessage());
+
+        }
+
+        @Override
+        public void messageArrived(String topic, MqttMessage mqttMessage) {
+            Mqtt311ConnectionImpl.this.messageArrived(topic, mqttMessage);
+        }
+
+        @Override
+        public void deliveryComplete(IMqttDeliveryToken token) {
+            logger.atInfo().log("Delivery completion is {}", token.isComplete());
+        }
+    }
+
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    private void messageArrived(String topic, MqttMessage mqttMessage) {
+        if (isClosing.get()) {
+            logger.atWarn().log("PIBLISH event ignored due to shutdown initiated");
+        } else {
+            GRPCClient.MqttReceivedMessage message = new GRPCClient.MqttReceivedMessage(
+                    mqttMessage.getQos(), mqttMessage.isRetained(), topic, mqttMessage.getPayload(),
+                    null, null, null,null, null, null);
+            executorService.submit(() -> {
+                try {
+                    grpcClient.onReceiveMqttMessage(connectionId, message);
+                } catch (Exception ex) {
+                    logger.atError().withThrowable(ex).log("onReceiveMqttMessage failed");
+                }
+            });
+
+            logger.atInfo().log("Received MQTT message: connectionId {} topic '{}' QoS {} retain {}",
+                    connectionId, topic, mqttMessage.getQos(), mqttMessage.isRetained());
         }
     }
 }

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
@@ -305,7 +305,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
     private void processMessage(String topic, MqttMessage mqttMessage) {
         if (isClosing.get()) {
-            logger.atWarn().log("PIBLISH event ignored due to shutdown initiated");
+            logger.atWarn().log("PUBLISH event ignored due to shutdown initiated");
         } else {
             GRPCClient.MqttReceivedMessage message = new GRPCClient.MqttReceivedMessage(
                     mqttMessage.getQos(), mqttMessage.isRetained(), topic, mqttMessage.getPayload(),

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
@@ -20,7 +20,9 @@ import org.eclipse.paho.mqttv5.client.IMqttAsyncClient;
 import org.eclipse.paho.mqttv5.client.IMqttMessageListener;
 import org.eclipse.paho.mqttv5.client.IMqttToken;
 import org.eclipse.paho.mqttv5.client.MqttAsyncClient;
+import org.eclipse.paho.mqttv5.client.MqttCallback;
 import org.eclipse.paho.mqttv5.client.MqttConnectionOptions;
+import org.eclipse.paho.mqttv5.client.MqttDisconnectResponse;
 import org.eclipse.paho.mqttv5.common.MqttMessage;
 import org.eclipse.paho.mqttv5.common.MqttSubscription;
 import org.eclipse.paho.mqttv5.common.packet.MqttProperties;
@@ -75,6 +77,7 @@ public class MqttConnectionImpl implements MqttConnection {
         try {
             MqttConnectionOptions connectionOptions = convertConnectParams(connectionParams);
             IMqttToken token = client.connect(connectionOptions);
+            client.setCallback(new MqttCallbackImpl());
             token.waitForCompletion(TimeUnit.SECONDS.toMillis(connectionParams.getConnectionTimeout()));
             success = true;
             return buildConnectResult(true, token, null);
@@ -417,63 +420,7 @@ public class MqttConnectionImpl implements MqttConnection {
         @SuppressWarnings("PMD.AvoidCatchingGenericException")
         @Override
         public void messageArrived(String topic, MqttMessage mqttMessage) {
-            MqttProperties receivedProperties = mqttMessage.getProperties();
-
-            String contentType = null;
-            Boolean payloadFormatIndicator = null;
-            Integer messageExpiryInterval = null;
-            String responseTopic = null;
-            byte[] correlationData = null;
-            if (receivedProperties != null) {
-                contentType = receivedProperties.getContentType();
-                payloadFormatIndicator = receivedProperties.getPayloadFormat();
-                if (receivedProperties.getMessageExpiryInterval() != null) {
-                    messageExpiryInterval = receivedProperties.getMessageExpiryInterval().intValue();
-                }
-                responseTopic = receivedProperties.getResponseTopic();
-                correlationData = receivedProperties.getCorrelationData();
-            }
-
-            List<Mqtt5Properties> userProps = convertToMqtt5Properties(receivedProperties);
-
-            if (isClosing.get()) {
-                logger.atWarn().log("PIBLISH event ignored due to shutdown initiated");
-            } else {
-                GRPCClient.MqttReceivedMessage message = new GRPCClient.MqttReceivedMessage(
-                        mqttMessage.getQos(), mqttMessage.isRetained(), topic,
-                        mqttMessage.getPayload(), userProps, contentType, payloadFormatIndicator,
-                        messageExpiryInterval, responseTopic, correlationData);
-                executorService.submit(() -> {
-                    try {
-                        grpcClient.onReceiveMqttMessage(connectionId, message);
-                    } catch (Exception ex) {
-                        logger.atError().withThrowable(ex).log("onReceiveMqttMessage failed");
-                    }
-                });
-            }
-
-            logger.atInfo().log("Received MQTT message: connectionId {} topic '{}' QoS {} retain {}",
-                            connectionId, topic, mqttMessage.getQos(), mqttMessage.isRetained());
-
-            if (userProps != null) {
-                userProps.forEach(p -> logger.atInfo()
-                        .log("Received MQTT userProperties: {}, {}", p.getKey(), p.getValue()));
-            }
-            if (contentType != null) {
-                logger.atInfo().log("Received MQTT message has content type '{}'", contentType);
-            }
-            if (payloadFormatIndicator != null) {
-                logger.atInfo().log("Received MQTT message has payload format indicator '{}'", payloadFormatIndicator);
-            }
-            if (messageExpiryInterval != null) {
-                logger.atInfo().log("Received MQTT message has message expiry interval {}", messageExpiryInterval);
-            }
-            if (responseTopic != null) {
-                logger.atInfo().log("Received MQTT message has response topic: {}", responseTopic);
-            }
-            if (correlationData != null) {
-                logger.atInfo().log("Received MQTT message has correlation data: {}", correlationData);
-            }
+            MqttConnectionImpl.this.messageArrived(topic, mqttMessage);
         }
     }
 
@@ -506,5 +453,137 @@ public class MqttConnectionImpl implements MqttConnection {
                     .log("{} MQTT userProperties: {}, {}", commandName, p.getKey(), p.getValue()));
         }
         return userProperties;
+    }
+
+    class MqttCallbackImpl implements MqttCallback {
+
+        @Override
+        @SuppressWarnings("PMD.AvoidCatchingGenericException")
+        public void disconnected(MqttDisconnectResponse mqttDisconnectResponse) {
+            GRPCClient.DisconnectInfo disconnectInfo = convertDisconnectPacket(mqttDisconnectResponse);
+
+            final String errorString = mqttDisconnectResponse.getException() == null
+                    ? null : mqttDisconnectResponse.getException().getMessage();
+
+            // only unsolicited disconnect
+            if (isClosing.get()) {
+                logger.atWarn().log("DISCONNECT event ignored due to shutdown initiated");
+            } else {
+                executorService.submit(() -> {
+                    try {
+                        grpcClient.onMqttDisconnect(connectionId, disconnectInfo, errorString);
+                    } catch (Exception ex) {
+                        logger.atError().withThrowable(ex).log("onMqttDisconnect failed");
+                    }
+                });
+            }
+        }
+
+        @Override
+        public void mqttErrorOccurred(org.eclipse.paho.mqttv5.common.MqttException e) {
+            logger.error("Client error with reason code {} and message '{}'", e.getReasonCode(), e.getMessage());
+        }
+
+        @Override
+        @SuppressWarnings("PMD.AvoidCatchingGenericException")
+        public void messageArrived(String topic, MqttMessage mqttMessage) throws Exception {
+            MqttConnectionImpl.this.messageArrived(topic, mqttMessage);
+        }
+
+        @Override
+        public void deliveryComplete(IMqttToken token) {
+            logger.atInfo().log("Delivery completion is {}", token.isComplete());
+        }
+
+        @Override
+        public void connectComplete(boolean reconnect, String s) {
+            logger.atInfo().log("Connection completed");
+        }
+
+        @Override
+        public void authPacketArrived(int i, MqttProperties mqttProperties) {
+            logger.atInfo().log("Connection completed");
+        }
+
+        private GRPCClient.DisconnectInfo convertDisconnectPacket(MqttDisconnectResponse response) {
+            if (response == null) {
+                return null;
+            }
+
+
+            List<UserProperty> properties = response.getUserProperties();
+            final List<Mqtt5Properties> userProperties = properties == null
+                    ? null : convertToMqtt5Properties(properties);
+
+            final int reasonCode = response.getReturnCode();
+
+            return new GRPCClient.DisconnectInfo(reasonCode,
+                    null,
+                    response.getReasonString(),
+                    response.getServerReference(),
+                    userProperties
+            );
+        }
+    }
+
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    private void messageArrived(String topic, MqttMessage mqttMessage) {
+        MqttProperties receivedProperties = mqttMessage.getProperties();
+
+        String contentType = null;
+        Boolean payloadFormatIndicator = null;
+        Integer messageExpiryInterval = null;
+        String responseTopic = null;
+        byte[] correlationData = null;
+        if (receivedProperties != null) {
+            contentType = receivedProperties.getContentType();
+            payloadFormatIndicator = receivedProperties.getPayloadFormat();
+            if (receivedProperties.getMessageExpiryInterval() != null) {
+                messageExpiryInterval = receivedProperties.getMessageExpiryInterval().intValue();
+            }
+            responseTopic = receivedProperties.getResponseTopic();
+            correlationData = receivedProperties.getCorrelationData();
+        }
+
+        List<Mqtt5Properties> userProps = convertToMqtt5Properties(receivedProperties);
+
+        if (isClosing.get()) {
+            logger.atWarn().log("PIBLISH event ignored due to shutdown initiated");
+        } else {
+            GRPCClient.MqttReceivedMessage message = new GRPCClient.MqttReceivedMessage(
+                    mqttMessage.getQos(), mqttMessage.isRetained(), topic,
+                    mqttMessage.getPayload(), userProps, contentType, payloadFormatIndicator,
+                    messageExpiryInterval, responseTopic, correlationData);
+            executorService.submit(() -> {
+                try {
+                    grpcClient.onReceiveMqttMessage(connectionId, message);
+                } catch (Exception ex) {
+                    logger.atError().withThrowable(ex).log("onReceiveMqttMessage failed");
+                }
+            });
+        }
+
+        logger.atInfo().log("Received MQTT message: connectionId {} topic '{}' QoS {} retain {}",
+                connectionId, topic, mqttMessage.getQos(), mqttMessage.isRetained());
+
+        if (userProps != null) {
+            userProps.forEach(p -> logger.atInfo()
+                    .log("Received MQTT userProperties: {}, {}", p.getKey(), p.getValue()));
+        }
+        if (contentType != null) {
+            logger.atInfo().log("Received MQTT message has content type '{}'", contentType);
+        }
+        if (payloadFormatIndicator != null) {
+            logger.atInfo().log("Received MQTT message has payload format indicator '{}'", payloadFormatIndicator);
+        }
+        if (messageExpiryInterval != null) {
+            logger.atInfo().log("Received MQTT message has message expiry interval {}", messageExpiryInterval);
+        }
+        if (responseTopic != null) {
+            logger.atInfo().log("Received MQTT message has response topic: {}", responseTopic);
+        }
+        if (correlationData != null) {
+            logger.atInfo().log("Received MQTT message has correlation data: {}", correlationData);
+        }
     }
 }

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
@@ -529,7 +529,7 @@ public class MqttConnectionImpl implements MqttConnection {
         List<Mqtt5Properties> userProps = convertToMqtt5Properties(receivedProperties);
 
         if (isClosing.get()) {
-            logger.atWarn().log("PIBLISH event ignored due to shutdown initiated");
+            logger.atWarn().log("PUBLISH event ignored due to shutdown initiated");
         } else {
             GRPCClient.MqttReceivedMessage message = new GRPCClient.MqttReceivedMessage(
                     mqttMessage.getQos(), mqttMessage.isRetained(), topic,

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
@@ -476,6 +476,9 @@ public class MqttConnectionImpl implements MqttConnection {
                     }
                 });
             }
+
+            logger.atInfo().log("MQTT connectionId {} disconnected error '{}' disconnectInfo '{}'",
+                    connectionId, errorString, disconnectInfo);
         }
 
         @Override


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-260
add callback for disconnect

**Description of changes:**
- Add callback for disconnect
- Add properties for disconnect
- Refactor message arriving for listener


**Why is this change necessary:**
Implement callback

**How was this change tested:**
Start a local broker and disconnect while the client is running.

**Test results:**
```
[INFO ] 2023-07-17 13:45:48.427 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId client1
[INFO ] 2023-07-17 13:45:48.514 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId client1 address 127.0.0.1 port 42735
[INFO ] 2023-07-17 13:45:48.516 [grpc-default-executor-0] EngineControlImpl - Created new agent control for client1 on 127.0.0.1:42735
[INFO ] 2023-07-17 13:45:48.541 [grpc-default-executor-0] ExampleControl - Agent client1 is connected
[INFO ] 2023-07-17 13:45:48.543 [pool-2-thread-1] AgentTestScenario - Playing test scenario for agent id client1
[INFO ] 2023-07-17 13:45:51.551 [pool-2-thread-1] AgentTestScenario - Set CONNECT user property: region, US
[INFO ] 2023-07-17 13:45:51.551 [pool-2-thread-1] AgentTestScenario - Set CONNECT user property: type, JSON
[INFO ] 2023-07-17 13:45:51.552 [pool-2-thread-1] AgentTestScenario - Set CONNECT request response information true
[INFO ] 2023-07-17 13:45:52.024 [pool-2-thread-1] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
receiveMaximum: 20
retainAvailable: true
'
[INFO ] 2023-07-17 13:45:52.024 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-07-17 13:45:52.024 [pool-2-thread-1] AgentTestScenario - MQTT connection with id 1 is established
[INFO ] 2023-07-17 13:45:57.028 [pool-2-thread-1] AgentTestScenario - Set SUBSCRIBE user property: region, US
[INFO ] 2023-07-17 13:45:57.028 [pool-2-thread-1] AgentTestScenario - Set SUBSCRIBE user property: type, JSON
[INFO ] 2023-07-17 13:45:57.032 [pool-2-thread-1] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-07-17 13:45:57.048 [pool-2-thread-1] AgentTestScenario - Subscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-07-17 13:46:01.673 [grpc-default-executor-0] GRPCDiscoveryServer - OnMqttDisconnect: agentId client1 connectionId 1 disconnect 'reasonCode: 0
' error 'Connection lost'
[INFO ] 2023-07-17 13:46:01.673 [grpc-default-executor-0] AgentTestScenario - MQTT disconnected on agentId client1 connectionId 1 disconnect 'reasonCode: 0
' error 'Connection lost'
[INFO ] 2023-07-17 13:46:07.052 [pool-2-thread-1] AgentTestScenario - Set PUBLISH payload format indicator true
[INFO ] 2023-07-17 13:46:07.052 [pool-2-thread-1] AgentTestScenario - Set PUBLISH message expiry interval 3600
[INFO ] 2023-07-17 13:46:07.052 [pool-2-thread-1] AgentTestScenario - Set PUBLISH response topic /thing1/response/topic
[INFO ] 2023-07-17 13:46:07.053 [pool-2-thread-1] AgentTestScenario - Set PUBLISH correlation data <ByteString@61f9c11e size=16 contents="correlation_data">
[INFO ] 2023-07-17 13:46:07.053 [pool-2-thread-1] AgentTestScenario - Set PUBLISH user property: region, US
[INFO ] 2023-07-17 13:46:07.053 [pool-2-thread-1] AgentTestScenario - Set PUBLISH user property: type, JSON
[INFO ] 2023-07-17 13:46:07.053 [pool-2-thread-1] AgentTestScenario - Set PUBLISH content type text/plain; charset=utf-8
[INFO ] 2023-07-17 13:46:07.056 [pool-2-thread-1] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic test/topic
[INFO ] 2023-07-17 13:46:07.079 [pool-2-thread-1] AgentTestScenario - Published connectionId 1 reason code 32104 reason string 'Client is not connected'
[INFO ] 2023-07-17 13:46:12.080 [pool-2-thread-1] AgentTestScenario - Set UNSUBSCRIBE user property: region, US
[INFO ] 2023-07-17 13:46:12.080 [pool-2-thread-1] AgentTestScenario - Set UNSUBSCRIBE user property: type, JSON
[INFO ] 2023-07-17 13:46:12.085 [pool-2-thread-1] AgentControlImpl - UnsubscribeMqtt: unsubscribe on connectionId 1
[INFO ] 2023-07-17 13:46:12.097 [pool-2-thread-1] AgentTestScenario - Unsubscribe response: connectionId 1 reason codes [32104] reason string 'Client is not connected'
[INFO ] 2023-07-17 13:46:22.098 [pool-2-thread-1] AgentTestScenario - Set DISCONNECT user property: region, US
[INFO ] 2023-07-17 13:46:22.098 [pool-2-thread-1] AgentTestScenario - Set DISCONNECT user property: type, JSON
[INFO ] 2023-07-17 13:46:52.217 [pool-2-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 1 closed
[INFO ] 2023-07-17 13:46:52.220 [pool-2-thread-1] AgentControlImpl - sending shutdown request
[INFO ] 2023-07-17 13:46:52.234 [pool-2-thread-1] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-07-17 13:46:52.290 [grpc-default-executor-0] GRPCDiscoveryServer - UnregisterAgent: agentId client1 reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-07-17 13:46:52.291 [grpc-default-executor-0] AgentControlImpl - shutting down channel with agent id client1
[INFO ] 2023-07-17 13:46:52.292 [grpc-default-executor-0] AgentControlImpl - channel terminated with agent id client1
[INFO ] 2023-07-17 13:46:52.292 [grpc-default-executor-0] ExampleControl - Agent client1 is disconnected
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
