### PR TITLE
feat(uat): add T21 and plugin to generate html-documentation

### DIFF
--- a/uat/README.md
+++ b/uat/README.md
@@ -137,3 +137,10 @@ For more information please read [Create a CodeBuild service role](https://docs.
 MQTT clients based on IoT Device SDK for Java v2, mosquitto C, Paho Java, Paho Python do no provide API to get information from PUBREC/PUBREL/PUBCOMP packages used when messages published with QoS 2.
 
 Not all features of MQTT v5.0 have been implemented in clients and are supported by gRPC proto and the control as was requested, these are not bugs but designed by requirement.
+
+### Generate html-documentation from JavaDoc
+To generate html-documentation from JavaDoc, run the following command from the uat directory of the project:
+```bash
+mvn javadoc:javadoc
+```
+The main html-file will be located in each module by path **~/target/site/apidocs/index.html**

--- a/uat/pom.xml
+++ b/uat/pom.xml
@@ -85,5 +85,16 @@
         <spotbugs.plugin.version>4.0.0</spotbugs.plugin.version>
         <antrun.plugin.version>3.0.0</antrun.plugin.version>
         <surefire.plugin.version>3.0.0</surefire.plugin.version>
+        <maven.javadoc.plugin.version>3.5.0</maven.javadoc.plugin.version>
     </properties>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven.javadoc.plugin.version}</version>
+            </plugin>
+        </plugins>
+    </reporting>
 </project>

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1531,45 +1531,10 @@ Feature: GGMQ-1
     And I disconnect device "basic_connect" with reason code 0
     Then I remove IP address "127.0.0.2" from loopback interface
 
-    @mqtt3 @sdk-java
-    Examples:
-      | mqtt-v | name        | agent                                       | recipe                  |
-      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient    | client_java_sdk.yaml    |
-
-    @mqtt3 @mosquitto-c @SkipOnWindows
-    Examples:
-      | mqtt-v | name        | agent                                       | recipe                  |
-      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml |
-
-    @mqtt3 @paho-java
-    Examples:
-      | mqtt-v | name        | agent                                       | recipe                  |
-      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
-
-    @mqtt3 @paho-python @SkipOnWindows
-    Examples:
-      | mqtt-v | name        | agent                                       | recipe                  |
-      | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
-
     @mqtt5 @sdk-java
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient    | client_java_sdk.yaml    |
-
-    @mqtt5 @mosquitto-c @SkipOnWindows
-    Examples:
-      | mqtt-v | name        | agent                                       | recipe                  |
-      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml |
-
-    @mqtt5 @paho-java
-    Examples:
-      | mqtt-v | name        | agent                                       | recipe                  |
-      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
-
-    @mqtt5 @paho-python @SkipOnWindows
-    Examples:
-      | mqtt-v | name        | agent                                       | recipe                  |
-      | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
 
 
   @GGMQ-1-T22

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1463,6 +1463,115 @@ Feature: GGMQ-1
       | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
 
 
+  @GGMQ-1-T21
+  Scenario Outline: GGMQ-1-T21-<mqtt-v>-<name>: As a customer, I change the connectivity ip address and GGADs are able to connect via IPD
+    When I create a Greengrass deployment with components
+      | aws.greengrass.clientdevices.Auth        | LATEST                                  |
+      | aws.greengrass.clientdevices.mqtt.EMQX   | LATEST                                  |
+      | aws.greengrass.clientdevices.IPDetector  | LATEST                                  |
+      | <agent>                                  | classpath:/local-store/recipes/<recipe> |
+    And I create client device "basic_connect"
+    When I associate "basic_connect" with ggc
+    And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:
+    """
+{
+    "MERGE":{
+        "deviceGroups":{
+            "formatVersion":"2021-03-05",
+            "definitions":{
+                "MyPermissiveDeviceGroup":{
+                    "selectionRule":"thingName: ${basic_connect}",
+                    "policyName":"MyPermissivePolicy"
+                }
+            },
+            "policies":{
+                "MyPermissivePolicy":{
+                    "AllowAll":{
+                        "statementDescription":"Allow client devices to perform all actions.",
+                        "operations":[
+                            "*"
+                        ],
+                        "resources":[
+                            "*"
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}
+    """
+    And I update my Greengrass deployment configuration, setting the component <agent> configuration to:
+    """
+{
+    "MERGE":{
+        "controlAddresses":"${mqttControlAddresses}",
+        "controlPort":"${mqttControlPort}"
+    }
+}
+    """
+    And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.IPDetector configuration to:
+    """
+{
+    "MERGE":{
+        "includeIPv4LoopbackAddrs":"true"
+    }
+}
+    """
+    And I deploy the Greengrass deployment configuration
+    Then the Greengrass deployment is COMPLETED on the device after 5 minutes
+    And the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes
+
+    Then I add IP address "127.0.0.2" to loopback interface
+    Then I wait 90 seconds
+
+    And I discover core device broker as "default_broker" from "basic_connect" in OTF
+    And I connect device "basic_connect" on <agent> to "default_broker" using mqtt "<mqtt-v>"
+
+    And I disconnect device "basic_connect" with reason code 0
+    Then I remove IP address "127.0.0.2" from loopback interface
+
+    @mqtt3 @sdk-java
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient    | client_java_sdk.yaml    |
+
+    @mqtt3 @mosquitto-c @SkipOnWindows
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml |
+
+    @mqtt3 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
+
+    @mqtt3 @paho-python @SkipOnWindows
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
+
+    @mqtt5 @sdk-java
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient    | client_java_sdk.yaml    |
+
+    @mqtt5 @mosquitto-c @SkipOnWindows
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml |
+
+    @mqtt5 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
+
+    @mqtt5 @paho-python @SkipOnWindows
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
+
+
   @GGMQ-1-T22
   Scenario Outline: GGMQ-1-T22-<mqtt-v>-<name>: As a customer, I can send a message of size 128KiB to the MQTT broker
     When I create a Greengrass deployment with components


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-203
https://klika-tech.atlassian.net/browse/GGMQ-275
add and remove steps for loopback address

**Description of changes:**
- Add 'I add IP address "ip_address" to loopback interface' step
- Add 'I remove IP address "ip_address" from loopback interface' step
- Add plugin to generate html-documentation from JavaDoc

**Why is this change necessary:**
Implement scenarios

**How was this change tested:**
Run scenario on CodeBuild

**Test results:**
```
Given my device is registered as a Thing....................................passed
And my device is running Greengrass.........................................passed
When I create a Greengrass deployment with components.......................passed
And I create client device "basic_connect"..................................passed
When I associate "basic_connect" with ggc...................................passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:.passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.client.Mqtt5JavaSdkClient configuration to:.passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.IPDetector configuration to:.passed
And I deploy the Greengrass deployment configuration........................passed
Then the Greengrass deployment is COMPLETED on the device after 5 minutes...passed
And the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes.passed
Then I add IP address "127.0.0.2" to loopback interface.....................passed
Then I wait 90 seconds......................................................passed
And I discover core device broker as "default_broker" from "basic_connect" in OTF.passed
And I connect device "basic_connect" on aws.greengrass.client.Mqtt5JavaSdkClient to "default_broker" using mqtt "v5".passed
And I disconnect device "basic_connect" with reason code 0..................passed
Then I remove IP address "127.0.0.2" from loopback interface................passed
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
