### PR TITLE
docs(uat): update comments for proper doc generation

### DIFF
--- a/uat/custom-components/client-python-paho/README.md
+++ b/uat/custom-components/client-python-paho/README.md
@@ -132,3 +132,18 @@ Python Paho MQTT does not provide the API to set the Subscription ID in SUBSCRIB
 
 3. Unsubscription
 In Python Paho on_unsubscribe() callback does not provide reason codes for MQTTv3, instead zero code will be returned on success.
+
+## Generate documentation
+
+Install pdoc
+
+```cmd
+pip install pdoc3
+```
+
+Run command
+```cmd
+python -m pdoc --html --config show_source_code=False src
+```
+
+Directory "html" with the documentation will be generated.

--- a/uat/custom-components/client-python-paho/src/grpc_client_server/grpc_control_server.py
+++ b/uat/custom-components/client-python-paho/src/grpc_client_server/grpc_control_server.py
@@ -56,10 +56,9 @@ class GRPCControlServer(mqtt_client_control_pb2_grpc.MqttClientControlServicer):
     def __init__(self, client: GRPCDiscoveryClient, address: str):
         """
         Construct GRPCControlServer
-        Parameters
-        ----------
-        client - GRPCDiscoveryClient object
-        address - local gRPC service address
+        Args:
+            client: GRPCDiscoveryClient object
+            address: local gRPC service address
         """
         self.__logger = GRPCControlServer.logger
         self.__shutdown_reason = ""
@@ -89,9 +88,8 @@ class GRPCControlServer(mqtt_client_control_pb2_grpc.MqttClientControlServicer):
     async def wait(self, mqtt_lib: MQTTLib):
         """
         Wait until incoming shutdown request
-        Parameters
-        ----------
-        mqtt_lib - MQTT side of the client to handler incoming requests
+        Args:
+            mqtt_lib: MQTT side of the client to handler incoming requests
         """
         self.__mqtt_lib = mqtt_lib
         self.__logger.info("Server awaiting termination")
@@ -115,11 +113,11 @@ class GRPCControlServer(mqtt_client_control_pb2_grpc.MqttClientControlServicer):
         """
         override
         Handler of ShutdownAgent gRPC call.
-        Parameters
-        ----------
-        request - incoming request
-        context - request context
-        Returns Empty object
+        Args:
+            request: incoming request
+            context: request context
+        Returns:
+            Empty object
         """
         self.__shutdown_reason = request.reason
         self.__logger.info("shutdownAgent: reason %s", self.__shutdown_reason)
@@ -132,11 +130,11 @@ class GRPCControlServer(mqtt_client_control_pb2_grpc.MqttClientControlServicer):
         """
         override
         Handler of CreateMqttConnection gRPC call.
-        Parameters
-        ----------
-        request - incoming request
-        context - request context
-        Returns MqttConnectReply object
+        Args:
+            request: incoming request
+            context: request context
+        Returns:
+            MqttConnectReply object
         """
         await self.__check_connect_request(request, context)
 
@@ -216,11 +214,11 @@ class GRPCControlServer(mqtt_client_control_pb2_grpc.MqttClientControlServicer):
         """
         override
         Handler of PublishMqtt gRPC call.
-        Parameters
-        ----------
-        request - incoming request
-        context - request context
-        Returns MqttPublishReply object
+        Args:
+            request: incoming request
+            context: request context
+        Returns:
+            MqttPublishReply object
         """
         if not request.HasField("msg"):
             self.__logger.warning("PublishMqtt: message is missing")
@@ -308,11 +306,11 @@ class GRPCControlServer(mqtt_client_control_pb2_grpc.MqttClientControlServicer):
         """
         override
         Handler of CloseMqttConnection gRPC call.
-        Parameters
-        ----------
-        request - incoming request
-        context - request context
-        Returns Empty object
+        Args:
+            request: incoming request
+            context: request context
+        Returns:
+            Empty object
         """
         timeout = request.timeout
         if timeout < TIMEOUT_MIN:
