### PR TITLE
feat(uat): implement GGMQ scenario based on GGAD-1-T26

### DIFF
--- a/uat/README.md
+++ b/uat/README.md
@@ -157,7 +157,7 @@ Example:
 java -Dggc.archive=greengrass-nucleus-latest.zip -Dtest.log.path=logs -Dtags="@GGMQ and not @SkipOnWindows" -jar testing-features/target/client-devices-auth-testing-features.jar
 ```
 
-@OffTheNetwork - scenarios with port 8883 blocked for some time
+@OffTheNetwork - scenarios with port 8883 blocked for some time. These tests require OS level firewall should be activated on a machine there Nucleus is running: iptables on Linux and advfirewall on Windows.
 
 To run tests matching ALL following criteria and all tags should be listed using "and" between tags
 ```bash

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/addon/Event.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/addon/Event.java
@@ -16,12 +16,12 @@ public interface Event {
         /** MQTT message is received. */
         EVENT_TYPE_MQTT_MESSAGE,
 
+        /** MQTT connection is disconnected. */
+        EVENT_TYPE_MQTT_DISCONNECTED,
+
         // TODO: implement other events
         // /** MQTT Connecttion established. */
         // EVENT_TYPE_MQTT_CONNECTED,
-
-        // /** MQTT connection is disconnected. */
-        // EVENT_TYPE_MQTT_DISCONNECTED,
 
         // /** Agent is registered and discovered. */
         // EVENT_TYPE_AGENT_DISCOVERED,

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/addon/MqttDisconnectEvent.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/addon/MqttDisconnectEvent.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.testing.mqtt.client.control.implementation.addon;
+
+import com.aws.greengrass.testing.mqtt.client.Mqtt5Disconnect;
+import com.aws.greengrass.testing.mqtt.client.control.api.ConnectionControl;
+import com.aws.greengrass.testing.mqtt.client.control.api.addon.EventFilter;
+import lombok.Getter;
+import lombok.NonNull;
+
+/**
+ * Implements event about MQTT connection has been disconnected.
+ */
+public class MqttDisconnectEvent extends EventImpl {
+
+    private final ConnectionControl connectionControl;
+
+    @Getter
+    private final Mqtt5Disconnect disconnect;
+
+    @Getter
+    private final String osError;
+
+    /**
+     * Creates instance of MqttDisconnectEvent.
+     *
+     * @param connectionControl the connection control which receives that message
+     * @param disconnect the disconnect gRPC event
+     * @param osError the OS error as received from the client
+     */
+    public MqttDisconnectEvent(@NonNull ConnectionControl connectionControl, @NonNull Mqtt5Disconnect disconnect,
+                                String osError) {
+        super(Type.EVENT_TYPE_MQTT_DISCONNECTED);
+        this.connectionControl = connectionControl;
+        this.disconnect = disconnect;
+        this.osError = osError;
+    }
+
+    @Override
+    public String getConnectionName() {
+        return connectionControl.getConnectionName();
+    }
+
+    @Override
+    public boolean isMatched(@NonNull EventFilter filter) {
+        // check type and timestamp
+        boolean matched = super.isMatched(filter);
+        if (!matched) {
+            return false;
+        }
+
+        // check connection
+        matched = compareConnection(filter.getConnectionControl(), filter.getAgentId(), filter.getConnectionId(), 
+                                    filter.getConnectionName());
+        return matched;
+    }
+
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    private boolean compareConnection(ConnectionControl expectedConnectionControl, String agentId, Integer connectionId,
+                                        String connectionName) {
+        // 1'st priority
+        if (expectedConnectionControl != null) {
+            // compare references !
+            return expectedConnectionControl == connectionControl;
+        }
+
+        // 2'nd priority
+        if (agentId != null && connectionId != null) {
+            return agentId.equals(connectionControl.getAgentControl().getAgentId())
+                        && connectionId == connectionControl.getConnectionId();
+        }
+
+        // 3'th priority
+        // check connection name
+        return connectionName == null || connectionName.equals(getConnectionName());
+    }
+}

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/BrokerCertificateSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/BrokerCertificateSteps.java
@@ -85,16 +85,8 @@ public class BrokerCertificateSteps {
      */
     @Then("I verify the certificate {string} equals the certificate {string}")
     public void verifyCertsAreEqual(String certNameA, String certNameB) {
-        CertificateInfo certInfoA = certificateInfos.get(certNameA);
-        if (certInfoA == null) {
-            throw new IllegalStateException(String.format("Certificate %s not found.", certNameA));
-        }
-
-        CertificateInfo certInfoB = certificateInfos.get(certNameB);
-        if (certInfoB == null) {
-            throw new IllegalStateException(String.format("Certificate %s not found.", certNameB));
-        }
-
+        CertificateInfo certInfoA = getCertificateInfo(certNameA);
+        CertificateInfo certInfoB = getCertificateInfo(certNameB);
         if (!certInfoA.getCertificate().equals(certInfoB.getCertificate())) {
             throw new IllegalStateException("Certificates are differ");
         }
@@ -111,11 +103,7 @@ public class BrokerCertificateSteps {
     @Then("I verify that the subject alternative names of certificate {string} contains endpoint {string}")
     public void verifyBrokerCertificateContainsEndpoint(String certName, String endpoint)
             throws CertificateParsingException {
-        CertificateInfo certInfo = certificateInfos.get(certName);
-        if (certInfo == null) {
-            throw new IllegalStateException(String.format("Certificate %s not found.", certName));
-        }
-
+        CertificateInfo certInfo = getCertificateInfo(certName);
         Collection<List<?>> altNames = certInfo.getCertificate().getSubjectAlternativeNames();
         if (altNames == null) {
             throw new IllegalStateException("Missing Subject alternatiuve names of certificate");
@@ -140,11 +128,7 @@ public class BrokerCertificateSteps {
      */
     @Then("I verify the TLS accepted issuer list of certificate {string} is empty")
     public void verifyAcceptedIssuerListEmpty(String certName) {
-        CertificateInfo certInfo = certificateInfos.get(certName);
-        if (certInfo == null) {
-            throw new IllegalStateException(String.format("Certificate %s not found.", certName));
-        }
-
+        CertificateInfo certInfo = getCertificateInfo(certName);
         Principal[] clientCertIssuers = certInfo.getPrincinals();
         if (clientCertIssuers != null && clientCertIssuers.length > 0) {
             throw new IllegalStateException("Accepted issuer list is not empty");
@@ -296,5 +280,21 @@ public class BrokerCertificateSteps {
             }
             return new CertificateFutures(serverCertsFut, clientCertIssuersFut);
         }
+    }
+
+    /**
+     * Get information of certificate by name.
+     *
+     * @param certName the name of certificate
+     * @return certificate information
+     * @throws IllegalStateException on errors
+     */
+    private CertificateInfo getCertificateInfo(String certName) {
+        CertificateInfo certInfo = certificateInfos.get(certName);
+        if (certInfo == null) {
+            throw new IllegalStateException(String.format("Certificate %s not found.", certName));
+        }
+
+        return certInfo;
     }
 }

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/BrokerCertificateSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/BrokerCertificateSteps.java
@@ -24,8 +24,10 @@ import java.net.Socket;
 import java.net.URI;
 import java.security.Principal;
 import java.security.PrivateKey;
+import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,10 +45,18 @@ import javax.net.ssl.X509TrustManager;
 @ScenarioScoped
 public class BrokerCertificateSteps {
     private static final int GET_CERTIFICATE_TIMEOUT_SEC = 5;
+    private static final int GET_PRINCIPALS_TIMEOUT_SEC = 5;
 
     private final MqttBrokers mqttBrokers;
 
-    private final Map<String, X509Certificate> certificates = new HashMap<>();
+    private final Map<String, CertificateInfo> certificateInfos = new HashMap<>();
+
+    @AllArgsConstructor
+    @Getter
+    private static class CertificateInfo {
+        X509Certificate certificate;                    // TODO: can be list/array
+        Principal[] princinals;
+    }
 
     @AllArgsConstructor
     @Getter
@@ -75,18 +85,69 @@ public class BrokerCertificateSteps {
      */
     @Then("I verify the certificate {string} equals the certificate {string}")
     public void verifyCertsAreEqual(String certNameA, String certNameB) {
-        X509Certificate certA = certificates.get(certNameA);
-        if (certA == null) {
+        CertificateInfo certInfoA = certificateInfos.get(certNameA);
+        if (certInfoA == null) {
             throw new IllegalStateException(String.format("Certificate %s not found.", certNameA));
         }
 
-        X509Certificate certB = certificates.get(certNameB);
-        if (certB == null) {
+        CertificateInfo certInfoB = certificateInfos.get(certNameB);
+        if (certInfoB == null) {
             throw new IllegalStateException(String.format("Certificate %s not found.", certNameB));
         }
 
-        if (!certA.equals(certB)) {
+        if (!certInfoA.getCertificate().equals(certInfoB.getCertificate())) {
             throw new IllegalStateException("Certificates are differ");
+        }
+    }
+
+    /**
+     * Checks is certificate contains endpoint in ubject alternative names extension.
+     *
+     * @param certName the name of certificate
+     * @param endpoint the name of endpoint or IP address
+     * @throws CertificateParsingException when could not extract subject alternative names from certificate
+     * @throws IllegalStateException on errors
+     */
+    @Then("I verify that the subject alternative names of certificate {string} contains endpoint {string}")
+    public void verifyBrokerCertificateContainsEndpoint(String certName, String endpoint)
+            throws CertificateParsingException {
+        CertificateInfo certInfo = certificateInfos.get(certName);
+        if (certInfo == null) {
+            throw new IllegalStateException(String.format("Certificate %s not found.", certName));
+        }
+
+        Collection<List<?>> altNames = certInfo.getCertificate().getSubjectAlternativeNames();
+        if (altNames == null) {
+            throw new IllegalStateException("Missing Subject alternatiuve names of certificate");
+        }
+
+        for (List<?> alt : altNames) {
+            Object altName = alt.get(1);
+            log.info("Cert alt name {}", altName);
+            if (endpoint.equals(altName)) {
+                return;
+            }
+        }
+
+        throw new IllegalStateException("Endpoint not found in the subject alternative names of certificate");
+    }
+
+    /**
+     * Checks is certificate's accepted issuer list is missing or empty.
+     *
+     * @param certName the name of certificate
+     * @throws IllegalStateException on errors
+     */
+    @Then("I verify the TLS accepted issuer list of certificate {string} is empty")
+    public void verifyAcceptedIssuerListEmpty(String certName) {
+        CertificateInfo certInfo = certificateInfos.get(certName);
+        if (certInfo == null) {
+            throw new IllegalStateException(String.format("Certificate %s not found.", certName));
+        }
+
+        Principal[] clientCertIssuers = certInfo.getPrincinals();
+        if (clientCertIssuers != null && clientCertIssuers.length > 0) {
+            throw new IllegalStateException("Accepted issuer list is not empty");
         }
     }
 
@@ -129,9 +190,13 @@ public class BrokerCertificateSteps {
                     throw new IllegalStateException("Certificate array is empty");
                 }
 
+                Principal[] principal = futures.getPrincinal().get(GET_PRINCIPALS_TIMEOUT_SEC,
+                                                                            TimeUnit.SECONDS);
+
+                // FIXME: strictly speaking we can have a array of certificates here
                 X509Certificate cert = serverCerts[0];
-                certificates.put(certName, cert);
-                log.info("Saved broker's '{}' certificate '{}'", brokerId, cert);
+                certificateInfos.put(certName, new CertificateInfo(cert, principal));
+                log.info("Saved broker's '{}' certificate info '{}'", brokerId, cert);
                 return;
             } catch (IllegalStateException | ExecutionException | TimeoutException ex) {
                 lastException = ex;

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1933,7 +1933,7 @@ Feature: GGMQ-1
 
 
   @GGMQ-1-T26
-  Scenario Outline: GGMQ-1-T26-<mqtt-v>-<name>: As a customer, my GGAD stays connected when CDA rotates cert in EMQX broker
+  Scenario Outline: GGMQ-1-T26-<mqtt-v>-<name>: As a customer, my GGAD stays connected when CDA rotates cert for EMQX broker
     When I create a Greengrass deployment with components
       | aws.greengrass.clientdevices.Auth        | LATEST                                  |
       | aws.greengrass.clientdevices.mqtt.EMQX   | LATEST                                  |


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-273
Implement GGMQ scenario based on GGAD-1-T26

**Description of changes:**
- Add GGMQ-1-T26 scenario based on GGAD-1-T26
- Add disconnection check to GGMQ-1-T25
- Add disconnect type of event to event storage
- Add two steps to verify a certificate of broker
- Add two steps to check is connection disconnected or is not
- Replace RuntimeException with IllegalStateException in implemenetation of steps
- Rename steps to clear event storage
- Update readme by add sentense about firewall

**Why is this change necessary:**
We should port GGAD-1-T26 scenario to OTF base

**How was this change tested:**
By running Cucumber's scenarios

**Test results:**
```
[INFO ] 2023-08-02 19:06:50.952 [main] StepTrackingReporting - Passed: 'GGMQ-1-T26-v3-sdk-java: As a customer, my GGAD stays connected when CDA rotates cert in EMQX broker'
[INFO ] 2023-08-02 19:06:50.952 [main] StepTrackingReporting - Passed: 'GGMQ-1-T26-v3-mosquitto-c: As a customer, my GGAD stays connected when CDA rotates cert in EMQX broker'
[INFO ] 2023-08-02 19:06:50.953 [main] StepTrackingReporting - Passed: 'GGMQ-1-T26-v3-paho-java: As a customer, my GGAD stays connected when CDA rotates cert in EMQX broker'
[INFO ] 2023-08-02 19:06:50.953 [main] StepTrackingReporting - Passed: 'GGMQ-1-T26-v3-paho-python: As a customer, my GGAD stays connected when CDA rotates cert in EMQX broker'
[INFO ] 2023-08-02 19:06:50.953 [main] StepTrackingReporting - Passed: 'GGMQ-1-T26-v5-sdk-java: As a customer, my GGAD stays connected when CDA rotates cert in EMQX broker'
[ERROR] 2023-08-02 19:06:50.953 [main] StepTrackingReporting - Failed: 'GGMQ-1-T26-v5-mosquitto-c: As a customer, my GGAD stays connected when CDA rotates cert in EMQX broker': Failed at 'the Greengrass deployme
nt is COMPLETED on the device after 5 minutes'
[INFO ] 2023-08-02 19:06:50.953 [main] StepTrackingReporting - Passed: 'GGMQ-1-T26-v5-paho-java: As a customer, my GGAD stays connected when CDA rotates cert in EMQX broker'
[INFO ] 2023-08-02 19:06:50.953 [main] StepTrackingReporting - Passed: 'GGMQ-1-T26-v5-paho-python: As a customer, my GGAD stays connected when CDA rotates cert in EMQX broker'
```
and when one failed restarted:
```
[INFO ] 2023-08-02 20:05:39.241 [main] StepTrackingReporting - Passed: 'GGMQ-1-T26-v5-mosquitto-c: As a customer, my GGAD stays connected when CDA rotates cert in EMQX broker'
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
