### PR TITLE
feat(uat): implement GGMQ scenario based on GGAD-1-T25

### DIFF
--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -798,10 +798,10 @@ public class MqttControlSteps {
         ConnectionControl connectionControl = getConnectionControl(clientDeviceThingName);
 
         // Add test id to new name
-        final String newConnectionNameWithTestId = getClientDeviceThingName(clientDeviceId);
+        final String newConnectionNameWithTestId = getClientDeviceThingName(newConnectionName);
         connectionControl.setConnectionName(newConnectionNameWithTestId);
 
-        log.info("Connection {string} was renamed to {string}",
+        log.info("Connection {} was renamed to {}",
                  clientDeviceThingName,
                  newConnectionNameWithTestId);
     }

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -786,6 +786,27 @@ public class MqttControlSteps {
     }
 
     /**
+     * Renames connection.
+     *
+     * @param clientDeviceId the id of the device (thing name) as defined by user in scenario
+     * @param newConnectionName new name of the connection
+     * @throws RuntimeException throws in fail case
+     */
+    @And("I rename connection {string} to {string}")
+    public void renameConnection(String clientDeviceId, String newConnectionName) {
+        final String clientDeviceThingName = getClientDeviceThingName(clientDeviceId);
+        ConnectionControl connectionControl = getConnectionControl(clientDeviceThingName);
+
+        // Add test id to new name
+        final String newConnectionNameWithTestId = getClientDeviceThingName(clientDeviceId);
+        connectionControl.setConnectionName(newConnectionNameWithTestId);
+
+        log.info("Connection {string} was renamed to {string}",
+                 clientDeviceThingName,
+                 newConnectionNameWithTestId);
+    }
+
+    /**
      * Try to create MQTT connection to broker and ensure connection has been failed.
      *
      * @param clientDeviceId the id of the device (thing name) as defined by user in scenario

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1829,6 +1829,8 @@ Feature: GGMQ-1
       | <agent>                                  | classpath:/local-store/recipes/<recipe> |
     And I create client device "publisher"
     And I create client device "subscriber"
+    When I associate "publisher" with ggc
+    When I associate "subscriber" with ggc
     And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:
     """
 {
@@ -1868,8 +1870,6 @@ Feature: GGMQ-1
     }
 }
     """
-    When I associate "publisher" with ggc
-    When I associate "subscriber" with ggc
 
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 5 minutes
@@ -1881,13 +1881,13 @@ Feature: GGMQ-1
     And I connect device "subscriber" on <agent> to "localMqttBroker2" using mqtt "<mqtt-v>"
 
     When I subscribe "subscriber" to "iot_data_0" with qos 1
-    When I publish from "publisher" to "iot_data_0" with qos 1 and message "Test message" and expect status 0
+    When I publish from "publisher" to "iot_data_0" with qos 1 and message "Test message"
     And message "Test message" received on "subscriber" from "iot_data_0" topic within 5 seconds
     And I rename connection "publisher" to "publisher_old"
 
     # Reconnect publisher with the same device id
     And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
-    When I publish from "publisher" to "iot_data_0" with qos 1 and message "Connect again" and expect status 0
+    When I publish from "publisher" to "iot_data_0" with qos 1 and message "Connect again"
     And message "Connect again" received on "subscriber" from "iot_data_0" topic within 5 seconds
 
     # WARNING: Paho Java client does not work in this test because of "Untranslated MqttException - RC: 0"

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1890,8 +1890,6 @@ Feature: GGMQ-1
     When I publish from "publisher" to "iot_data_0" with qos 1 and message "Connect again"
     And message "Connect again" received on "subscriber" from "iot_data_0" topic within 5 seconds
 
-    # WARNING: Paho Java client does not work in this test because of "Untranslated MqttException - RC: 0"
-    # Add this client here after this issue will be fixed
     @mqtt3 @sdk-java
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
@@ -1901,6 +1899,11 @@ Feature: GGMQ-1
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml |
+
+    @mqtt3 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
     @mqtt3 @paho-python
     Examples:
@@ -1916,6 +1919,11 @@ Feature: GGMQ-1
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml |
+
+    @mqtt5 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
     @mqtt5 @paho-python
     Examples:

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1875,9 +1875,10 @@ Feature: GGMQ-1
     Then the Greengrass deployment is COMPLETED on the device after 5 minutes
     And the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes
 
-    And I discover core device broker as "default_broker" from "publisher" in OTF
-    And I connect device "publisher" on <agent> to "default_broker" using mqtt "<mqtt-v>"
-    And I connect device "subscriber" on <agent> to "default_broker" using mqtt "<mqtt-v>"
+    Then I discover core device broker as "localMqttBroker1" from "publisher" in OTF
+    Then I discover core device broker as "localMqttBroker2" from "subscriber" in OTF
+    And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
+    And I connect device "subscriber" on <agent> to "localMqttBroker2" using mqtt "<mqtt-v>"
 
     When I subscribe "subscriber" to "iot_data_0" with qos 1
     When I publish from "publisher" to "iot_data_0" with qos 1 and message "Test message" and expect status 0
@@ -1885,7 +1886,7 @@ Feature: GGMQ-1
     And I rename connection "publisher" to "publisher_old"
 
     # Reconnect publisher with the same device id
-    And I connect device "publisher" on <agent> to "default_broker" using mqtt "<mqtt-v>"
+    And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
     When I publish from "publisher" to "iot_data_0" with qos 1 and message "Connect again" and expect status 0
     And message "Connect again" received on "subscriber" from "iot_data_0" topic within 5 seconds
 

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1887,6 +1887,7 @@ Feature: GGMQ-1
 
     # Reconnect publisher with the same device id
     And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
+    And I wait 5 seconds
     When I publish from "publisher" to "iot_data_0" with qos 1 and message "Connect again" and expect status 0
     And message "Connect again" received on "subscriber" from "iot_data_0" topic within 5 seconds
 

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1820,6 +1820,115 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  | publish-status-na |
       | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | 0                 |
 
+  @GGMQ-1-T25
+  Scenario Outline: GGMQ-1-T25-<mqtt-v>-<name>: As a customer, I connect with same client id twice (not reconnect) and be able to publish and subscribe to messages.
+    When I create a Greengrass deployment with components
+      | aws.greengrass.clientdevices.Auth        | LATEST                                  |
+      | aws.greengrass.clientdevices.mqtt.EMQX   | LATEST                                  |
+      | aws.greengrass.clientdevices.IPDetector  | LATEST                                  |
+      | <agent>                                  | classpath:/local-store/recipes/<recipe> |
+    And I create client device "publisher"
+    And I create client device "subscriber"
+    And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:
+    """
+{
+    "MERGE":{
+        "deviceGroups":{
+            "formatVersion":"2021-03-05",
+            "definitions":{
+                "MyPermissiveDeviceGroup":{
+                    "selectionRule":"thingName: ${publisher} OR thingName: ${subscriber}",
+                    "policyName":"MyPermissivePolicy"
+                }
+            },
+            "policies":{
+                "MyPermissivePolicy":{
+                    "AllowAll":{
+                        "statementDescription":"Allow client devices to perform all actions.",
+                        "operations":[
+                            "*"
+                        ],
+                        "resources":[
+                            "*"
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}
+    """
+
+    And I update my Greengrass deployment configuration, setting the component <agent> configuration to:
+    """
+{
+    "MERGE":{
+        "controlAddresses":"${mqttControlAddresses}",
+        "controlPort":"${mqttControlPort}"
+    }
+}
+    """
+    When I associate "publisher" with ggc
+    When I associate "subscriber" with ggc
+
+    And I deploy the Greengrass deployment configuration
+    Then the Greengrass deployment is COMPLETED on the device after 5 minutes
+    And the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes
+
+    And I discover core device broker as "default_broker" from "publisher" in OTF
+    And I connect device "publisher" on <agent> to "default_broker" using mqtt "<mqtt-v>"
+    And I connect device "subscriber" on <agent> to "default_broker" using mqtt "<mqtt-v>"
+
+    When I subscribe "subscriber" to "iot_data_0" with qos 1
+    When I publish from "publisher" to "iot_data_0" with qos 1 and message "Test message" and expect status 0
+    And message "Test message" received on "subscriber" from "iot_data_0" topic within 5 seconds
+    And I rename connection "publisher" to "publisher_old"
+
+    # Reconnect publisher with the same device id
+    And I connect device "publisher" on <agent> to "default_broker" using mqtt "<mqtt-v>"
+    When I publish from "publisher" to "iot_data_0" with qos 1 and message "Connect again" and expect status 0
+    And message "Connect again" received on "subscriber" from "iot_data_0" topic within 5 seconds
+
+    @mqtt3 @sdk-java
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient    | client_java_sdk.yaml    |
+
+    @mqtt3 @mosquitto-c @SkipOnWindows
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml |
+
+    @mqtt3 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
+
+    @mqtt3 @paho-python
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
+
+    @mqtt5 @sdk-java
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient    | client_java_sdk.yaml    |
+
+    @mqtt5 @mosquitto-c @SkipOnWindows
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml |
+
+    @mqtt5 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
+
+    @mqtt5 @paho-python
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
+
 
   @GGMQ-1-T27 @OffTheNetwork
   Scenario Outline: GGMQ-1-T27-<mqtt-v>-<name>: As a customer, my Greengrass-issued certificate does not rotate when mqtt reconnects

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1887,10 +1887,11 @@ Feature: GGMQ-1
 
     # Reconnect publisher with the same device id
     And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
-    And I wait 5 seconds
     When I publish from "publisher" to "iot_data_0" with qos 1 and message "Connect again" and expect status 0
     And message "Connect again" received on "subscriber" from "iot_data_0" topic within 5 seconds
 
+    # WARNING: Paho Java client does not work in this test because of "Untranslated MqttException - RC: 0"
+    # Add this client here after this issue will be fixed
     @mqtt3 @sdk-java
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
@@ -1900,11 +1901,6 @@ Feature: GGMQ-1
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml |
-
-    @mqtt3 @paho-java
-    Examples:
-      | mqtt-v | name        | agent                                       | recipe                  |
-      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
     @mqtt3 @paho-python
     Examples:
@@ -1920,11 +1916,6 @@ Feature: GGMQ-1
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml |
-
-    @mqtt5 @paho-java
-    Examples:
-      | mqtt-v | name        | agent                                       | recipe                  |
-      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
     @mqtt5 @paho-python
     Examples:


### PR DESCRIPTION
**Issue #, if available:**
Implement GGMQ scenario based on GGAD-1-T25
https://klika-tech.atlassian.net/browse/GGMQ-206

**Description of changes:**
- Add T25 scenario
- Add new step - rename a connection

**Why is this change necessary:**
Implement scenarios

**How was this change tested:**
Run scenario locally

**Test results:**
```
Given my device is registered as a Thing....................................passed
And my device is running Greengrass.........................................passed
When I create a Greengrass deployment with components.......................passed
And I create client device "publisher"......................................passed
And I create client device "subscriber".....................................passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:.passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.client.Mqtt5PythonPahoClient configuration to:.passed
When I associate "publisher" with ggc.......................................passed
When I associate "subscriber" with ggc......................................passed
And I deploy the Greengrass deployment configuration........................passed
Then the Greengrass deployment is COMPLETED on the device after 5 minutes...passed
And the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes.passed
Then I discover core device broker as "localMqttBroker1" from "publisher" in OTF.passed
Then I discover core device broker as "localMqttBroker2" from "subscriber" in OTF.passed
And I connect device "publisher" on aws.greengrass.client.Mqtt5PythonPahoClient to "localMqttBroker1" using mqtt "v5".passed
And I connect device "subscriber" on aws.greengrass.client.Mqtt5PythonPahoClient to "localMqttBroker2" using mqtt "v5".passed
When I subscribe "subscriber" to "iot_data_0" with qos 1....................passed
When I publish from "publisher" to "iot_data_0" with qos 1 and message "Test message" and expect status 0.passed
And message "Test message" received on "subscriber" from "iot_data_0" topic within 5 seconds.passed
And I rename connection "publisher" to "publisher_old"......................passed
And I connect device "publisher" on aws.greengrass.client.Mqtt5PythonPahoClient to "localMqttBroker1" using mqtt "v5".passed
When I publish from "publisher" to "iot_data_0" with qos 1 and message "Connect again" and expect status 0.passed
And message "Connect again" received on "subscriber" from "iot_data_0" topic within 5 seconds.passed
```
All clients (except Java Paho):
```
[INFO ] 2023-08-01 15:54:25.075 [main] StepTrackingReporting - Passed: 'GGMQ-1-T25-v3-sdk-java: As a customer, I connect with same client id twice (not reconnect) and be able to publish and subscribe to messages.'
[INFO ] 2023-08-01 15:54:25.075 [main] StepTrackingReporting - Passed: 'GGMQ-1-T25-v3-mosquitto-c: As a customer, I connect with same client id twice (not reconnect) and be able to publish and subscribe to messages.'
[INFO ] 2023-08-01 15:54:25.075 [main] StepTrackingReporting - Passed: 'GGMQ-1-T25-v3-paho-python: As a customer, I connect with same client id twice (not reconnect) and be able to publish and subscribe to messages.'
[INFO ] 2023-08-01 15:54:25.075 [main] StepTrackingReporting - Passed: 'GGMQ-1-T25-v5-sdk-java: As a customer, I connect with same client id twice (not reconnect) and be able to publish and subscribe to messages.'
[INFO ] 2023-08-01 15:54:25.075 [main] StepTrackingReporting - Passed: 'GGMQ-1-T25-v5-mosquitto-c: As a customer, I connect with same client id twice (not reconnect) and be able to publish and subscribe to messages.'
[INFO ] 2023-08-01 15:54:25.075 [main] StepTrackingReporting - Passed: 'GGMQ-1-T25-v5-paho-python: As a customer, I connect with same client id twice (not reconnect) and be able to publish and subscribe to messages.'
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