@@ -351,11 +349,11 @@ class GRPCControlServer(mqtt_client_control_pb2_grpc.MqttClientControlServicer):
         """
         override
         Handler of SubscribeMqtt gRPC call.
-        Parameters
-        ----------
-        request - incoming request
-        context - request context
-        Returns MqttSubscribeReply object
+        Args:
+            request: incoming request
+            context: request context
+        Returns:
+            MqttSubscribeReply object
         """
         timeout = request.timeout
         if timeout < TIMEOUT_MIN:
@@ -440,11 +438,11 @@ class GRPCControlServer(mqtt_client_control_pb2_grpc.MqttClientControlServicer):
         """
         override
         Handler of UnsubscribeMqtt gRPC call.
-        Parameters
-        ----------
-        request - incoming request
-        context - request context
-        Returns MqttSubscribeReply object
+        Args:
+            request: incoming request
+            context: request context
+        Returns:
+            MqttSubscribeReply object
         """
 
         timeout = request.timeout
@@ -485,11 +483,11 @@ class GRPCControlServer(mqtt_client_control_pb2_grpc.MqttClientControlServicer):
     async def __check_connect_request(self, request: MqttConnectRequest, context: grpc.aio.ServicerContext):
         """
         Check that mqtt connect request is correct.
-        Parameters
-        ----------
-        request - incoming request
-        context - request context
-        Returns MqttConnectReply object
+        Args:
+            request: incoming request
+            context: request context
+        Returns:
+            MqttConnectReply object
         """
         if not request.clientId:
             self.__logger.warning("CreateMqttConnection: clientId can't be empty")

--- a/uat/custom-components/client-python-paho/src/grpc_client_server/grpc_discovery_client.py
+++ b/uat/custom-components/client-python-paho/src/grpc_client_server/grpc_discovery_client.py
@@ -24,10 +24,9 @@ class GRPCDiscoveryClient:
     def __init__(self, agent_id: str, address: str):
         """
         Construct GRPCDiscoveryClient
-        Parameters
-        ----------
-        agentId - id of agent to identify control channel by gRPC server
-        address - address of gRPC service, including port
+        Args:
+            agentId: id of agent to identify control channel by gRPC server
+            address: address of gRPC service, including port
         """
         self.__logger = GRPCDiscoveryClient.logger
         self.__agent_id = agent_id
@@ -42,10 +41,9 @@ class GRPCDiscoveryClient:
     def discovery_agent(self, address: str, port: int):
         """
         Discover the agent.
-        Parameters
-        ----------
-        address - host of local gRPC service
-        port of local gRPC service
+        Args:
+            address: host of local gRPC service
+            port: port of local gRPC service
         """
         request = mqtt_client_control_pb2.DiscoveryRequest(agentId=self.__agent_id, address=address, port=port)
 
@@ -58,9 +56,8 @@ class GRPCDiscoveryClient:
     def register_agent(self) -> str:
         """
         Register the agent.
-        Parameters
-        ----------
-        Returns IP address of client as visible by server
+        Returns:
+            IP address of client as visible by server
         """
         request = mqtt_client_control_pb2.RegisterRequest(agentId=self.__agent_id)
         reply = None
@@ -76,9 +73,8 @@ class GRPCDiscoveryClient:
     def unregister_agent(self, reason: str):
         """
         Unregister the agent.
-        Parameters
-        ----------
-        reason - reason of unregistering
+        Args:
+            reason: reason of unregistering
         """
         request = mqtt_client_control_pb2.UnregisterRequest(agentId=self.__agent_id, reason=reason)
         try:
