### PR TITLE
fix(uat): resolve issue when key file in PCKS#8 format can't be read

### DIFF
--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
@@ -206,8 +206,9 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
                 connectionParams.getCert() != null);
         connectionOptions.setServerURIs(new String[]{uri});
 
-        if (connectionParams.getKey() != null) {
-            SSLSocketFactory sslSocketFactory = SslUtil.getSocketFactory(connectionParams);
+        if (connectionParams.getCert() != null) {
+            SSLSocketFactory sslSocketFactory = SslUtil.getSocketFactory(
+                connectionParams.getCa(), connectionParams.getCert(), connectionParams.getKey());
             connectionOptions.setSocketFactory(sslSocketFactory);
         }
 

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
@@ -39,7 +39,7 @@ public interface MqttLib extends AutoCloseable {
         /** Clean session (clean start) flag of CONNECT packet. */
         private boolean cleanSession;
 
-        /** Content of CA, optional. */
+        /** Content of CA list joined by \n, optional. */
         private String ca;
 
         /** Content of MQTT client's certificate, optional. */

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
@@ -39,8 +39,8 @@ public interface MqttLib extends AutoCloseable {
         /** Clean session (clean start) flag of CONNECT packet. */
         private boolean cleanSession;
 
-        /** Content of CA list joined by \n, optional. */
-        private String ca;
+        /** List of CA, optional. */
+        private List<String> ca;
 
         /** Content of MQTT client's certificate, optional. */
         private String cert;

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
@@ -214,8 +214,7 @@ class GRPCControlServer {
                     return;
                 }
 
-                final String ca = String.join("\n", caList);
-                connectionParamsBuilder.ca(ca).cert(cert).key(key);
+                connectionParamsBuilder.ca(caList).cert(cert).key(key);
             }
 
             logger.atInfo().log("createMqttConnection: clientId {} broker {}:{}", clientId, host, port);

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
@@ -317,8 +317,9 @@ public class MqttConnectionImpl implements MqttConnection {
         connectionOptions.setServerURIs(new String[]{uri});
         connectionOptions.setConnectionTimeout(connectionParams.getConnectionTimeout());
 
-        if (connectionParams.getKey() != null) {
-            SSLSocketFactory sslSocketFactory = SslUtil.getSocketFactory(connectionParams);
+        if (connectionParams.getCert() != null) {
+            SSLSocketFactory sslSocketFactory = SslUtil.getSocketFactory(
+                connectionParams.getCa(), connectionParams.getCert(), connectionParams.getKey());
             connectionOptions.setSocketFactory(sslSocketFactory);
         }
 

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
@@ -39,7 +39,7 @@ public interface MqttLib extends AutoCloseable {
         /** Clean session (clean start) flag of CONNECT packet. */
         private boolean cleanSession;
 
-        /** Content of CA, optional. */
+        /** Content of CA list joined by \n, optional. */
         private String ca;
 
         /** Content of MQTT client's certificate, optional. */


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-283
TLS connection fails

**Description of changes:**
- Rework SslUtils to support PCKS#8 key format
- Use list of certificate instead of concatenated to String
- Use certificate presense as mark TLS credentials are present.



**Why is this change necessary:**
Paho-jave client does not support PKCS#8 format of key file.

**How was this change tested:**
Manually by run Control as application with key file in PKCS#8 format and for local mosquitto client.

**Test results:**

Control
```
$ ./run_for_mosquitto_pkcs8.sh
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.google.inject.internal.cglib.core.$ReflectUtils$1 (file:/usr/share/maven/lib/guice.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain)
WARNING: Please consider reporting this to the maintainers of com.google.inject.internal.cglib.core.$ReflectUtils$1
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Detecting the operating system and CPU architecture
[INFO] ------------------------------------------------------------------------
[INFO] os.detected.name: linux
[INFO] os.detected.arch: x86_64
[INFO] os.detected.bitness: 64
[INFO] os.detected.version: 5.15
[INFO] os.detected.version.major: 5
[INFO] os.detected.version.minor: 15
[INFO] os.detected.release: ubuntu
[INFO] os.detected.release.version: 20.04
[INFO] os.detected.release.like.ubuntu: true
[INFO] os.detected.release.like.debian: true
[INFO] os.detected.classifier: linux-x86_64
[INFO]
[INFO] ---< com.aws.greengrass:aws-greengrass-testing-mqtt-client-control >----
[INFO] Building aws-greengrass-testing-mqtt-client-control 1.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
Downloading from greengrass-common: https://d2jrmugq4soldf.cloudfront.net/snapshots/io/grpc/grpc-core/maven-metadata.xml
Downloading from central: https://repo1.maven.org/maven2/io/grpc/grpc-core/maven-metadata.xml
Downloaded from central: https://repo1.maven.org/maven2/io/grpc/grpc-core/maven-metadata.xml (4.9 kB at 13 kB/s)
[WARNING] Could not transfer metadata io.grpc:grpc-core/maven-metadata.xml from/to greengrass-common (https://d2jrmugq4soldf.cloudfront.net/snapshots): Authorization failed for https://d2jrmugq4soldf.cloudfront.net/snapshots/io/grpc/grpc-core/maven-metadata.xml 403 Forbidden
Downloading from central: https://repo1.maven.org/maven2/io/grpc/grpc-api/maven-metadata.xml
Downloading from greengrass-common: https://d2jrmugq4soldf.cloudfront.net/snapshots/io/grpc/grpc-api/maven-metadata.xml
Downloaded from central: https://repo1.maven.org/maven2/io/grpc/grpc-api/maven-metadata.xml (3.3 kB at 67 kB/s)
[WARNING] Could not transfer metadata io.grpc:grpc-api/maven-metadata.xml from/to greengrass-common (https://d2jrmugq4soldf.cloudfront.net/snapshots): Authorization failed for https://d2jrmugq4soldf.cloudfront.net/snapshots/io/grpc/grpc-api/maven-metadata.xml 403 Forbidden
[INFO]
[INFO] --- exec-maven-plugin:3.1.0:java (default-cli) @ aws-greengrass-testing-mqtt-client-control ---
[INFO ] 2023-08-01 13:12:33.034 [com.aws.greengrass.testing.mqtt.client.control.ExampleControl.main()] ExampleControl - Control: port 47619, with TLS, MQTT v5
[INFO ] 2023-08-01 13:12:33.272 [com.aws.greengrass.testing.mqtt.client.control.ExampleControl.main()] EngineControlImpl - MQTT client control gRPC server started, listening on 47619
[INFO ] 2023-08-01 13:12:40.915 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId paho-java-agent
[INFO ] 2023-08-01 13:12:40.998 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId paho-java-agent address 127.0.0.1 port 40489
[INFO ] 2023-08-01 13:12:41.003 [grpc-default-executor-0] EngineControlImpl - Created new agent control for paho-java-agent on 127.0.0.1:40489
[INFO ] 2023-08-01 13:12:41.048 [grpc-default-executor-0] ExampleControl - Agent paho-java-agent is connected
[INFO ] 2023-08-01 13:12:41.056 [pool-4-thread-1] AgentTestScenario - Playing test scenario for agent id paho-java-agent
[INFO ] 2023-08-01 13:12:44.101 [pool-4-thread-1] AgentTestScenario - Set CONNECT user property: region, US
[INFO ] 2023-08-01 13:12:44.101 [pool-4-thread-1] AgentTestScenario - Set CONNECT user property: type, JSON
[INFO ] 2023-08-01 13:12:44.104 [pool-4-thread-1] AgentTestScenario - Set CONNECT request response information true
[INFO ] 2023-08-01 13:12:45.045 [pool-4-thread-1] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
receiveMaximum: 20
retainAvailable: true
'
[INFO ] 2023-08-01 13:12:45.046 [pool-4-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-08-01 13:12:45.046 [pool-4-thread-1] AgentTestScenario - MQTT connection with id 1 is established
[INFO ] 2023-08-01 13:12:50.064 [pool-4-thread-1] AgentTestScenario - Set SUBSCRIBE user property: region, US
[INFO ] 2023-08-01 13:12:50.065 [pool-4-thread-1] AgentTestScenario - Set SUBSCRIBE user property: type, JSON
[INFO ] 2023-08-01 13:12:50.078 [pool-4-thread-1] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-08-01 13:12:50.107 [pool-4-thread-1] AgentTestScenario - Subscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-08-01 13:13:00.119 [pool-4-thread-1] AgentTestScenario - Set PUBLISH payload format indicator true
[INFO ] 2023-08-01 13:13:00.120 [pool-4-thread-1] AgentTestScenario - Set PUBLISH message expiry interval 3600
[INFO ] 2023-08-01 13:13:00.120 [pool-4-thread-1] AgentTestScenario - Set PUBLISH response topic /thing1/response/topic
[INFO ] 2023-08-01 13:13:00.123 [pool-4-thread-1] AgentTestScenario - Set PUBLISH correlation data <ByteString@61e87e86 size=16 contents="correlation_data">
[INFO ] 2023-08-01 13:13:00.124 [pool-4-thread-1] AgentTestScenario - Set PUBLISH user property: region, US
[INFO ] 2023-08-01 13:13:00.124 [pool-4-thread-1] AgentTestScenario - Set PUBLISH user property: type, JSON
[INFO ] 2023-08-01 13:13:00.125 [pool-4-thread-1] AgentTestScenario - Set PUBLISH content type text/plain; charset=utf-8
[INFO ] 2023-08-01 13:13:00.139 [pool-4-thread-1] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic test/topic
[INFO ] 2023-08-01 13:13:00.204 [pool-4-thread-1] AgentTestScenario - Published connectionId 1 reason code 0 reason string ''
[INFO ] 2023-08-01 13:13:00.214 [grpc-default-executor-0] GRPCDiscoveryServer - OnReceiveMessage: agentId paho-java-agent connectionId 1 topic test/topic QoS 0
[INFO ] 2023-08-01 13:13:00.215 [grpc-default-executor-0] AgentTestScenario - Message received on agentId paho-java-agent connectionId 1 topic test/topic QoS 0 content <ByteString@3a1e642c size=12 contents="Hello World!">
[INFO ] 2023-08-01 13:13:00.215 [grpc-default-executor-0] AgentTestScenario - Message has payload format indicator true
[INFO ] 2023-08-01 13:13:00.215 [grpc-default-executor-0] AgentTestScenario - Message has message expiry interval 3600
[INFO ] 2023-08-01 13:13:00.215 [grpc-default-executor-0] AgentTestScenario - Message has response topic /thing1/response/topic
[INFO ] 2023-08-01 13:13:00.215 [grpc-default-executor-0] AgentTestScenario - Message has correlation data <ByteString@1559f787 size=16 contents="correlation_data">
[INFO ] 2023-08-01 13:13:00.215 [grpc-default-executor-0] AgentTestScenario - Message has user property key region value US
[INFO ] 2023-08-01 13:13:00.215 [grpc-default-executor-0] AgentTestScenario - Message has user property key type value JSON
[INFO ] 2023-08-01 13:13:00.216 [grpc-default-executor-0] AgentTestScenario - Message has content type 'text/plain; charset=utf-8'
[INFO ] 2023-08-01 13:13:05.205 [pool-4-thread-1] AgentTestScenario - Set UNSUBSCRIBE user property: region, US
[INFO ] 2023-08-01 13:13:05.206 [pool-4-thread-1] AgentTestScenario - Set UNSUBSCRIBE user property: type, JSON
[INFO ] 2023-08-01 13:13:05.219 [pool-4-thread-1] AgentControlImpl - UnsubscribeMqtt: unsubscribe on connectionId 1
[INFO ] 2023-08-01 13:13:05.233 [pool-4-thread-1] AgentTestScenario - Unsubscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-08-01 13:13:15.234 [pool-4-thread-1] AgentTestScenario - Set DISCONNECT user property: region, US
[INFO ] 2023-08-01 13:13:15.234 [pool-4-thread-1] AgentTestScenario - Set DISCONNECT user property: type, JSON
[INFO ] 2023-08-01 13:13:15.399 [pool-4-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 1 closed
[INFO ] 2023-08-01 13:13:15.415 [pool-4-thread-1] AgentControlImpl - sending shutdown request
[INFO ] 2023-08-01 13:13:15.426 [pool-4-thread-1] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-08-01 13:13:15.445 [grpc-default-executor-0] GRPCDiscoveryServer - UnregisterAgent: agentId paho-java-agent reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-08-01 13:13:15.445 [grpc-default-executor-0] AgentControlImpl - shutting down channel with agent id paho-java-agent
[INFO ] 2023-08-01 13:13:15.447 [grpc-default-executor-0] AgentControlImpl - channel terminated with agent id paho-java-agent
[INFO ] 2023-08-01 13:13:15.447 [grpc-default-executor-0] ExampleControl - Agent paho-java-agent is disconnected
^C[INFO ] 2023-08-01 13:13:18.663 [Thread-1] ExampleControl - *** shutting down gRPC server since JVM is shutting down
```

Paho java Client:
```
[INFO ] 2023-08-01 13:12:40.409 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Making gPRC client connection with 127.0.0.1:47619 as paho-java-agent...
[INFO ] 2023-08-01 13:12:40.936 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Client connection with Control is established, local address is 127.0.0.1
[INFO ] 2023-08-01 13:12:40.991 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - GRPCControlServer created and listed on 127.0.0.1:40489
[INFO ] 2023-08-01 13:12:41.081 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Handle gRPC requests
[INFO ] 2023-08-01 13:12:41.081 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - Server awaitTermination
[INFO ] 2023-08-01 13:12:44.208 [grpc-default-executor-0] GRPCControlServer - createMqttConnection: clientId client broker server:8883
[INFO ] 2023-08-01 13:12:44.589 [grpc-default-executor-0] MqttConnectionImpl - CONNECT Tx user property 'region':'US'
[INFO ] 2023-08-01 13:12:44.589 [grpc-default-executor-0] MqttConnectionImpl - CONNECT Tx user property 'type':'JSON'
[INFO ] 2023-08-01 13:12:44.589 [grpc-default-executor-0] MqttConnectionImpl - CONNECT Tx request response information: true
[INFO ] 2023-08-01 13:12:50.094 [grpc-default-executor-0] GRPCControlServer - Subscription: filter 'test/topic' QoS 0 noLocal false retainAsPublished false retainHandling 2
[INFO ] 2023-08-01 13:12:50.094 [grpc-default-executor-0] GRPCControlServer - Subscribe: connectionId 1 for 1 filters
[INFO ] 2023-08-01 13:12:50.096 [grpc-default-executor-0] MqttConnectionImpl - Subscribe MQTT userProperties: region, US
[INFO ] 2023-08-01 13:12:50.096 [grpc-default-executor-0] MqttConnectionImpl - Subscribe MQTT userProperties: type, JSON
[INFO ] 2023-08-01 13:12:50.103 [grpc-default-executor-0] GRPCControlServer - Subscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-08-01 13:13:00.180 [grpc-default-executor-0] GRPCControlServer - Publish: connectionId 1 topic 'test/topic' QoS 1 retain false
[INFO ] 2023-08-01 13:13:00.184 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx payload format indicator 'true'
[INFO ] 2023-08-01 13:13:00.184 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx expiry message interval '3600'
[INFO ] 2023-08-01 13:13:00.184 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx response topic: /thing1/response/topic
[INFO ] 2023-08-01 13:13:00.184 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx correlation data: [99, 111, 114, 114, 101, 108, 97, 116, 105, 111, 110, 95, 100, 97, 116, 97]
[INFO ] 2023-08-01 13:13:00.185 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx user property 'region':'US'
[INFO ] 2023-08-01 13:13:00.185 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx user property 'type':'JSON'
[INFO ] 2023-08-01 13:13:00.185 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx payload content type 'text/plain; charset=utf-8'
[INFO ] 2023-08-01 13:13:00.200 [grpc-default-executor-0] GRPCControlServer - Publish response: connectionId 1 reason code 0 reason string ''
[INFO ] 2023-08-01 13:13:00.201 [MQTT Call: client] MqttConnectionImpl - Received MQTT message: connectionId 1 topic 'test/topic' QoS 0 retain false
[INFO ] 2023-08-01 13:13:00.202 [MQTT Call: client] MqttConnectionImpl - Received MQTT userProperties: region, US
[INFO ] 2023-08-01 13:13:00.202 [MQTT Call: client] MqttConnectionImpl - Received MQTT userProperties: type, JSON
[INFO ] 2023-08-01 13:13:00.203 [MQTT Call: client] MqttConnectionImpl - Received MQTT message has content type 'text/plain; charset=utf-8'
[INFO ] 2023-08-01 13:13:00.203 [MQTT Call: client] MqttConnectionImpl - Received MQTT message has payload format indicator 'true'
[INFO ] 2023-08-01 13:13:00.203 [MQTT Call: client] MqttConnectionImpl - Received MQTT message has message expiry interval 3600
[INFO ] 2023-08-01 13:13:00.203 [MQTT Call: client] MqttConnectionImpl - Received MQTT message has response topic: /thing1/response/topic
[INFO ] 2023-08-01 13:13:00.203 [MQTT Call: client] MqttConnectionImpl - Received MQTT message has correlation data: [99, 111, 114, 114, 101, 108, 97, 116, 105, 111, 110, 95, 100, 97, 116, 97]
[INFO ] 2023-08-01 13:13:00.203 [MQTT Call: client] MqttConnectionImpl - Delivery completion is true
[INFO ] 2023-08-01 13:13:05.227 [grpc-default-executor-0] GRPCControlServer - Unsubscribe: connectionId 1 for [test/topic] filters
[INFO ] 2023-08-01 13:13:05.228 [grpc-default-executor-0] MqttConnectionImpl - Unsubscribe MQTT userProperties: region, US
[INFO ] 2023-08-01 13:13:05.228 [grpc-default-executor-0] MqttConnectionImpl - Unsubscribe MQTT userProperties: type, JSON
[INFO ] 2023-08-01 13:13:05.230 [grpc-default-executor-0] GRPCControlServer - Unsubscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-08-01 13:13:15.266 [grpc-default-executor-0] GRPCControlServer - closeMqttConnection: connectionId 1 reason 4
[INFO ] 2023-08-01 13:13:15.267 [grpc-default-executor-0] MqttConnectionImpl - Disconnect MQTT userProperties: region, US
[INFO ] 2023-08-01 13:13:15.268 [grpc-default-executor-0] MqttConnectionImpl - Disconnect MQTT userProperties: type, JSON
[INFO ] 2023-08-01 13:13:15.423 [grpc-default-executor-0] GRPCControlServer - shutdownAgent: reason 'That's it.'
[INFO ] 2023-08-01 13:13:15.436 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - Server awaitTermination done
[INFO ] 2023-08-01 13:13:15.437 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Shutdown gPRC link
[INFO ] 2023-08-01 13:13:15.451 [com.aws.greengrass.testing.mqtt5.client.Main.main()] Main - Execution done successfully
```


**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
