### PR TITLE
feat(uat): add windows build for python paho client

### DIFF
--- a/uat/custom-components/client-python-paho/src/mqtt_lib/mqtt_connection.py
+++ b/uat/custom-components/client-python-paho/src/mqtt_lib/mqtt_connection.py
@@ -730,11 +730,11 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
 
             if message.response_topic is not None:
                 properties.ResponseTopic = message.response_topic
-                self.__logger.warning("Copied TX response topic '%s'", message.response_topic)
+                self.__logger.info("Copied TX response topic '%s'", message.response_topic)
 
             if message.correlation_data is not None:
                 properties.CorrelationData = message.correlation_data
-                self.__logger.warning("Copied TX correlation data '%s'", str(message.correlation_data))
+                self.__logger.info("Copied TX correlation data '%s'", str(message.correlation_data))
 
             properties.UserProperty = user_properties
 
@@ -802,6 +802,11 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
         """
         props = mqtt_result.properties
         mqtt_properties = self.__convert_to_mqtt5_properties(getattr(props, "UserProperty", None), "CONNACK")
+
+        response_information = getattr(props, "ResponseInformation", None)
+        if response_information is not None:
+            self.__logger.info("CONNACK Rx response information: '%s'", response_information)
+
         conn_ack = Mqtt5ConnAck(
             sessionPresent=mqtt_result.flags["session present"],
             reasonCode=mqtt_result.reason_code,
@@ -816,7 +821,7 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
             subscriptionIdentifiersAvailable=getattr(props, "SubscriptionIdentifierAvailable", None),
             sharedSubscriptionsAvailable=getattr(props, "SharedSubscriptionAvailable", None),
             serverKeepAlive=getattr(props, "ServerKeepAlive", None),
-            responseInformation=getattr(props, "ResponseInformation", None),
+            responseInformation=response_information,
             serverReference=getattr(props, "ServerReference", None),
             topicAliasMaximum=getattr(props, "TopicAliasMaximum", None),
             properties=mqtt_properties,

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -87,7 +87,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  | subscribe-status-q1 |
       | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   | GRANTED_QOS_0       |
 
-    @mqtt3 @paho-python @SkipOnWindows
+    @mqtt3 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  | subscribe-status-q1 |
       | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | GRANTED_QOS_1       |
@@ -107,7 +107,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  | subscribe-status-q1 |
       | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   | GRANTED_QOS_1       |
 
-    @mqtt5 @paho-python @SkipOnWindows
+    @mqtt5 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  | subscribe-status-q1 |
       | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | GRANTED_QOS_1       |
@@ -243,7 +243,7 @@ Feature: GGMQ-1
       | mqtt-v | name     | agent                                          | recipe                  | iot_data_1-publish | subscribe-status-q1 |
       | v3     | sdk-java | aws.greengrass.client.Mqtt5JavaSdkClient       | client_java_sdk.yaml    | 0                  | GRANTED_QOS_0       |
 
-    @mqtt3 @paho-python @SkipOnWindows
+    @mqtt3 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  | iot_data_1-publish | subscribe-status-q1 |
       | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | 0                  | GRANTED_QOS_1       |
@@ -253,7 +253,7 @@ Feature: GGMQ-1
       | mqtt-v | name     | agent                                          | recipe                  | iot_data_1-publish | subscribe-status-q1 |
       | v5     | sdk-java | aws.greengrass.client.Mqtt5JavaSdkClient       | client_java_sdk.yaml    | 135                | GRANTED_QOS_1       |
 
-    @mqtt5 @paho-python @SkipOnWindows
+    @mqtt5 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  | iot_data_1-publish | subscribe-status-q1 |
       | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | 0                  | GRANTED_QOS_1       |
@@ -402,7 +402,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
-    @mqtt3 @paho-python @SkipOnWindows
+    @mqtt3 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
@@ -422,7 +422,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  |
       | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
-    @mqtt5 @paho-python @SkipOnWindows
+    @mqtt5 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
@@ -548,7 +548,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
-    @mqtt3 @paho-python @SkipOnWindows
+    @mqtt3 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
@@ -568,7 +568,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  |
       | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
-    @mqtt5 @paho-python @SkipOnWindows
+    @mqtt5 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
@@ -745,7 +745,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
       | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   | GRANTED_QOS_0       | GRANTED_QOS_0         | 0                  |
 
-    @mqtt3 @paho-python @SkipOnWindows
+    @mqtt3 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
       | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | UNSPECIFIED_ERROR   | GRANTED_QOS_1         | 0                  |
@@ -765,7 +765,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
       | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   | NOT_AUTHORIZED      | GRANTED_QOS_1         | 16                 |
 
-    @mqtt5 @paho-python @SkipOnWindows
+    @mqtt5 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
       | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | NOT_AUTHORIZED      | GRANTED_QOS_1         | 0                  |
@@ -891,7 +891,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
-    @mqtt3 @paho-python @SkipOnWindows
+    @mqtt3 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
@@ -911,7 +911,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  |
       | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
-    @mqtt5 @paho-python @SkipOnWindows
+    @mqtt5 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
@@ -1040,7 +1040,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
-    @mqtt3 @paho-python @SkipOnWindows
+    @mqtt3 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
@@ -1060,7 +1060,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  |
       | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
-    @mqtt5 @paho-python @SkipOnWindows
+    @mqtt5 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
@@ -1437,7 +1437,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
-    @mqtt3 @paho-python @SkipOnWindows
+    @mqtt3 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
@@ -1457,7 +1457,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  |
       | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
-    @mqtt5 @paho-python @SkipOnWindows
+    @mqtt5 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
@@ -1558,7 +1558,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
-    @mqtt3 @paho-python @SkipOnWindows
+    @mqtt3 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
@@ -1578,7 +1578,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  |
       | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
-    @mqtt5 @paho-python @SkipOnWindows
+    @mqtt5 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
@@ -1714,7 +1714,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  | publish-status-na |
       | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   | 0                 |
 
-    @mqtt3 @paho-python @SkipOnWindows
+    @mqtt3 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  | publish-status-na |
       | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | 0                 |
@@ -1734,7 +1734,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  | publish-status-na |
       | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   | 135               |
 
-    @mqtt5 @paho-python @SkipOnWindows
+    @mqtt5 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  | publish-status-na |
       | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | 0                 |
@@ -1825,7 +1825,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
-    @mqtt3 @paho-python @SkipOnWindows
+    @mqtt3 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
@@ -2347,7 +2347,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  | publish-status-nms |
       | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   | 16                 |
 
-    @mqtt5 @paho-python @SkipOnWindows
+    @mqtt5 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  | publish-status-nms |
       | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | 0                  |

--- a/uat/testing-features/src/main/resources/local-store/recipes/client_python_paho.yaml
+++ b/uat/testing-features/src/main/resources/local-store/recipes/client_python_paho.yaml
@@ -16,7 +16,9 @@ ComponentConfiguration:
     controlAddresses: 127.0.0.1
     controlPort: 47619
 Manifests:
-  - Artifacts:
+  - Platform:
+      os: linux
+    Artifacts:
       - URI: classpath:/local-store/artifacts/client-python-paho
         Permission:
           Read: ALL
@@ -24,4 +26,14 @@ Manifests:
     Lifecycle:
       Run: |
         {artifacts:path}/client-python-paho "{configuration:/agentId}" "{configuration:/controlPort}" {configuration:/controlAddresses}
-# Only linux support at this moment
+
+  - Platform:
+      os: windows
+    Artifacts:
+      - URI: classpath:/local-store/artifacts/client-python-paho.exe
+        Permission:
+          Read: ALL
+          Execute: OWNER
+    Lifecycle:
+      Run: |
+        {artifacts:path}/client-python-paho.exe "{configuration:/agentId}" "{configuration:/controlPort}" {configuration:/controlAddresses}


### PR DESCRIPTION
**Issue #, if available:**
Implement Windows Build for Python Paho client.
Implement the ability to run test scenarios on Windows for Python Paho Client.
Fix "Response topic and correlation data are received as warnings on python-paho client side" bug.
https://klika-tech.atlassian.net/browse/GGMQ-157
https://klika-tech.atlassian.net/browse/GGMQ-274

**Description of changes:**
- Update Python Paho client building system to make it possible running scenarios on Windows
- Response topic and correlation data bug was fixed

**Why is this change necessary:**
Test all scenarios with Python Paho client on Windows

**How was this change tested:**
Run scenarios locally on Windows

**Test results:**
```
[INFO ] 2023-07-24 19:40:52.140 [main] StepTrackingReporting - Passed: 'GGMQ-1-T1-v3-paho-python: As a customer, I can connect, subscribe/publish at QoS 0 and 1 and receive using client application to MQTT topic'
[INFO ] 2023-07-24 20:49:51.906 [main] StepTrackingReporting - Passed: 'GGMQ-1-T2-v3-paho-python: GGAD can publish to an MQTT topic at QoS 0 and QoS 1 based on CDA configuration'
[INFO ] 2023-07-24 19:40:52.142 [main] StepTrackingReporting - Passed: 'GGMQ-1-T8-v3-paho-python: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic'
[INFO ] 2023-07-24 20:53:06.914 [main] StepTrackingReporting - Passed: 'GGMQ-1-T9-v3-paho-python: As a customer, I can configure local MQTT messages to be forwarded to an IoT Core MQTT topic'
[INFO ] 2023-07-24 19:40:52.142 [main] StepTrackingReporting - Passed: 'GGMQ-1-T13-v3-paho-python: As a customer, I can connect two GGADs and send message from one GGAD to the other based on CDA configuration'
[INFO ] 2023-07-24 19:40:52.142 [main] StepTrackingReporting - Passed: 'GGMQ-1-T14-v3-paho-python: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic'
[INFO ] 2023-07-24 19:40:52.142 [main] StepTrackingReporting - Passed: 'GGMQ-1-T15-v3-paho-python: As a customer, I can configure Pubsub messages to be forwarded to local MQTT topic'
[INFO ] 2023-07-24 19:40:52.142 [main] StepTrackingReporting - Passed: 'GGMQ-1-T20-v3-paho-python: As a customer, I can associate and connect GGADs with GGC over custom port'
[INFO ] 2023-07-24 19:40:52.142 [main] StepTrackingReporting - Passed: 'GGMQ-1-T22-v3-paho-python: As a customer, I can send a message of size 128KiB to the MQTT broker'
[INFO ] 2023-07-24 19:40:52.144 [main] StepTrackingReporting - Passed: 'GGMQ-1-T24-v3-paho-python: As a customer, I can reset CDA config and update it and CDA will use the new config'
[INFO ] 2023-07-24 19:40:52.144 [main] StepTrackingReporting - Passed: 'GGMQ-1-T101-v3-paho-python: As a customer, I can use publish retain flag using MQTT V3.1.1'
[INFO ] 2023-07-24 20:26:50.676 [main] StepTrackingReporting - Passed: 'GGMQ-1-T1-v5-paho-python: As a customer, I can connect, subscribe/publish at QoS 0 and 1 and receive using client application to MQTT topic'
[INFO ] 2023-07-24 20:26:50.676 [main] StepTrackingReporting - Passed: 'GGMQ-1-T2-v5-paho-python: GGAD can publish to an MQTT topic at QoS 0 and QoS 1 based on CDA configuration'
[INFO ] 2023-07-24 20:26:50.677 [main] StepTrackingReporting - Passed: 'GGMQ-1-T8-v5-paho-python: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic'
[INFO ] 2023-07-24 20:26:50.677 [main] StepTrackingReporting - Passed: 'GGMQ-1-T9-v5-paho-python: As a customer, I can configure local MQTT messages to be forwarded to an IoT Core MQTT topic'
[INFO ] 2023-07-24 20:26:50.677 [main] StepTrackingReporting - Passed: 'GGMQ-1-T13-v5-paho-python: As a customer, I can connect two GGADs and send message from one GGAD to the other based on CDA configuration'
[INFO ] 2023-07-24 20:26:50.677 [main] StepTrackingReporting - Passed: 'GGMQ-1-T14-v5-paho-python: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic'
[INFO ] 2023-07-24 20:26:50.677 [main] StepTrackingReporting - Passed: 'GGMQ-1-T15-v5-paho-python: As a customer, I can configure Pubsub messages to be forwarded to local MQTT topic'
[INFO ] 2023-07-24 20:26:50.677 [main] StepTrackingReporting - Passed: 'GGMQ-1-T20-v5-paho-python: As a customer, I can associate and connect GGADs with GGC over custom port'
[INFO ] 2023-07-24 20:26:50.677 [main] StepTrackingReporting - Passed: 'GGMQ-1-T22-v5-paho-python: As a customer, I can send a message of size 128KiB to the MQTT broker'
[INFO ] 2023-07-24 20:26:50.677 [main] StepTrackingReporting - Passed: 'GGMQ-1-T24-v5-paho-python: As a customer, I can reset CDA config and update it and CDA will use the new config'
[INFO ] 2023-07-24 20:26:50.677 [main] StepTrackingReporting - Passed: 'GGMQ-1-T102-v5-paho-python: As a customer, I can use new MQTT v5.0 features'
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