@@ -91,10 +87,9 @@ class GRPCDiscoveryClient:
         """
         Called when MQTT message is receive my MQTT client
         and deliver information from it to gRPC server.
-        Parameters
-        ----------
-        connection_id - ID of connection, which received the message
-        mqtt_message - received message
+        Args:
+            connection_id: ID of connection, which received the message
+            mqtt_message: received message
         """
         mqtt_connection_id = MqttConnectionId(connectionId=connection_id)
         request = mqtt_client_control_pb2.OnReceiveMessageRequest(
@@ -119,11 +114,10 @@ class GRPCDiscoveryClient:
         """
         Called when MQTT connection has been
         disconnected by client or server side.
-        Parameters
-        ----------
-        connection_id - ID of disconnected connection
-        disconnect_info - disconnect information
-        error_string - specific error information
+        Args:
+            connection_id: ID of disconnected connection
+            disconnect_info: disconnect information
+            error_string: specific error information
         """
         mqtt_connection_id = MqttConnectionId(connectionId=connection_id)
         request = mqtt_client_control_pb2.OnMqttDisconnectRequest(

--- a/uat/custom-components/client-python-paho/src/grpc_client_server/grpc_lib.py
+++ b/uat/custom-components/client-python-paho/src/grpc_client_server/grpc_lib.py
@@ -22,12 +22,12 @@ class GRPCLib:  # pylint: disable=too-few-public-methods
     async def make_link(self, agent_id: str, hosts: List[str], port: int) -> GRPCLink:
         """
         Creates and returns GRPCLink object.
-        Parameters
-        ----------
-        agent_id - id of agent to identify control channel by server
-        hosts - host names/IPs to connect to testing framework
-        port - TCP port to connect to
-        Returns GRPCLink object
+        Args:
+            agent_id: id of agent to identify control channel by server
+            hosts: host names/IPs to connect to testing framework
+            port: TCP port to connect to
+        Returns:
+            GRPCLink object
         """
         grpc_link = GRPCLink(agent_id, hosts, port)
         await grpc_link.start_server()

--- a/uat/custom-components/client-python-paho/src/grpc_client_server/grpc_link.py
+++ b/uat/custom-components/client-python-paho/src/grpc_client_server/grpc_link.py
@@ -21,10 +21,9 @@ class ClientConnectResult:  # pylint: disable=too-few-public-methods
     def __init__(self, client: GRPCDiscoveryClient, local_ip: str):
         """
         Construct ClientConnectResult
-        Parameters
-        ----------
-        client - Discovery client object
-        local_ip - local client IP address
+        Args:
+            client: Discovery client object
+            local_ip: local client IP address
         """
         self.client = client
         self.local_ip = local_ip
@@ -38,11 +37,10 @@ class GRPCLink:
     def __init__(self, agent_id: str, hosts: List[str], port: int):
         """
         Construct GRPCLink.
-        Parameters
-        ----------
-        agent_id - id of agent to identify control channel by server
-        hosts - host names/IPs to connect to testing framework
-        port - TCP port to connect to
+        Args:
+            agent_id: id of agent to identify control channel by server
+            hosts: host names/IPs to connect to testing framework
+            port: TCP port to connect to
         """
         self.__logger = GRPCLink.logger
 
@@ -66,9 +64,10 @@ class GRPCLink:
     async def handle_requests(self, mqtt_lib: MQTTLib) -> str:
         """
         Handle gRPC requests.
-        Parameters
-        ----------
-        Returns shutdown reason
+        Args:
+            mqtt_lib: MQTTLib object
+        Returns:
+            shutdown reason
         """
         self.__logger.info("Handle gRPC requests")
         await self.__server.wait(mqtt_lib)
@@ -77,9 +76,8 @@ class GRPCLink:
     def shutdown(self, reason: str):
         """
         Unregister MQTT client control in testing framework.
-        Parameters
-        ----------
-        reason - reason of shutdown
+        Args:
+            reason: reason of shutdown
         """
         self.__logger.info("Shutdown gPRC link")
         self.__client.unregister_agent(reason)
@@ -90,21 +88,19 @@ class GRPCLink:
     def build_address(host: str, port: int) -> str:
         """
         Build full address from name/IP and port.
-        Parameters
-        ----------
-        host - host name/IP to connect to testing framework
-        port - TCP port to connect to
+        Args:
+            host: host name/IP to connect to testing framework
+            port: TCP port to connect to
         """
         return host + ":" + str(port)
 
     def __make_clients_connection(self, agent_id: str, hosts: List[str], port: int):
         """
         Search for the available host.
-        Parameters
-        ----------
-        agent_id - id of agent to identify control channel by server
-        hosts - host names/IPs to connect to testing framework
-        port - TCP port to connect to
+        Args:
+            agent_id: id of agent to identify control channel by server
+            hosts: host names/IPs to connect to testing framework
+            port: TCP port to connect to
         """
         last_exception = None
         try:

--- a/uat/custom-components/client-python-paho/src/main.py
+++ b/uat/custom-components/client-python-paho/src/main.py
@@ -30,11 +30,10 @@ class Arguments:  # pylint: disable=too-few-public-methods
     def __init__(self, agent_id: str, hosts: List[str], port: int):
         """
         Construct Arguments
-        Parameters
-        ----------
-        agent_id - id of agent to identify control channel by server
-        hosts - host names/IPs to connect to testing framework
-        port - TCP port to connect to
+        Args:
+            agent_id: id of agent to identify control channel by server
+            hosts: host names/IPs to connect to testing framework
+            port: TCP port to connect to
         """
         self.agent_id = agent_id
         self.hosts = hosts
@@ -52,9 +51,8 @@ class Main:
     def parse_args(self) -> Arguments:
         """
         Setup and run.
-        Parameters
-        ----------
-        Returns parsed arguments
+        Returns:
+            parsed arguments
         """
         parser = argparse.ArgumentParser()
         parser.add_argument(
@@ -90,9 +88,8 @@ class Main:
     async def do_all(self, temp_files_manager: TempFilesManager):
         """
         Run program.
-        Parameters
-        ----------
-        temp_files_manager - Temp files manager
+        Args:
+            temp_files_manager: Temp files manager
         """
         arguments = self.parse_args()
         grpc_lib = GRPCLib()
@@ -109,7 +106,8 @@ class Main:
     async def main(self) -> int:
         """
         Setup and run.
-        Returns response code, which shows the shutdown reason
+        Returns:
+            response code, which shows the shutdown reason
         """
 
         exit_code = 0

--- a/uat/custom-components/client-python-paho/src/mqtt_lib/mqtt_connection.py
+++ b/uat/custom-components/client-python-paho/src/mqtt_lib/mqtt_connection.py
@@ -142,7 +142,12 @@ class AsyncioHelper:
     logger = logging.getLogger("AsyncioHelper")
 
     def __init__(self, loop, client):
-        """Construct AsyncioHelper"""
+        """
+        Construct AsyncioHelper
+        Args:
+            loop: async loop
+            client: mqtt client
+        """
         self.__logger = AsyncioHelper.logger
         self.misc = None
         self.loop = loop
@@ -153,7 +158,7 @@ class AsyncioHelper:
         self.client.on_socket_unregister_write = self.on_socket_unregister_write
 
     def on_socket_open(self, client, userdata, sock):  # pylint: disable=unused-argument
-        """Client socket open callback"""
+        """Client socket open callback callback"""
 
         def callback():
             """Loop Reader callback"""
@@ -164,13 +169,13 @@ class AsyncioHelper:
         self.misc = self.loop.create_task(self.misc_loop())
 
     def on_socket_close(self, client, userdata, sock):  # pylint: disable=unused-argument
-        """Client socket close callback"""
+        """Client socket close callback callback"""
         self.__logger.debug("On socket close")
         self.loop.remove_reader(sock)
         self.misc.cancel()
 
     def on_socket_register_write(self, client, userdata, sock):  # pylint: disable=unused-argument
-        """Client socket register write"""
+        """Client socket register write callback"""
         self.__logger.debug("On socket register write")
 
         def callback():
@@ -179,7 +184,7 @@ class AsyncioHelper:
         self.loop.add_writer(sock, callback)
 
     def on_socket_unregister_write(self, client, userdata, sock):  # pylint: disable=unused-argument
-        """Client socket unregister write"""
+        """Client socket unregister write callback"""
         self.__logger.debug("On socket unregister write")
         self.loop.remove_writer(sock)
 
@@ -205,10 +210,9 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
     ):
         """
         Construct MQTTConnection
-        Parameters
-        ----------
-        connection_params - the connection parameters
-        grpc_client - the consumer of received messages and disconnect events
+        Args:
+            connection_params: the connection parameters
+            grpc_client: the consumer of received messages and disconnect events
         """
         super().__init__()
         self.__logger = MqttConnection.logger
@@ -238,9 +242,8 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
     def set_connection_id(self, connection_id: int):
         """
         Connection id setter
-        Parameters
-        ----------
-        connection_id - connection id as assigned by MQTT library
+        Args:
+            connection_id: connection id as assigned by MQTT library
         """
         self.__connection_id = connection_id
 
@@ -255,10 +258,10 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
     async def start(self, timeout: int) -> ConnectResult:
         """
         Starts MQTT connection.
-        Parameters
-        ----------
-        timeout - connect operation timeout in seconds
-        Returns connection result
+        Args:
+            timeout: connect operation timeout in seconds
+        Returns:
+            connection result
         """
         self.__asyncio_helper = AsyncioHelper(self.__loop, self.__client)  # pylint: disable=unused-private-member
 
@@ -358,11 +361,10 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
     async def disconnect(self, timeout: int, reason: int, mqtt_properties: List[Mqtt5Properties]):
         """
         Closes MQTT connection.
-        Parameters
-        ----------
-        timeout - disconnect operation timeout in seconds
-        mqtt_properties - list of Mqtt5Properties
-        reason - disconnect reason code
+        Args:
+            timeout: disconnect operation timeout in seconds
+            mqtt_properties: list of Mqtt5Properties
+            reason: disconnect reason code
         """
         if not self.__is_closing:
             self.__is_closing = True
@@ -426,11 +428,11 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
     async def publish(self, timeout: int, message: MqttPubMessage) -> MqttPublishReply:
         """
         Publish MQTT message.
-        Parameters
-        ----------
-        timeout - publish operation timeout in seconds
-        message - Mqtt message info and payload
-        Returns MqttPublishReply object
+        Args:
+            timeout: publish operation timeout in seconds
+            message: Mqtt message info and payload
+        Returns:
+            MqttPublishReply object
         """
         self.state_check()
         self.__on_publish_future = self.__loop.create_future()
@@ -486,12 +488,12 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
     ) -> MqttSubscribeReply:
         """
         Subscribe on MQTT topics.
-        Parameters
-        ----------
-        timeout - subscribe operation timeout in seconds
-        subscriptions - Subscriptions information
-        mqtt_properties - list of Mqtt5Properties
-        Returns MqttSubscribeReply object
+        Args:
+            timeout: subscribe operation timeout in seconds
+            subscriptions: Subscriptions information
+            mqtt_properties: list of Mqtt5Properties
+        Returns:
+            MqttSubscribeReply object
         """
         self.state_check()
 
@@ -595,12 +597,12 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
     ) -> MqttSubscribeReply:
         """
         Unsubscribe from MQTT topics.
-        Parameters
-        ----------
-        timeout - subscribe operation timeout in seconds
-        filters - Topics to unsubscribe
-        mqtt_properties - list of Mqtt5Properties
-        Returns MqttSubscribeReply object
+        Args:
+            timeout: subscribe operation timeout in seconds
+            filters: Topics to unsubscribe
+            mqtt_properties: list of Mqtt5Properties
+        Returns:
+            MqttSubscribeReply object
         """
         self.state_check()
 
@@ -668,10 +670,10 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
     def __create_client(self, connection_params: ConnectionParams) -> mqtt.Client:
         """
         Create async PAHO MQTT 5 Client
-        Parameters
-        ----------
-        connection_params - the connection parameters
-        Returns async PAHO MQTT 5 Client
+        Args:
+            connection_params: the connection parameters
+        Returns:
+            async PAHO MQTT 5 Client
         """
 
         client = None
@@ -723,10 +725,10 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
     def __create_publish_properties(self, message: MqttPubMessage):
         """
         Create MQTT5 properties
-        Parameters
-        ----------
-        message - MqttPubMessage
-        Returns MQTT5 properties
+        Args:
+            message: MqttPubMessage
+        Returns:
+            MQTT5 properties
         """
         properties = Properties(PacketTypes.PUBLISH)
         user_properties = self.__convert_to_user_properties(message.mqtt_properties, "PUBLISH")
@@ -776,11 +778,11 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
     ) -> List[Tuple[str, str]]:
         """
         Convert Mqtt5Properties into to User properties list
-        Parameters
-        ----------
-        mqtt_properties - mqtt_properties
-        message_type - message type
-        Returns User properties list
+        Args:
+            mqtt_properties: mqtt_properties
+            message_type: message type
+        Returns:
+            User properties list
         """
         user_properties = []
 
@@ -801,11 +803,11 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
     ) -> List[Mqtt5Properties]:
         """
         Convert User properties list into to Mqtt5Properties
-        Parameters
-        ----------
-        user_properties - User properties list
-        message_type - message type
-        Returns Mqtt5Properties
+        Args:
+            user_properties: User properties list
+            message_type: message type
+        Returns:
+            Mqtt5Properties
         """
         if user_properties:
             mqtt_properties = []
@@ -822,10 +824,10 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
     def __convert_to_conn_ack(self, mqtt_result: MqttResult) -> Mqtt5ConnAck:
         """
         Convert MqttResult into to Mqtt5ConnAck
-        Parameters
-        ----------
-        mqtt_result - MqttResult object
-        Returns Mqtt5ConnAck object
+        Args:
+            mqtt_result: MqttResult object
+        Returns:
+            Mqtt5ConnAck object
         """
         props = mqtt_result.properties
         mqtt_properties = self.__convert_to_mqtt5_properties(getattr(props, "UserProperty", None), "CONNACK")
@@ -859,10 +861,10 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
     def __convert_to_disconnect(self, mqtt_result: MqttResult) -> Mqtt5Disconnect:
         """
         Convert MqttResult into to Mqtt5Disconnect
-        Parameters
-        ----------
-        mqtt_result - MqttResult object
-        Returns Mqtt5Disconnect object
+        Args:
+            mqtt_result: MqttResult object
+        Returns:
+            Mqtt5Disconnect object
         """
         props = mqtt_result.properties
         mqtt_properties = self.__convert_to_mqtt5_properties(getattr(props, "UserProperty", None), "DISCONNECT")
@@ -878,10 +880,10 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
     def __convert_to_pub_reply(self, pub_info: mqtt.MQTTMessageInfo) -> MqttPublishReply:
         """
         Build MQTT publish reply
-        Parameters
-        ----------
-        pub_info - published message info
-        Returns MqttPublishReply object
+        Args:
+            pub_info: published message info
+        Returns:
+            MqttPublishReply object
         """
         # Python Paho MQTT does not support recieving any properties for the pusblished messages
         return MqttPublishReply(reasonCode=pub_info.rc)
@@ -889,10 +891,10 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
     def __convert_to_sub_reply(self, mqtt_result: SubscribesResult) -> MqttSubscribeReply:
         """
         Build MQTT subscribe reply
-        Parameters
-        ----------
-        mqtt_result - subscribe info
-        Returns MqttSubscribeReply object
+        Args:
+            mqtt_result: subscribe info
+        Returns:
+            MqttSubscribeReply object
         """
         props = mqtt_result.properties
         mqtt_properties = self.__convert_to_mqtt5_properties(getattr(props, "UserProperty", None), "SUBACK")
@@ -907,10 +909,10 @@ class MqttConnection:  # pylint: disable=too-many-instance-attributes
     def __convert_to_mqtt_message(self, message: mqtt.MQTTMessage) -> Mqtt5Message:
         """
         Convert MQTTMessage into to Mqtt5Message
-        Parameters
-        ----------
-        message - MQTTMessage object
-        Returns Mqtt5Message object
+        Args:
+            message: MQTTMessage object
+        Returns:
+            Mqtt5Message object
         """
         props = getattr(message, "properties", None)
 

--- a/uat/custom-components/client-python-paho/src/mqtt_lib/mqtt_lib.py
+++ b/uat/custom-components/client-python-paho/src/mqtt_lib/mqtt_lib.py
@@ -19,9 +19,8 @@ class MQTTLib:
     def __init__(self, temp_files_manager: TempFilesManager):
         """
         Construct MQTTLib
-        Parameters
-        ----------
-        temp_files_manager - Temp files manager
+        Args:
+            temp_files_manager: Temp files manager
         """
         self.__logger = MQTTLib.logger
         self.__logger.info("Initialize Paho MQTT library")
@@ -34,21 +33,21 @@ class MQTTLib:
     ) -> MqttConnection:
         """
         Create MQTTConnection object
-        Parameters
-        ----------
-        connection_params - the connection parameters
-        grpc_client - the consumer of received messages and disconnect events
-        Returns MQTTConnection object
+        Args:
+            connection_params: the connection parameters
+            grpc_client: the consumer of received messages and disconnect events
+        Returns:
+            MQTTConnection object
         """
         return MqttConnection(connection_params, grpc_client, self.__temp_files_manager)
 
     def register_connection(self, mqtt_connection: MqttConnection) -> int:
         """
         Register the MQTT connection.
-        Parameters
-        ----------
-        mqtt_connection - connection to register
-        Returns id of connection
+        Args:
+            mqtt_connection: connection to register
+        Returns:
+            id of connection
         """
         while True:
             self.__connection_id_next += 1
@@ -62,19 +61,19 @@ class MQTTLib:
     def get_connection(self, connection_id: int) -> MqttConnection:
         """
         Get the MQTT connection.
-        Parameters
-        ----------
-        connection_id - id of connection
-        Returns MqttConnection on success or None when connection does not found
+        Args:
+            connection_id: id of connection
+        Returns:
+            MqttConnection on success or None when connection does not found
         """
         return self.__connections.get(connection_id)
 
     def unregister_connection(self, connection_id: int) -> MqttConnection:
         """
         Unregister the MQTT connection.
-        Parameters
-        ----------
-        connection_id - id of connection
-        Returns MqttConnection on success or None when connection does not found
+        Args:
+            connection_id: id of connection
+        Returns:
+            MqttConnection on success or None when connection does not found
         """
         return self.__connections.pop(connection_id, None)

--- a/uat/custom-components/client-python-paho/src/mqtt_lib/temp_files_manager.py
+++ b/uat/custom-components/client-python-paho/src/mqtt_lib/temp_files_manager.py
@@ -19,9 +19,10 @@ class TempFilesManager:
     def create_new_temp_file(self, data: str) -> str:
         """
         Create new temp file
-        Parameters:
-        ----------
-        Returns new temp file path in system
+        Args:
+            data: data to save in temp file
+        Returns:
+            new temp file path in system
         """
         new_file = tempfile.NamedTemporaryFile(mode="wt", delete=False)  # pylint: disable=consider-using-with
 


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-287
Prepare documentation for the client (Paho Python)

**Description of changes:**
- Update comments to Google-style python docstrings
- Update README.md

**Why is this change necessary:**
It allow generate documentation for Paho Python client by run pdoc3

**How was this change tested:**
Documentation generation - manually. 

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
